### PR TITLE
Remove limits for body email text.

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatmail.php
+++ b/lhc_web/lib/core/lhchat/lhchatmail.php
@@ -102,9 +102,9 @@ class erLhcoreClassChatMail {
     	$Errors = array();
 
     	if (isset($params['archive_mode']) && $params['archive_mode'] == true){
-    		$messages = array_reverse(erLhcoreClassChat::getList(array('limit' => 100, 'sort' => 'id DESC','customfilter' => array('user_id != -1'), 'filter' => array('chat_id' => $chat->id)),'erLhcoreClassModelChatArchiveMsg',erLhcoreClassModelChatArchiveRange::$archiveMsgTable));
+    		$messages = array_reverse(erLhcoreClassChat::getList(array('limit' => false, 'sort' => 'id DESC','customfilter' => array('user_id != -1'), 'filter' => array('chat_id' => $chat->id)),'erLhcoreClassModelChatArchiveMsg',erLhcoreClassModelChatArchiveRange::$archiveMsgTable));
     	} else {
-    		$messages = array_reverse(erLhcoreClassModelmsg::getList(array('limit' => 100,'sort' => 'id DESC','customfilter' => array('user_id != -1'), 'filter' => array('chat_id' => $chat->id))));
+    		$messages = array_reverse(erLhcoreClassModelmsg::getList(array('limit' => false,'sort' => 'id DESC','customfilter' => array('user_id != -1'), 'filter' => array('chat_id' => $chat->id))));
     	}
     	
     	// Fetch chat messages


### PR DESCRIPTION
This update should remove the limitation to 100 row for email text so visitor can receive a full chat transcript in email also operator from his panel, by sending an email to visitor will be able to send the full chat transcript.

This should fix and resolve two GitHub issues.
https://github.com/LiveHelperChat/livehelperchat/issues/1019
https://github.com/LiveHelperChat/livehelperchat/issues/1284

**This fix has been not tested by me.**