### PR TITLE
fixed Non-static method erLhcoreClassSiteaccessGenerator::trimArrayEl…

### DIFF
--- a/lhc_web/lib/core/lhcore/lhsiteaccessgenerator.php
+++ b/lhc_web/lib/core/lhcore/lhsiteaccessgenerator.php
@@ -61,7 +61,7 @@ class erLhcoreClassSiteaccessGenerator {
     	$cfgSite->save();
     }
 
-    public function trimArrayElements($array){
+    public static function trimArrayElements($array){
     	foreach ($array as $key => & $value) {
     		$value = trim($value);
     	}


### PR DESCRIPTION
…ements()

Non-static method erLhcoreClassSiteaccessGenerator::trimArrayElements() should not be called statically in /Users/kunl/code/work/livehelperchat/lhc_web/lib/core/lhcore/lhsiteaccessgenerator.php on line 55