### PR TITLE
set email sender address per department

### DIFF
--- a/lhc_web/modules/lhchat/sendchat.php
+++ b/lhc_web/modules/lhchat/sendchat.php
@@ -44,6 +44,7 @@ if (is_object($chat) && $chat->hash == $Params['user_parameters']['hash'] && ($c
             $tpl = erLhcoreClassTemplate::getInstance('lhchat/sendmail.tpl.php');
             $mailTemplate = erLhAbstractModelEmailTemplate::fetch(3);
             erLhcoreClassChatMail::prepareSendMail($mailTemplate);
+            if ($chat->department->email) { $mailTemplate->from_email = $chat->department->email; }
             $mailTemplate->recipient = $form->email;
 
             $messages = array_reverse(erLhcoreClassModelmsg::getList(array('customfilter' => array('user_id != -1'),'limit' => 500, 'sort' => 'id DESC','filter' => array('chat_id' => $chat->id))));


### PR DESCRIPTION
email template #3, sent when the visitor requests a transcript in the widget: send transcript to the client from the department's email address instead of the system default, otherwise it discloses system default in whitelabel chats (when department address/domain is different from the system default)