### PR TITLE
Configure widget parent and add close -callback

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
@@ -415,8 +415,18 @@ var lh_inst  = {
 
           var fragment = this.appendHTML(this.iframe_html);
 
-          document.body.insertBefore(fragment, document.body.childNodes[0]);
-          
+          var parentElement = document.body;
+
+          if (typeof LHCChatOptions != 'undefined' &&
+            typeof LHCChatOptions.opt != 'undefined' &&
+            typeof LHCChatOptions.opt.widget_parent != 'undefined') {
+            if(document.getElementById(LHCChatOptions.opt.widget_parent) != null) {
+                parentElement = document.getElementById(LHCChatOptions.opt.widget_parent);
+              }
+          }
+
+          parentElement.insertBefore(fragment, parentElement.childNodes[0]);
+
           var lhc_obj = this;
           
 		  if (typeof delayShow !== 'undefined') {         		

--- a/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/getstatus.tpl.php
@@ -429,7 +429,7 @@ var lh_inst  = {
                     
           var closeHandler = document.getElementById('lhc_close');
           if (closeHandler !== null){
-              closeHandler.onclick = function() { lhc_obj.hide(); return false; };
+              closeHandler.onclick = function() { lhc_obj.hide(); lh_inst.chatClosedCallback('user'); return false; };
           };
           
           document.getElementById('lhc_min').onclick = function() { lhc_obj.min(); return false; };
@@ -481,7 +481,14 @@ var lh_inst  = {
     		this.substatus = '';
     	}
     },
-    
+
+    chatClosedCallback : function(type){
+      if (typeof LHCChatOptions != 'undefined' && typeof LHCChatOptions.callback != 'undefined' && typeof LHCChatOptions.callback.close_chat_cb != 'undefined') {
+        LHCChatOptions.callback.close_chat_cb(type+this.substatus);
+        this.substatus = '';
+      }
+    },
+
     genericCallback : function(name){
     	if (typeof LHCChatOptions != 'undefined' && typeof LHCChatOptions.callback != 'undefined' && typeof LHCChatOptions.callback[name] != 'undefined') {
     		LHCChatOptions.callback[name](this);    	
@@ -834,6 +841,7 @@ var lh_inst  = {
     		lh_inst.genericCallback(functionName);    	
     	} else if (action == 'lhc_close') {
     		lh_inst.hide();
+                lh_inst.chatClosedCallback('message')
     	}
     }
 };


### PR DESCRIPTION
Two different changes here.

First one is adding callback when widget is closed. I found two places where it seemed to be appropriate to add call, and tried to add somewhat proper parameter ("user" when user closes, "message" when message causes closing).

Second change makes it possible to change the parent of chat widget. We need something like this as we have single page application and we want to have the widget visible only in certain places (internal tabs in application). With configurable parent we can the visibility of widget when needed.