### PR TITLE
3.59v

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1241,6 +1241,7 @@ class Install
                 ('customer_site_url',	'http://livehelperchat.com',	0,	'Your site URL address',	0),
                 ('transfer_configuration','0','0','Transfer configuration','1'),
                 ('list_unread','0','0','List unread chats','0'),
+                ('autoclose_abandon_pending','0,0','0','Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>.','0'),
                 ('mobile_options',	'a:2:{s:13:\"notifications\";i:0;s:7:\"fcm_key\";s:152:\"AAAAiF8DeNk:APA91bFVHu2ybhBUTtlEtQrUEPpM2fb-5ovgo0FVNm4XxK3cYJtSwRcd-pqcBot_422yDOzHyw2p9ZFplkHrmNXjm8f5f-OIzfalGmpsypeXvnPxhU6Db1B2Z1Acc-TamHUn2F4xBJkP\";}',	0,	'',	1),
                 ('list_closed','0','0','List closed chats','0'),
                 ('autoclose_activity_timeout','0','0','Automatically close active chat if from last visitor/operator message passed. 0 - disabled, n > 0 time in minutes','0'),

--- a/lhc_web/design/defaulttheme/tpl/lhchat/listchatconfig.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/listchatconfig.tpl.php
@@ -251,6 +251,9 @@
                 <?php $attribute = 'autoclose_activity_timeout'?>
     		    <?php include(erLhcoreClassDesign::designtpl('lhchat/part/chat_settings.tpl.php'));?>
 
+                <?php $attribute = 'autoclose_abandon_pending'?>
+    		    <?php include(erLhcoreClassDesign::designtpl('lhchat/part/chat_settings.tpl.php'));?>
+
                 <?php $attribute = 'autoclose_timeout_pending'?>
     		    <?php include(erLhcoreClassDesign::designtpl('lhchat/part/chat_settings.tpl.php'));?>
 

--- a/lhc_web/design/defaulttheme/tpl/lhsystem/update/statusdb.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsystem/update/statusdb.tpl.php
@@ -34,7 +34,7 @@
           <div class="card-body">
             <ul>
         		<?php foreach ($queries as $query) : ?>
-        			<li><?php echo $query;?></li>
+        			<li><?php echo htmlspecialchars($query);?></li>
         		<?php endforeach; ?>
         	</ul>
           </div>

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,3 +1,15 @@
+3.59v
+
+1. Option to automatically close the chats where visitor has abandoned them. In other words will close chats where pending widget row indicates that visitor has left the chat.
+2. Option to do prefill offline message form. Usefull if bot redirects to offline form and you do not want that message area would be prefilled by previous covnersation.
+3. Update chat -> Transfer to operator has now option to transfer chat to operator and ignore department online hours.
+4. Internal failing of visitor sending messages will be logged in audit log. Usefull if you experiencing high load and want to investigate why it's happening.
+5. Transactions will be used on remarks saving.
+6. saveThis method was not respecting passed arguments to indicate what columns should be updated.
+7. Department load statistic modal window.
+
+execute doc/update_db/update_232.sql for update
+
 3.58v
 
 1. You can change TOS field text value directly in theme. E.g Our terms of service [url=http://livehelperchat.com]Live Helper Chat[/url]

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -8477,6 +8477,13 @@
         "hidden": "0"
       },
       {
+        "identifier": "autoclose_abandon_pending",
+        "value": "0,0",
+        "type": "0",
+        "explain": "Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>.",
+        "hidden": "0"
+      },
+      {
         "identifier": "autoclose_activity_timeout",
         "value": "0",
         "type": "0",

--- a/lhc_web/doc/update_db/update_232.sql
+++ b/lhc_web/doc/update_db/update_232.sql
@@ -1,0 +1,2 @@
+INSERT INTO `lh_chat_config` (`identifier`,`value`,`type`,`explain`,`hidden`) VALUES
+('autoclose_abandon_pending','0,0','0','Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>.','0');

--- a/lhc_web/lib/core/lhchat/lhchatworkflow.php
+++ b/lhc_web/lib/core/lhchat/lhchatworkflow.php
@@ -234,7 +234,7 @@ class erLhcoreClassChatWorkflow {
 
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -268,7 +268,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -305,7 +305,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -341,7 +341,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -377,7 +377,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -417,7 +417,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically by cron because of inactivity');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron because of inactivity!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 
@@ -461,7 +461,7 @@ class erLhcoreClassChatWorkflow {
                 $chat->status = erLhcoreClassModelChat::STATUS_CLOSED_CHAT;
 
                 $msg = new erLhcoreClassModelmsg();
-                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was automatically closed by cron because visitor left the pending chat!');
+                $msg->msg = erTranslationClassLhTranslation::getInstance()->getTranslation('chat/syncuser','Chat was closed by cron because visitor left the pending chat!');
                 $msg->chat_id = $chat->id;
                 $msg->user_id = -1;
 

--- a/lhc_web/lib/core/lhcore/lhupdate.php
+++ b/lhc_web/lib/core/lhcore/lhupdate.php
@@ -2,8 +2,8 @@
 
 class erLhcoreClassUpdate
 {
-	const DB_VERSION = 231;
-	const LHC_RELEASE = 358;
+	const DB_VERSION = 232;
+	const LHC_RELEASE = 359;
 
 	public static function doTablesUpdate($definition){
 		$updateInformation = self::getTablesStatus($definition);

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1449,6 +1449,7 @@ try {
                 ('disable_print','0',0,'Disable chat print', '0'),
                 ('hide_disabled_department','1',0,'Hide disabled department widget', '0'),
                 ('disable_send','0',0,'Disable chat transcript send', '0'),
+                ('autoclose_abandon_pending','0,0','0','Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>','0'),
                 ('ignore_user_status','0',0,'Ignore users online statuses and use departments online hours', '0'),
                 ('bbc_button_visible','1',0,'Show BB Code button', '0'),
                 ('password_data','','0','Password requirements','1'),


### PR DESCRIPTION
1. Option to automatically close the chats where visitor has abandoned them. In other words will close chats where pending widget row indicates that visitor has left the chat.
2. Option to do prefill offline message form. Usefull if bot redirects to offline form and you do not want that message area would be prefilled by previous covnersation.
3. Update chat -> Transfer to operator has now option to transfer chat to operator and ignore department online hours.
4. Internal failing of visitor sending messages will be logged in audit log. Usefull if you experiencing high load and want to investigate why it's happening.
5. Transactions will be used on remarks saving.
6. saveThis method was not respecting passed arguments to indicate what columns should be updated.
7. Department load statistic modal window.

execute doc/update_db/update_232.sql for update