### PR TITLE
Fix livehelperchat version reporting, github issue #1165

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhsystem/update.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsystem/update.tpl.php
@@ -6,7 +6,7 @@
 
 <div class="row">
 	<div class="col-md-4">
-		<h3><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/update','Your version')?> - <?php echo erLhcoreClassUpdate::LHC_RELEASE/100;?></h3>
+		<h3><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/update','Your version')?> - <?php echo sprintf("%0.2f", erLhcoreClassUpdate::LHC_RELEASE/100);?></h3>
 		<h3><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/update','Current version')?> - <span class="success-color" id="recent-version">...</span></h3>
 		<a class="btn btn-default btn-xs" href="http://livehelperchat.com/news-5c.html" target="_blank"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/update','News')?></a>
 		<a class="btn btn-default btn-xs" href="http://livehelperchat.com/article/view/63" target="_blank"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/update','Update instructions')?></a>
@@ -35,7 +35,7 @@ function updateDatabase() {
       jsonp: 'callback',
       jsonpCallback: 'jsonpCallbackLHC',
       success: function(data){        
-              $('#recent-version').text(data.version/100); 
+              $('#recent-version').text((data.version/100).toFixed(2));
       }
   });
 	 


### PR DESCRIPTION
We apply the appropriate padding/precision when displaying the current version to cater for when version numbers have a zero suffix. eg: v2.80

**BEFORE CHANGES: v2.80 would be displayed as 2.8**
![image](https://user-images.githubusercontent.com/35119727/34592762-61fbba38-f201-11e7-8b91-354850e31d25.png)

**AFTER CHANGES: v2.80 would be displayed as 2.80**
![image](https://user-images.githubusercontent.com/35119727/34596808-b3a743ea-f21d-11e7-96f7-61a7e2cafd23.png)
