### PR TITLE
Replaced insert to cell with variables to speed up loop

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatexport.php
+++ b/lhc_web/lib/core/lhchat/lhchatexport.php
@@ -58,116 +58,106 @@ class erLhcoreClassChatExport {
 	}
 	
 	public static function chatListExportXLS($chats, $params = array()) {
-		include 'lib/core/lhform/PHPExcel.php';
-		$cacheMethod = PHPExcel_CachedObjectStorageFactory::cache_to_phpTemp;
-		$cacheSettings = array( 'memoryCacheSize ' => '64MB');
-		PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
 
-		$objPHPExcel = new PHPExcel();
-		$objPHPExcel->setActiveSheetIndex(0);
-		$objPHPExcel->getActiveSheet()->getStyle('A1:AW1')->getFont()->setBold(true);		
-		$objPHPExcel->getActiveSheet()->setTitle('Report');
-						
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(0, 1, "ID");
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(1, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Visitor Name'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(2, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','E-mail'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(3, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Phone'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(4, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Wait time'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(5, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Country'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(6, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','City'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(7, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','IP'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(8, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Operator'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(9, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Department'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(10, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Date'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(11, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Minutes'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(12, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Vote status'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(13, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Mail send'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(14, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Page'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(15, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Came from'));
-		$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(16, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Link'));
+		include 'lib/core/lhform/PHPExcel.php';
+
+		$chatArray = array();
+		
+		$id = "ID";
+		$name = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Visitor Name');
+		$email = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','E-mail');
+		$phone = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Phone');
+		$wait = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Wait time');
+		$country = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Country');
+		$city = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','City');
+		$ip = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','IP');
+		$operator = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Operator');
+		$dept = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Department');
+		$date = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Date');
+		$minutes = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Minutes');
+		$vote = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Vote status');
+		$mail = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Mail send');
+		$page = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Page');
+		$from = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Came from');
+		$link = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Link');
 		
 		if (isset($params['type']) && $params['type'] == 2) {
-		    $objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow(17, 1, erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Chat content'));
+		    $content = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/chatexport','Chat content');
+		} else {
+			$content = null;
 		}
-		
-		$attributes = array(
-			'id',
-			'nick',
-			'email',
-			'phone',
-		    'wait_time',
-			'country_name',
-			'city',
-			'ip',
-			'user',
-			'department'
-		);
-		
-		$i = 2;
-		foreach ($chats as $item) {
-			foreach ($attributes as $key => $attr) {
-				$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i, (string)$item->{$attr});
-			}
-			$key++;
-			$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i,  date(erLhcoreClassModule::$dateFormat,$item->time));
-			
-			$key++;
-			$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i,  date('H:i:s',$item->time));
-			
-			$key++;
-			$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i,  ($item->fbst == 1 ? 'UP' : ($item->fbst == 2 ? 'DOWN' : 'NONE')));
-			
-			$key++;
-			$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i, $item->mail_send == 1 ? 'Yes' : 'No');
-			
-			$key++;
-			if ($item->referrer != ''){
-			    $objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i,  $item->referrer);
-			}
-						
-			$key++;	
-			if ($item->session_referrer != ''){
-				$referer = parse_url($item->session_referrer);				
-				if (isset($referer['host'])) {					
-					$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i, $referer['host']);
-				}				
-			}	
-			
-			$key++;
-			$objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i, "URL");
-			$objPHPExcel->getActiveSheet()->getCellByColumnAndRow($key, $i)->getHyperlink()->setUrl(erLhcoreClassXMP::getBaseHost() . $_SERVER['HTTP_HOST'] . erLhcoreClassDesign::baseurl('user/login').'/(r)/'.rawurlencode(base64_encode('chat/single/'.$item->id)));
 
-			// Print chat content to last column
-			if (isset($params['type']) && $params['type'] == 2) {
-			    $key++;	
+		$chatArray[] = array($id, $name, $email, $phone, $wait, $country, $city, $ip, $operator, $dept, $date, $minutes, $vote, $mail, $page, $from, $link, $content);
+		
+        foreach ($chats as $item) {
+                $id = (string)$item->{'id'};
+                $nick = (string)$item->{'nick'};
+                $email = (string)$item->{'email'};
+                $phone = (string)$item->{'phone'};
+                $wait = (string)$item->{'wait_time'};
+                $country = (string)$item->{'country_name'};
+                $city = (string)$item->{'city'};
+                $ip = (string)$item->{'ip'};
+                $user = (string)$item->{'user'};
+                $dept = (string)$item->{'department'};
 
-			    $messages = erLhcoreClassModelmsg::getList(array('limit' => 10000,'sort' => 'id ASC','filter' => array('chat_id' => $item->id)));			    
-			    $messagesContent = '';
+                $date = date(erLhcoreClassModule::$dateFormat,$item->time);
+                $minutes = date('H:i:s',$item->time);
+                $vote = ($item->fbst == 1 ? 'UP' : ($item->fbst == 2 ? 'DOWN' : 'NONE'));
+                $mail = $item->mail_send == 1 ? 'Yes' : 'No';
+                $page = $item->referrer;
+                
+                if ($item->session_referrer != ''){
+                        $referer = parse_url($item->session_referrer);                    
+                        if (isset($referer['host'])) {
+                            $from = $referer['host'];
+                        } else {
+                        	$from = null;
+                        }
+                } else {
+                	$from = null;
+                }
 
-				foreach ($messages as $msg ) {
-					if ($msg->user_id == -1) {
-						$messagesContent .= date(erLhcoreClassModule::$dateDateHourFormat,$msg->time).' '. erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncadmin','System assistant').': '.htmlspecialchars($msg->msg)."\n";
-					} else {
-						$messagesContent .= date(erLhcoreClassModule::$dateDateHourFormat,$msg->time).' '. ($msg->user_id == 0 ? htmlspecialchars($item->nick) : htmlspecialchars($msg->name_support)).': '.htmlspecialchars($msg->msg)."\n";
-					}
-				}
-				
-			    $objPHPExcel->getActiveSheet()->setCellValueByColumnAndRow($key, $i, trim($messagesContent));
-			}
-			
-			$i++;
-		}
-		
-		$objWriter = PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
-		
-		// We'll be outputting an excel file
-		header('Content-type: application/vnd.ms-excel');
-		
-		// It will be called file.xls
-		header('Content-Disposition: attachment; filename="report.xlsx"');
-		
-		// Write file to the browser
-		$objWriter->save('php://output');
+                $url = erLhcoreClassXMP::getBaseHost() . $_SERVER['HTTP_HOST'] . erLhcoreClassDesign::baseurl('user/login').'/(r)/'.rawurlencode(base64_encode('chat/single/'.$item->id));
+
+                // Print chat content to last column
+                if (isset($params['type']) && $params['type'] == 2) {
+
+                    $messages = erLhcoreClassModelmsg::getList(array('limit' => 10000,'sort' => 'id ASC','filter' => array('chat_id' => $item->id)));                       
+                    $messagesContent = '';
+
+                        foreach ($messages as $msg ) {
+                                if ($msg->user_id == -1) {
+                                        $messagesContent .= date(erLhcoreClassModule::$dateDateHourFormat,$msg->time).' '. erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncadmin','System assistant').': '.htmlspecialchars($msg->msg)."\n";
+                                } else {
+                                        $messagesContent .= date(erLhcoreClassModule::$dateDateHourFormat,$msg->time).' '. ($msg->user_id == 0 ? htmlspecialchars($item->nick) : htmlspecialchars($msg->name_support)).': '.htmlspecialchars($msg->msg)."\n";
+                                }
+                        }
+
+                    $chatArray[] = array($id, $nick, $email, $phone, $wait, $country, $city, $ip, $user, $dept, $date, $minutes, $vote, $mail, $page, $from, $url, trim($messagesContent));
+                } else {
+                	$chatArray[] = array($id, $nick, $email, $phone, $wait, $country, $city, $ip, $user, $dept, $date, $minutes, $vote, $mail, $page, $from, $url);
+                }
+        }
+
+		// Create new PHPExcel object
+		$objPHPExcel = new PHPExcel();
+		$objPHPExcel->setActiveSheetIndex(0);
+
+		// Set the starting point and array of data
+		$objPHPExcel->getActiveSheet()->fromArray($chatArray, null, 'A1');
+
+		// Set style for top row
+		$objPHPExcel->getActiveSheet()->getStyle('A1:AW1')->getFont()->setBold(true);
+
+		// Set file type and name of file
+		header('Content-Type: application/vnd.ms-excel');
+		header('Content-Disposition: attachment;filename="report.xlsx"');
+		header('Cache-Control: max-age=0');
+
+		$writer = PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
+
+		$writer->save('php://output');
 	}
 }
 


### PR DESCRIPTION
- Removed all of the getActiveSheet()->setCellValueByColumnAndRow calls and replaced them with variables stored in an array.  After all chats have been inserted in the array, the array itself is written to excel.
- Advantages: This cuts the processing and saving time in half.  With a test sample of 10,000 chats, we now will not hit the php default timeout.
- Disadvantages:  The URL is no longer a hyperlink, just the address.  We cannot change the url to a hyperlink, since it is being stored in an array instead of written to the cell.