### PR TITLE
#890 Updating Google maps to use new api endpoint

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers/section_map_online.tpl.php
@@ -30,5 +30,5 @@
 <script type="text/javascript">
 var GeoLocationData = {zoom:<?php echo $geo_location_data['zoom']?>,lat:<?php echo $geo_location_data['lat']?>,lng:<?php echo $geo_location_data['lng']?>};
 </script>
-<script src="https://maps-api-ssl.google.com/maps/api/js?v=3&sensor=false&callback=gMapsCallback"></script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?<?php if (erConfigClassLhConfig::getInstance()->getSetting( 'site', 'maps_api_key', false)) echo 'key=' . erConfigClassLhConfig::getInstance()->getSetting( 'site', 'maps_api_key', false) . '&'?>callback=gMapsCallback"></script>
 <?php endif;?>

--- a/lhc_web/settings/settings.ini.default.php
+++ b/lhc_web/settings/settings.ini.default.php
@@ -21,6 +21,7 @@ return array (
       'date_hour_format' => 'H:i:s',
       'date_date_hour_format' => 'Y-m-d H:i:s',
       'default_site_access' => 'eng',
+      'maps_api_key' => false,
       'extensions' =>
           array (
             // 0 => 'customstatus',


### PR DESCRIPTION
#890 Updating Google maps endpoint, and if `maps_api_key` is found in site settings it will append the api key to the url.
* Enable api through https://console.developers.google.com/flows/enableapi
* List api credentials in https://console.developers.google.com/apis/credentials