### PR TITLE
Make sure that lhc_status_container exists before hide.

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
@@ -451,11 +451,13 @@ var lh_inst  = {
     },
 
     toggleStatusWidget : function(hide){
-    	if (hide == true){    		
-    		this.addClass(document.getElementById('lhc_status_container'),'hide-status');
-    	} else {
-    		this.removeClass(document.getElementById('lhc_status_container'),'hide-status');    		
-    	}
+      if(document.getElementById('lhc_status_container') != null) {
+        if (hide == true){
+          this.addClass(document.getElementById('lhc_status_container'),'hide-status');
+        } else {
+          this.removeClass(document.getElementById('lhc_status_container'),'hide-status');
+        }
+      }
     },
     
     lh_openchatWindow : function() {    	


### PR DESCRIPTION
When the status widget is created with (position)/api and
the chat widget is opened, it will try to hide the status
widget and fails.