### PR TITLE
Spelling corrections, online visitor access & started changing 'user' to 'visitor'

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers.tpl.php
@@ -23,7 +23,7 @@
 	<!-- Nav tabs -->
 	<ul class="nav nav-pills" role="tablist">
 		<li role="presentation" class="active"><a href="#onlineusers" aria-controls="onlineusers" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online visitors list');?>"><i class="material-icons">face</i></a></li>
-		<li role="presentation"><a id="map-activator" href="#map" aria-controls="map" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online users on map');?>"><i class="material-icons">place</i></a></li>
+		<li role="presentation"><a id="map-activator" href="#map" aria-controls="map" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online visitors on map');?>"><i class="material-icons">place</i></a></li>
 	</ul>
 
 	<!-- Tab panes -->

--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online_tab.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online_tab.tpl.php
@@ -1,4 +1,4 @@
 <?php include(erLhcoreClassDesign::designtpl('lhchat/onlineusers/section_map_online_tab_pre.tpl.php')); ?>
 <?php if ($chat_onlineusers_section_map_online_tab_enabled == true && $currentUser->hasAccessTo('lhchat', 'use_onlineusers') == true) : ?>
-<li role="presentation"><a id="map-activator" href="#map" aria-controls="map" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online users on map');?>"><i class="material-icons mr-0">place</i></a></li>
+<li role="presentation"><a id="map-activator" href="#map" aria-controls="map" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online visitors on map');?>"><i class="material-icons mr-0">place</i></a></li>
 <?php endif;?>

--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online_tab.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online_tab.tpl.php
@@ -1,4 +1,4 @@
 <?php include(erLhcoreClassDesign::designtpl('lhchat/onlineusers/section_map_online_tab_pre.tpl.php')); ?>
-<?php if ($chat_onlineusers_section_map_online_tab_enabled == true) : ?>
+<?php if ($chat_onlineusers_section_map_online_tab_enabled == true && $currentUser->hasAccessTo('lhchat', 'use_onlineusers') == true) : ?>
 <li role="presentation"><a id="map-activator" href="#map" aria-controls="map" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online users on map');?>"><i class="material-icons mr-0">place</i></a></li>
 <?php endif;?>

--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_online_users.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_online_users.tpl.php
@@ -1,5 +1,5 @@
 <?php include(erLhcoreClassDesign::designtpl('lhchat/onlineusers/section_online_users_pre.tpl.php')); ?>
-<?php if ($chat_onlineusers_section_online_users_enabled == true) : ?>
+<?php if ($chat_onlineusers_section_online_users_enabled == true && $currentUser->hasAccessTo('lhchat', 'use_onlineusers') == true) : ?>
 <div class="row">
 	<div class="col-sm-2 form-group col-xs-6 pr5">
 		<label id="online-users-count" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','online users');?>">{{online.onlineusers.length}}</label>

--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_online_users_tab.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_online_users_tab.tpl.php
@@ -1,4 +1,4 @@
 <?php include(erLhcoreClassDesign::designtpl('lhchat/onlineusers/section_online_users_tab_pre.tpl.php')); ?>
-<?php if ($chat_onlineusers_section_online_users_tab_enabled == true) : ?>
+<?php if ($chat_onlineusers_section_online_users_tab_enabled == true && $currentUser->hasAccessTo('lhchat', 'use_onlineusers') == true) : ?>
 <li role="presentation"><a href="#onlineusers" aria-controls="onlineusers" role="tab" data-toggle="tab" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Online visitors list');?>"><i class="material-icons mr-0">face</i></a></li>
 <?php endif;?>

--- a/lhc_web/design/defaulttheme/tpl/lhdepartment/form.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhdepartment/form.tpl.php
@@ -131,7 +131,7 @@
 			<?php if (erLhcoreClassUser::instance()->hasAccessTo('lhdepartment','actworkflow')) : ?>
 			 <div role="tabpanel" class="tab-pane" id="chattransfer">
 			     <div class="form-group">
-    			     <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','To what department chat should be transfered if it is not accepted');?></label>
+    			     <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','To what department chat should be transferred if it is not accepted');?></label>
     				<?php echo erLhcoreClassRenderHelper::renderCombobox( array (
     										'input_name'     => 'TansferDepartmentID',
     										'optional_field' =>  erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','None'),
@@ -144,7 +144,7 @@
 				</div>
 				
 				<div class="form-group">
-				    <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.');?></label>
+				    <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.');?></label>
 				    <input type="text" class="form-control" name="TransferTimeout" value="<?php echo htmlspecialchars($departament->transfer_timeout);?>" />
 				</div>
 				

--- a/lhc_web/design/defaulttheme/tpl/lhfront/dashboard/index.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhfront/dashboard/index.tpl.php
@@ -42,7 +42,7 @@ $columnSize = 12 / $columnsTotal;
                      
                 <?php elseif ($wiget == 'online_visitors') : ?>
                 
-                     <?php if ($online_visitors_enabled_pre == true) : ?>
+                     <?php if ($online_visitors_enabled_pre == true && $currentUser->hasAccessTo('lhchat', 'use_onlineusers') == true) : ?>
                         <?php include(erLhcoreClassDesign::designtpl('lhfront/dashboard/panels/online_visitors.tpl.php'));?>
                      <?php endif;?>
                     

--- a/lhc_web/design/defaulttheme/tpl/lhfront/dashboard/panels/titles/transfered_chats.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhfront/dashboard/panels/titles/transfered_chats.tpl.php
@@ -1,1 +1,1 @@
-<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('pagelayout/pagelayout','Transfered chats');?>
+<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('pagelayout/pagelayout','Transferred chats');?>

--- a/lhc_web/doc/translation_default/translation_web.ts
+++ b/lhc_web/doc/translation_default/translation_web.ts
@@ -1747,11 +1747,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -2710,7 +2710,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3270,7 +3270,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3878,7 +3878,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/ar_EG/translation.ts
+++ b/lhc_web/translations/ar_EG/translation.ts
@@ -1729,11 +1729,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>المستخدمون المتصلون</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/ar_EG/translation.ts
+++ b/lhc_web/translations/ar_EG/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/bg_BG/translation.ts
+++ b/lhc_web/translations/bg_BG/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Известие, че чатът е затворен от оператор, изпраща се само е-мейл известие</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Към кой отдел да се прехвърли автоматично чата, ако не е приет от никого?</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Изчакване преди чата да се прехвърли към друг отдел. Минимум 5 секунди.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Посетители онлайн</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/bg_BG/translation.ts
+++ b/lhc_web/translations/bg_BG/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Списък на онлайн потребителите</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Покажи онлайн потребителите на картата</translation>
     </message>
     <message>

--- a/lhc_web/translations/cs_CS/translation.ts
+++ b/lhc_web/translations/cs_CS/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Seznam online návštěvníků</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Online uživatelé na mapě</translation>
     </message>
     <message>

--- a/lhc_web/translations/cs_CS/translation.ts
+++ b/lhc_web/translations/cs_CS/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informovat o ukončení rozhovoru operátorem, je odesláno pouze emailové upozornění.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Na jaké oddělení má být rozhovor převeden, pokud není přijat</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Časový limit v sekundách, než je rozhovor přesměrován na jiné oddělení. Minimum 5 sekund.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation>Nepřečtené rozhovory</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Předané rozhovory</translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Online návštěvníci</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Předané rozhovory</translation>
     </message>
     <message>

--- a/lhc_web/translations/da_DA/translation.ts
+++ b/lhc_web/translations/da_DA/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/da_DA/translation.ts
+++ b/lhc_web/translations/da_DA/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informer hvis chat er lukket af operatøren, kun mail meddelelsen sendes.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Til hvilken afdeling skal chat overføres, hvis det ikke er accepteret</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Timeout i sekunder før chat overføres til en anden afdeling. Mindst 5 sekunder.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Besøgende online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/de_DE/translation.ts
+++ b/lhc_web/translations/de_DE/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Nachricht wenn Chat vom Operator geschlossen wurde und nur eine E-Mail versendet wurde.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Zu welcher Abteilung der Chat übergeben werden soll, wenn er nicht akzeptiert wurde</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Zeitlimit in Sekunden, bevor der Chat einer anderen Abteilung übergeben wird. Minimum 5 Sekunden.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Besucher online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/de_DE/translation.ts
+++ b/lhc_web/translations/de_DE/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Liste der Online Besucher</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Online Besucher auf der Karte</translation>
     </message>
     <message>

--- a/lhc_web/translations/el_EL/translation.ts
+++ b/lhc_web/translations/el_EL/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Λίστα σε απευθείας σύνδεση επισκέπτες</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Online χρήστες για το χάρτη</translation>
     </message>
     <message>

--- a/lhc_web/translations/el_EL/translation.ts
+++ b/lhc_web/translations/el_EL/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Ενημερώνει τότε chat κλείνεται με χειριστή, ειδοποίηση για αλληλογραφία είναι το αποστολή.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Τι τμήμα συνομιλίας να μεταφερθούν, αν δεν είναι αποδεκτό</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Χρονικό όριο σε δευτερόλεπτα πριν chat μεταφέρεται σε άλλη υπηρεσία. Ελάχιστο 5 δευτερόλεπτα.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Συνδεδεμένοι χρήστες</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/es_MX/translation.ts
+++ b/lhc_web/translations/es_MX/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Lista de Visitantes Online</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Usuarios Online en el mapa</translation>
     </message>
     <message>

--- a/lhc_web/translations/es_MX/translation.ts
+++ b/lhc_web/translations/es_MX/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informar cuando un chat es cerrado por un operador, sólo se envía notificación por correo.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>A qué departamento el chat debe ser transferido si no se acepta</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Tiempo de espera en segundos antes de que el chat se transfiera a otro departamento. Mínimo 5 segundos.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Visitantes en línea</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Chats transferidos</translation>
     </message>
     <message>

--- a/lhc_web/translations/fa_FA/translation.ts
+++ b/lhc_web/translations/fa_FA/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>هنگام بسته شدن چت توسط اپراتور فقط با ارسال آگاه کننده اطلاع بده.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>در صورت پذیرفته نشدن، چت باید به کدام دپارتمان منتقل شود</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>مدت زمان قبل از انتقال چت به دپارتمان دیگر بر حسب ثانیه. حداقل 5 ثانیه می باشد.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>بازدیدکنندگان آنلاین</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/fa_FA/translation.ts
+++ b/lhc_web/translations/fa_FA/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>لیست بازدیدکنندگان آنلاین</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>کاربران آنلاین در نقشه</translation>
     </message>
     <message>

--- a/lhc_web/translations/fi_FI/translation.ts
+++ b/lhc_web/translations/fi_FI/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Kerro kun sähköpostilla, kun operaattori sulkee keskustelun.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Mihin yksikköön ohjataan, jos tätä ei hyväksytä.</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Odotusaika sekuntteina kunnes keskustelu ohjataan toiseen yksikköön. Vähintään 5s.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Kirjautuneet käyttäjät</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Siirretyt keskustelut</translation>
     </message>
     <message>

--- a/lhc_web/translations/fi_FI/translation.ts
+++ b/lhc_web/translations/fi_FI/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Paikalla olevien vieraiden lista</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Paikalla olevien vieraiden kartta</translation>
     </message>
     <message>

--- a/lhc_web/translations/fr_FR/translation.ts
+++ b/lhc_web/translations/fr_FR/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Liste des visiteurs en ligne</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Carte des utilisateurs en ligne</translation>
     </message>
     <message>

--- a/lhc_web/translations/fr_FR/translation.ts
+++ b/lhc_web/translations/fr_FR/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informer que le chat a été fermé par l&apos;opérateur</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Vers quel département les chats doivent être transférés s&apos;ils ne sont pas acceptés</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Timeout en secondes avant qu&apos;un chat soit transféré vers un autre département. Minimum 5 secondes.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Visiteurs connectés</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/he_HE/translation.ts
+++ b/lhc_web/translations/he_HE/translation.ts
@@ -1729,11 +1729,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>לאיזו מחלקה להעביר שיחה אם היא לא התקבלה</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>זמן להעברת שיחה למחלקה אחרת. מינימום 5 שניות</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>מבקרים פעילים</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/he_HE/translation.ts
+++ b/lhc_web/translations/he_HE/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>רשימת מבקרים פעילים</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>משתמשים מחוברים על מפה</translation>
     </message>
     <message>

--- a/lhc_web/translations/hr_HR/translation.ts
+++ b/lhc_web/translations/hr_HR/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Obavijesti kad operater koristi razgovor, samo putem e-mail obavijesti</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Kojem odjelu ovaj razgovor treba biti proslijeđen ako ne bude prihvaćen</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Vrijeme u sekundama prije nego što se razgovor proslijedi drugom odjelu. Najmanje 5 sekundi.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Online posjetitelja</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/hr_HR/translation.ts
+++ b/lhc_web/translations/hr_HR/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/id_ID/translation.ts
+++ b/lhc_web/translations/id_ID/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Menginformasikan ketika percakapan ditutup oleh operator, hanya email pemberitahuan yang dikirim.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Kepada departemen apa percakapan ini harus di transfer jika ini tidak diterima</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Batas waktu dalam detik sebelum percakapan ditransfer ke departemen lain. Minimal 5 detik.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Pengunjung online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/id_ID/translation.ts
+++ b/lhc_web/translations/id_ID/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/it_IT/translation.ts
+++ b/lhc_web/translations/it_IT/translation.ts
@@ -1730,11 +1730,11 @@
       <translation>Informare quando la chat è chiusa dall&apos;operatore, vieje inviata solo notifica di posta.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Reparto in cui la chat dev&apos;essere trasferita se non accettata</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Tempo massimo in secondi prima che la chat sia trasferita ad un altro reparto. Tempo minimo 5 secondi.</translation>
     </message>
     <message>
@@ -2693,7 +2693,7 @@
       <translation>Chat da leggere</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Chat trasferite</translation>
     </message>
     <message>
@@ -3857,7 +3857,7 @@
       <translation>Utenti online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Chat trasferite</translation>
     </message>
     <message>

--- a/lhc_web/translations/it_IT/translation.ts
+++ b/lhc_web/translations/it_IT/translation.ts
@@ -3249,7 +3249,7 @@
       <translation>Elenco visitatori online</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Utenti online su mappa</translation>
     </message>
     <message>

--- a/lhc_web/translations/ka_KA/translation.ts
+++ b/lhc_web/translations/ka_KA/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>ონლაინ ვიზიტორების სია</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>ონალინ მომხმარებლები რუკაზე</translation>
     </message>
     <message>

--- a/lhc_web/translations/ka_KA/translation.ts
+++ b/lhc_web/translations/ka_KA/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>ინფორმირება, როცა ჩეთი დაიხურება ოპერატორის მიერ. მხოლოდ ელ. ფოსტით შეტყობინება  გაიგზავნა.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>თუ რომელ დეპარტამენტს უნდა გადაეცეს ჩეთი თუ ის არ არის დადასტურებული</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>ტაიმ-აუტი წამებში იქამდე, სანამ ჩეთი გადაეცემა სხვა დეპარტამენტს. მინიმუმ 5 წამი</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>ონლაინ ვიზიტორები</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/lt_LT/translation.ts
+++ b/lhc_web/translations/lt_LT/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informuoti kada pokalbis būna uždarytas administratoriaus, tik el. pašto žinutė būna išsiųsta</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Kokiam departamentui pokalbis turėtų būti pervestas jei pokalbis nebuvo priimtas.</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Laikas sekundėmis prieš tai kol pokalbis priskiriamas paveldinčiam departamentui. Minimum 5 sekundės.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Prisijungę vartotojai</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Pervesti pokalbiai</translation>
     </message>
     <message>

--- a/lhc_web/translations/lt_LT/translation.ts
+++ b/lhc_web/translations/lt_LT/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Prisijungusių lankytojų sąrašas</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Prisijungusių vartotojų žemėlapis</translation>
     </message>
     <message>

--- a/lhc_web/translations/nl_NL/translation.ts
+++ b/lhc_web/translations/nl_NL/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Online bezoekers lijst</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Online gebruikers op de kaart</translation>
     </message>
     <message>

--- a/lhc_web/translations/nl_NL/translation.ts
+++ b/lhc_web/translations/nl_NL/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informeer wanneer chat is afgesloten door de operator, alleen een email-notificatie wordt verzonden.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Naar welke afdeling de chat moet worden doorgeschakeld als hij niet geaccepteerd wordt</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Timeout in seconden voordat een chat doorgezet wordt naar een andere afdeling. Minimaal 5 seconden.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3857,7 +3857,7 @@ dashboard,online_map,online_users,pending_chats,online_map,active_chats,unread_c
       <translation>Online bezoekers</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Doorgeschakelde chats</translation>
     </message>
     <message>

--- a/lhc_web/translations/no_NO/translation.ts
+++ b/lhc_web/translations/no_NO/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/no_NO/translation.ts
+++ b/lhc_web/translations/no_NO/translation.ts
@@ -1729,11 +1729,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Hvilken avdeling skal samtalen automatisk flyttes til hvis den ikke aksepteres</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>TIdsavbrudd før samtalen blir flyttet til en annen avdeling. Minimum 5 sekunder.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Påloggede besøkende</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/pl_PL/translation.ts
+++ b/lhc_web/translations/pl_PL/translation.ts
@@ -3249,7 +3249,7 @@ pokazywany</translation>
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/pl_PL/translation.ts
+++ b/lhc_web/translations/pl_PL/translation.ts
@@ -1730,11 +1730,11 @@ pokazywany</translation>
       <translation>Informuj kiedy rozmowa jest zamknięta przez operatora, tylko powiadomienie mailowe jest wysyłane.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Do jakiego wydziału rozmowa powinny być przeniesiona, jeśli nie została przyjęta</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Limit czasu w sekundach zanim rozmowa zostaje przeniesiona do innego wydziału. Minimum 5 sekund.</translation>
     </message>
     <message>
@@ -2693,7 +2693,7 @@ pokazywany</translation>
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3857,7 +3857,7 @@ pokazywany</translation>
       <translation>Goście on-line</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/pt_BR/translation.ts
+++ b/lhc_web/translations/pt_BR/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Lista de visitantes online</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Mapa de usuários online</translation>
     </message>
     <message>

--- a/lhc_web/translations/pt_BR/translation.ts
+++ b/lhc_web/translations/pt_BR/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informar quando o chat é fechado pelo operador, somente notificação por email é enviada</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Para qual departamento o chat deve ser transferido caso não seja aceito</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Tempo limite em segundos antes do chat ser transferido para outro departamento. Mínimo de 5 segundos.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation>Chats não lidos</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Chats transferidos</translation>
     </message>
     <message>
@@ -3857,7 +3857,7 @@ dashboard,online_map,online_users,pending_chats,online_map,active_chats,unread_c
       <translation>Visitantes online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Chats transferidos</translation>
     </message>
     <message>

--- a/lhc_web/translations/ro_RO/translation.ts
+++ b/lhc_web/translations/ro_RO/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Lista vizitatorilor online</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Utilizatori online afisati pe harta</translation>
     </message>
     <message>

--- a/lhc_web/translations/ro_RO/translation.ts
+++ b/lhc_web/translations/ro_RO/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Notifica cand conversatia este inchisa de operator (notificare prin e-mail)</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Catre care departament trebuie sa fie transferata conversatia daca nu este acceptata</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Timp in secunde inainte ca discutia sa fie transferata unui alt departament. Minim 5 secunde.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Vizitatori online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/ru_RU/translation.ts
+++ b/lhc_web/translations/ru_RU/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Информировать о том, что чат закрыт оператором, и возможно отправить только сообщение на e-mail</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>На какой департамент чат должен быть переведен, если его не принял ни один оператор</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Время ожидания, после которого чат будет переведен на другой департамент. Минимум 5 секунд.</translation>
     </message>
     <message>
@@ -2693,7 +2693,7 @@
       <translation>Непрочитанные чаты</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Перенаправленные чаты</translation>
     </message>
     <message>
@@ -3857,7 +3857,7 @@
       <translation>Пользователи онлайн</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Перенаправленные чаты</translation>
     </message>
     <message>

--- a/lhc_web/translations/ru_RU/translation.ts
+++ b/lhc_web/translations/ru_RU/translation.ts
@@ -3249,7 +3249,7 @@
       <translation>Список посетителей онлайн</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Онлайн пользователи на карте</translation>
     </message>
     <message>

--- a/lhc_web/translations/sq_AL/translation.ts
+++ b/lhc_web/translations/sq_AL/translation.ts
@@ -3249,7 +3249,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/sq_AL/translation.ts
+++ b/lhc_web/translations/sq_AL/translation.ts
@@ -2693,7 +2693,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3857,7 +3857,7 @@
       <translation>Vizitoret ne linje</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/sv_SV/translation.ts
+++ b/lhc_web/translations/sv_SV/translation.ts
@@ -3248,7 +3248,7 @@
       <translation>Lista över besökare som är online</translation>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation>Karta över besökare som är online</translation>
     </message>
     <message>

--- a/lhc_web/translations/sv_SV/translation.ts
+++ b/lhc_web/translations/sv_SV/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>Informera sedan stängs chatten av operatören, endast e-postnotifikation är tillgänglig.</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Till vilken avdelning chatten ska vidarebefordras om den inte blir accepterad</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Timeout i sekunder innan chatten vidarebefodras till en annan avdelning. Minst 5s.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation>Olästa chattar</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Överförda chattar</translation>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Besökare online</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation>Överförda chattar</translation>
     </message>
     <message>

--- a/lhc_web/translations/th_TH/translation.ts
+++ b/lhc_web/translations/th_TH/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>แจ้ง แล้วสนทนาถูกปิด โดยผู้ประกอบการ เพียงแต่ส่งเป็นจดหมายแจ้งเตือน</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>แผนกใดสนทนาควรโอนย้ายถ้ามันไม่ยอมรับ</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>การหมดเวลาเป็นวินาทีก่อนสนทนาจะถูกโอนย้ายไปที่แผนกอื่น อย่างน้อย 5 วินาที</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>ผู้เยี่ยมชมออนไลน์</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/th_TH/translation.ts
+++ b/lhc_web/translations/th_TH/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/tr_TR/translation.ts
+++ b/lhc_web/translations/tr_TR/translation.ts
@@ -1729,11 +1729,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>Konuşma kabul edilmediğinde aktarılacağı departman</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Konuşma başka bir departmana aktarılmadan önce geçmesi gereken zaman aşımı. Minimum 5 saniye.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3858,7 +3858,7 @@
       <translation>Online ziyaretçiler</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/tr_TR/translation.ts
+++ b/lhc_web/translations/tr_TR/translation.ts
@@ -3249,7 +3249,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/vi_VN/translation.ts
+++ b/lhc_web/translations/vi_VN/translation.ts
@@ -1729,11 +1729,11 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>Thời gian chờ tính bằng giây trước khi cuộc trò chuyện được chuyển sang cho một bộ phận khác. Tối thiểu 5 giây.</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>Khách trực tuyến</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/vi_VN/translation.ts
+++ b/lhc_web/translations/vi_VN/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/zh_ZH/translation.ts
+++ b/lhc_web/translations/zh_ZH/translation.ts
@@ -3248,7 +3248,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Online users on map</source>
+      <source>Online visitors on map</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/translations/zh_ZH/translation.ts
+++ b/lhc_web/translations/zh_ZH/translation.ts
@@ -1729,11 +1729,11 @@
       <translation>只有邮件通知是发送通知然后由运算符，关闭聊天。</translation>
     </message>
     <message>
-      <source>To what department chat should be transfered if it is not accepted</source>
+      <source>To what department chat should be transferred if it is not accepted</source>
       <translation>部門聊天，如果不接受，應該被轉移</translation>
     </message>
     <message>
-      <source>Timeout in seconds before chat is transfered to another department. Minimum 5 seconds.</source>
+      <source>Timeout in seconds before chat is transferred to another department. Minimum 5 seconds.</source>
       <translation>超時聊天秒前被轉移到另一個部門。至少5秒。</translation>
     </message>
     <message>
@@ -2692,7 +2692,7 @@
       <translation type="unfinished"/>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -3856,7 +3856,7 @@
       <translation>在线访客</translation>
     </message>
     <message>
-      <source>Transfered chats</source>
+      <source>Transferred chats</source>
       <translation type="unfinished"/>
     </message>
     <message>


### PR DESCRIPTION
Three changes:
1) Corrected spelling mistake of transfered to transferred in UI
2) Started changing 'user' to 'visitor'
3) Turned off the various online visitor displays if the operator has no access