### PR TITLE
check for lower-case authorization header

### DIFF
--- a/lhc_web/lib/core/lhrestapi/lhrestapivalidator.php
+++ b/lhc_web/lib/core/lhrestapi/lhrestapivalidator.php
@@ -108,9 +108,9 @@ class erLhcoreClassRestAPIHandler
 
         $headers = self::getHeaders();
 
-        if (isset($headers['Authorization'])) {
+        if (isset($headers['authorization'])) {
             
-            $dataAuthorisation = explode(' ', $headers['Authorization']);
+            $dataAuthorisation = explode(' ', $headers['authorization']);
             $apiData = explode(':', base64_decode($dataAuthorisation[1]));
             
             if (count($apiData) != 2) {


### PR DESCRIPTION
Names of Header fields are lowercased by the PHP function getallheaders() and the replacement function. However the validation code checks for the uppercase field "Authorization". 