### PR TITLE
 Fix #1219 RESTful API index broken, removed erroneous comma

### DIFF
--- a/lhc_web/modules/lhrestapi/swagger.json
+++ b/lhc_web/modules/lhrestapi/swagger.json
@@ -900,7 +900,7 @@
           }
         }
       }
-    },
+    }
   },
   "securityDefinitions": {
     "login": {


### PR DESCRIPTION
Removed erroneous comma from swagger.json, this prevents JSON.parse errors reported by web browsers:

`SyntaxError: JSON.parse: expected double-quoted property name at line 904 column 3 of the JSON data`