### PR TITLE
FIX Bubble issue on visitor and operator chat messages - Update material_font.css

### DIFF
--- a/lhc_web/design/defaulttheme/css/material_font.css
+++ b/lhc_web/design/defaulttheme/css/material_font.css
@@ -10,6 +10,10 @@
        url('../fonts/MaterialIcons-Regular.ttf') format('truetype');
 }
 
+div.message-row {
+overflow-wrap: break-word;
+}
+
 .material-icons {
   font-family: 'Material Icons';
   font-weight: normal;


### PR DESCRIPTION
FIX long link issue that go out of the bubble.
Here showed the issue:

![screen 1](https://cloud.githubusercontent.com/assets/5006150/24241146/2b04d60c-0fb4-11e7-8cd9-9aff6e921d67.png)

With the FIX this will not happen again.
