### PR TITLE
Check and fix possible error when doing json_encode

### DIFF
--- a/lhc_web/modules/lhchat/syncadmininterface.php
+++ b/lhc_web/modules/lhchat/syncadmininterface.php
@@ -242,6 +242,44 @@ $currentUser->updateLastVisit();
 
 erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.syncadmininterface',array('lists' => & $ReturnMessages));
 
-echo json_encode(array('error' => 'false', 'result' => $ReturnMessages ));
+function safe_json_encode($value){
+    if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+        $encoded = json_encode($value, JSON_PRETTY_PRINT);
+    } else {
+        $encoded = json_encode($value);
+    }
+    switch (json_last_error()) {
+        case JSON_ERROR_NONE:
+            return $encoded;
+        case JSON_ERROR_DEPTH:
+            return 'Maximum stack depth exceeded'; // or trigger_error() or throw new Exception()
+        case JSON_ERROR_STATE_MISMATCH:
+            return 'Underflow or the modes mismatch'; // or trigger_error() or throw new Exception()
+        case JSON_ERROR_CTRL_CHAR:
+            return 'Unexpected control character found';
+        case JSON_ERROR_SYNTAX:
+            return 'Syntax error, malformed JSON'; // or trigger_error() or throw new Exception()
+        case JSON_ERROR_UTF8:
+            $clean = utf8ize($value);
+            return safe_json_encode($clean);
+        default:
+            return 'Unknown error'; // or trigger_error() or throw new Exception()
+
+    }
+}
+
+function utf8ize($mixed) {
+    if (is_array($mixed)) {
+        foreach ($mixed as $key => $value) {
+            $mixed[$key] = utf8ize($value);
+        }
+    } else if (is_string ($mixed)) {
+        return utf8_encode($mixed);
+    }
+    return $mixed;
+}
+
+echo safe_json_encode(array('error' => 'false', 'result' => $ReturnMessages ));
+
 exit;
 ?>


### PR DESCRIPTION
json_encode can fail silently, and only way to determine
this is to check json_last_error(). One of the cases is UTF-8
error, which then can be resolved.

Implementation was found from http://stackoverflow.com/a/26760943/1682014