### PR TITLE
Update lhrestapivalidator.php

### DIFF
--- a/lhc_web/lib/core/lhrestapi/lhrestapivalidator.php
+++ b/lhc_web/lib/core/lhrestapi/lhrestapivalidator.php
@@ -42,7 +42,7 @@ class erLhcoreClassRestAPIHandler
     public static function setHeaders()
     {
         header('Access-Control-Allow-Origin: *');
-        header('Access-Control-Allow-Credentials', "true");
+        header('Access-Control-Allow-Credentials: true');
         header('Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, API-Key, Authorization');
         header('Content-Type: application/json');
         self::setOptionHeaders();


### PR DESCRIPTION
Fix to send the "Access-Control-Allow-Credentials" header correctly. This line caused an HTTP 500 when hosting via FastCGI.