### PR TITLE
Removing the unnecessary constructor method.

### DIFF
--- a/lhc_web/lib/core/lhdepartament/lhdepartament.php
+++ b/lhc_web/lib/core/lhdepartament/lhdepartament.php
@@ -2,11 +2,6 @@
 
 class erLhcoreClassDepartament{
 
-   function __construct()
-   {
-
-   }
-
    public static function getDepartaments()
    {
          $db = ezcDbInstance::get();


### PR DESCRIPTION
The `erLhcoreClassDepartament` class (`/lhc_web/lib/core/lhdepartament/lhdepartament.php`) doesn't extend any class, and has an empty constructor method.