### PR TITLE
XMPP fatal error on PHP7.2

### DIFF
--- a/lhc_web/lib/core/lhxmp/XMPPHP/XMLStream.php
+++ b/lhc_web/lib/core/lhxmp/XMPPHP/XMLStream.php
@@ -124,13 +124,13 @@ class XMPPHP_XMLStream {
 	 */
 	protected $default_ns;
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $until = '';
+	protected $until = array();
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $until_count = '';
+	protected $until_count = array();
 	/**
 	 * @var array
 	 */


### PR DESCRIPTION
I needed to change this until and until_count variables to array, because they are used as arrays and on previous versions of PHP was possible to do something like: 'string[] = 1', and its converts to an array. But now it doesn't work anymore and throws error.