### PR TITLE
Use caching for PHPExcel

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatexport.php
+++ b/lhc_web/lib/core/lhchat/lhchatexport.php
@@ -16,6 +16,10 @@ class erLhcoreClassChatExport {
 	
 	public static function exportDepartmentStats($departments) {
 	    include 'lib/core/lhform/PHPExcel.php';
+			$cacheMethod = PHPExcel_CachedObjectStorageFactory::cache_to_phpTemp;
+			$cacheSettings = array( 'memoryCacheSize ' => '64MB');
+			PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
+
 	    $objPHPExcel = new PHPExcel();
 	    $objPHPExcel->setActiveSheetIndex(0);
 	    $objPHPExcel->getActiveSheet()->getStyle('A1:AW1')->getFont()->setBold(true);
@@ -54,8 +58,12 @@ class erLhcoreClassChatExport {
 	}
 	
 	public static function chatListExportXLS($chats, $params = array()) {
-		include 'lib/core/lhform/PHPExcel.php';		
-		$objPHPExcel = new PHPExcel();		
+		include 'lib/core/lhform/PHPExcel.php';
+		$cacheMethod = PHPExcel_CachedObjectStorageFactory::cache_to_phpTemp;
+		$cacheSettings = array( 'memoryCacheSize ' => '64MB');
+		PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
+
+		$objPHPExcel = new PHPExcel();
 		$objPHPExcel->setActiveSheetIndex(0);
 		$objPHPExcel->getActiveSheet()->getStyle('A1:AW1')->getFont()->setBold(true);		
 		$objPHPExcel->getActiveSheet()->setTitle('Report');

--- a/lhc_web/lib/core/lhchat/lhchatstatistic.php
+++ b/lhc_web/lib/core/lhchat/lhchatstatistic.php
@@ -301,6 +301,10 @@ class erLhcoreClassChatStatistic {
         $data = self::averageOfChatsDialogsByUser($days,$filter,5000);   
         
         include 'lib/core/lhform/PHPExcel.php';
+        $cacheMethod = PHPExcel_CachedObjectStorageFactory::cache_to_phpTemp;
+        $cacheSettings = array( 'memoryCacheSize ' => '64MB');
+        PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
+
         $objPHPExcel = new PHPExcel();
         $objPHPExcel->setActiveSheetIndex(0);
         $objPHPExcel->getActiveSheet()->getStyle('A1:AW1')->getFont()->setBold(true);

--- a/lhc_web/modules/lhform/downloaditem.php
+++ b/lhc_web/modules/lhform/downloaditem.php
@@ -6,7 +6,12 @@ try {
 	$form = $item->form;
 	
 	include 'lib/core/lhform/PHPExcel.php';
-	 
+
+
+	$cacheMethod = PHPExcel_CachedObjectStorageFactory::cache_to_phpTemp;
+	$cacheSettings = array( 'memoryCacheSize ' => '64MB');
+	PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
+
 	$objPHPExcel = new PHPExcel();
 	
 	$objPHPExcel->setActiveSheetIndex(0);


### PR DESCRIPTION
The chat files are big, so default settings
just crash. So use cache for files.

We had around 25 000 chats the customer wanted to export. The exporting crashed almost immediately. With these changes,increasing hard coded limit 10 000 in lhc_web/modules/lhchat/closedchats.php  and some tweaking with php.ini(1.) all chats were exported.

The export tooks a while, around 1.5 minutes.


1.
memory_limit = 1024M
max_execution_time = 120
