### PR TITLE
Added a "closebutton" class

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/pagelayouts/userchat.php
+++ b/lhc_web/design/defaulttheme/tpl/pagelayouts/userchat.php
@@ -21,7 +21,7 @@
                             <a class="btn btn-default btn-xs" onclick="lhinst.restoreWidget('<?php echo $Result['chat']->id,'_',$Result['chat']->hash?>');" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chat','Switch to widget')?>"><i class="material-icons mr-0">open_in_browser</i></a>
                             <?php endif;?>
                                                 
-                		  	<a class="btn btn-default btn-xs" onclick="lhinst.userclosedchatandbrowser();" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chat','Close')?>"><i class="material-icons mr-0">close</i></a>
+                		  	<a class="btn btn-default btn-xs closebutton" onclick="lhinst.userclosedchatandbrowser();" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chat','Close')?>"><i class="material-icons mr-0">close</i></a>
                 		    <?php endif;?>	
                 		  
                 		  <?php if (isset($Result['show_switch_language'])) : ?>		  


### PR DESCRIPTION
FYI i have only amended this one line - 
`<a class="btn btn-default btn-xs closebutton" onclick="lhinst.userclosedchatandbrowser();" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chat','Close')?>"><i class="material-icons mr-0">close</i></a>`

I'm not sure why so many line show as being changed

Add a "closebutton" class to the close button to allow theming of the button.

I have this currently in my setup and it allows me to change the button color to red so it is more obvious, having this added to the master branch means i wont need to compare this file on each upgrade with my overridden version

thank you.