### PR TITLE
3.65v

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1088,7 +1088,8 @@ class Install
         	   	  KEY `attr_int_2` (`attr_int_2`),
         	   	  KEY `attr_int_3` (`attr_int_3`),
         	   	  KEY `position_title_v2` (`position`, `title`(191)),
-        	   	  KEY `user_id` (`user_id`)
+        	   	  KEY `user_id` (`user_id`),
+        	   	  KEY `unique_id` (`unique_id`)
                 ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
             $db->query("CREATE TABLE IF NOT EXISTS `lh_chat_online_user_footprint` (

--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1081,6 +1081,7 @@ class Install
         	   	  `attr_int_1` int(11) NOT NULL,
         	   	  `attr_int_2` int(11) NOT NULL,
         	   	  `attr_int_3` int(11) NOT NULL,
+                  `unique_id` varchar(20) NOT NULL,
                   PRIMARY KEY (`id`),
         	   	  KEY `department_id` (`department_id`),
         	   	  KEY `attr_int_1` (`attr_int_1`),

--- a/lhc_web/design/defaulttheme/tpl/lhchat/cannedmsg.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/cannedmsg.tpl.php
@@ -5,7 +5,6 @@
 <table class="table table-sm" cellpadding="0" cellspacing="0">
 <thead>
 <tr>
-    <th width="1%">ID</th>
     <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Title/Message');?></th>
     <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Department');?></th>
     <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','User');?></th>
@@ -19,8 +18,7 @@
 </thead>
 <?php foreach ($items as $item) : ?>
     <tr>
-        <td><?php echo $item->id?></td>
-        <td><?php echo nl2br(htmlspecialchars($item->title != '' ? $item->title : $item->msg))?></td>
+        <td title="<?php echo htmlspecialchars($item->unique_id)?>"><?php echo nl2br(htmlspecialchars($item->title != '' ? $item->title : $item->msg))?></td>
         <td><?php if ($item->department !== false) : ?><?php echo htmlspecialchars($item->department)?><?php else : ?>-<?php endif;?></td>
         <td><?php echo htmlspecialchars($item->user)?></td>
         <td><?php echo $item->delay?></td>

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,3 +1,21 @@
+3.65v
+
+1. In master/master replication environment canned messages import did not worked correctly because we did id's comparison. We now will have unique_id field for that.
+2. Now you can move triggers between trigger groups.
+3. There is now Rest API for files upload.
+4. Bugfix - https://github.com/LiveHelperChat/livehelperchat/issues/1624
+5. Rest API call now has {{msg_items}} and {{msg_all_html}} replaceable variables. https://doc.livehelperchat.com/docs/bot/rest-api#replaceable-variables
+6. Percentages now are rendered at the top instead of the same line.
+7. Javascript argument for default department if more than one department is passed. Related section - https://doc.livehelperchat.com/docs/javascript-arguments/#how-to-change-default-department-from-parent-page
+8. Changing department in the widget will update it's fields now. You can have custom fields by department now.
+9. Bot now supports file upload handling https://doc.livehelperchat.com/docs/bot/collect-custom-attribute#file-expecting-trigger-example
+10. Rest API authentication method now supports NTLMauth. Thanks to https://github.com/ProsWeb
+11. `addmsgadmin` now will support also system messages. https://api.livehelperchat.com/#/chat/post_restapi_addmsgadmin
+
+And various other small changes :)
+
+execute doc/update_db/update_238.sql for update
+
 3.64v
 
 1. Any form now can be integrated into a widget. https://doc.livehelperchat.com/docs/modules/forms/

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -3564,6 +3564,15 @@
         "collation": "utf8mb4_unicode_ci"
       },
       {
+        "field": "unique_id",
+        "type": "varchar(20)",
+        "null": "NO",
+        "key": "",
+        "default": null,
+        "extra": "",
+        "collation": "utf8mb4_unicode_ci"
+      },
+      {
         "field": "explain",
         "type": "varchar(250)",
         "null": "NO",
@@ -9554,6 +9563,7 @@
         "attr_int_1" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_1` (`attr_int_1`);",
         "attr_int_2" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_2` (`attr_int_2`);",
         "attr_int_3" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_3` (`attr_int_3`);",
+        "unique_id" : "ALTER TABLE `lh_canned_msg` ADD INDEX `unique_id` (`unique_id`);",
         "position_title_v2" : "ALTER TABLE `lh_canned_msg` ADD INDEX `position_title_v2` (`position`, `title`(191));"
       },
       "old" : ["position_title"]

--- a/lhc_web/doc/update_db/update_238.sql
+++ b/lhc_web/doc/update_db/update_238.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `lh_canned_msg` ADD `unique_id` varchar(20) NOT NULL, COMMENT='';
+UPDATE `lh_canned_msg` SET `unique_id` = `id`;
+ALTER TABLE `lh_canned_msg` ADD INDEX `unique_id` (`unique_id`);

--- a/lhc_web/lib/models/lhchat/erlhcoreclassmodelcannedmsg.php
+++ b/lhc_web/lib/models/lhchat/erlhcoreclassmodelcannedmsg.php
@@ -31,6 +31,7 @@ class erLhcoreClassModelCannedMsg
             'languages' => $this->languages,
             'additional_data' => $this->additional_data,
             'html_snippet' => $this->html_snippet,
+            'unique_id' => $this->unique_id,
         );
     }
 
@@ -329,36 +330,22 @@ class erLhcoreClassModelCannedMsg
     private $replaceData = array();
 
     public $id = null;
-
     public $msg = '';
-
     public $title = '';
-
     public $explain = '';
-
     public $languages = '';
-
     public $fallback_msg = '';
-
     public $additional_data = '';
-
     public $html_snippet = '';
-
     public $position = 0;
-
     public $delay = 0;
-
     public $department_id = 0;
-
     public $user_id = 0;
-
     public $auto_send = 0;
-
     public $attr_int_1 = 0;
-
     public $attr_int_2 = 0;
-
     public $attr_int_3 = 0;
+    public $unique_id = 0;
 }
 
 ?>

--- a/lhc_web/modules/lhcannedmsg/import.php
+++ b/lhc_web/modules/lhcannedmsg/import.php
@@ -56,8 +56,8 @@ if (isset($_POST['UploadFileAction'])) {
 
             foreach ($data as $item) {
 
-                if (is_numeric($item['id'])) {
-                    $cannedMessage = erLhcoreClassModelCannedMsg::fetch($item['id']);
+                if (!empty($item['unique_id'])) {
+                    $cannedMessage = erLhcoreClassModelCannedMsg::findOne(array('filter' => array('unique_id' => $item['unique_id'])));
                 }
 
                 if (!($cannedMessage instanceof erLhcoreClassModelCannedMsg)) {

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1245,13 +1245,15 @@ try {
         	   	  `attr_int_1` int(11) NOT NULL,
         	   	  `attr_int_2` int(11) NOT NULL,
         	   	  `attr_int_3` int(11) NOT NULL,
+        	   	  `unique_id` varchar(20) NOT NULL,
                   PRIMARY KEY (`id`),
         	   	  KEY `department_id` (`department_id`),
         	   	  KEY `attr_int_1` (`attr_int_1`),
         	   	  KEY `attr_int_2` (`attr_int_2`),
         	   	  KEY `attr_int_3` (`attr_int_3`),
         	   	  KEY `position_title_v2` (`position`, `title`(191)),
-        	   	  KEY `user_id` (`user_id`)
+        	   	  KEY `user_id` (`user_id`),
+        	   	  KEY `unique_id` (`unique_id`)
                 ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
                     $db->query("CREATE TABLE IF NOT EXISTS `lh_chat_online_user_footprint` (

--- a/lhc_web/pos/lhabstract/erlhabstractmodeladmintheme.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodeladmintheme.php
@@ -9,51 +9,18 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['name'] = new ezcPersistentObjectProperty();
-$def->properties['name']->columnName   = 'name';
-$def->properties['name']->propertyName = 'name';
-$def->properties['name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['name','header_content','header_css','static_content','static_js_content','static_css_content','css_attributes'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-// Header custom html
-$def->properties['header_content'] = new ezcPersistentObjectProperty();
-$def->properties['header_content']->columnName   = 'header_content';
-$def->properties['header_content']->propertyName = 'header_content';
-$def->properties['header_content']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// Custom header CSS entered manually, usefull during testing
-$def->properties['header_css'] = new ezcPersistentObjectProperty();
-$def->properties['header_css']->columnName   = 'header_css';
-$def->properties['header_css']->propertyName = 'header_css';
-$def->properties['header_css']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// Images fonts etc, static content
-$def->properties['static_content'] = new ezcPersistentObjectProperty();
-$def->properties['static_content']->columnName   = 'static_content';
-$def->properties['static_content']->propertyName = 'static_content';
-$def->properties['static_content']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// JS
-$def->properties['static_js_content'] = new ezcPersistentObjectProperty();
-$def->properties['static_js_content']->columnName   = 'static_js_content';
-$def->properties['static_js_content']->propertyName = 'static_js_content';
-$def->properties['static_js_content']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// CSS
-$def->properties['static_css_content'] = new ezcPersistentObjectProperty();
-$def->properties['static_css_content']->columnName   = 'static_css_content';
-$def->properties['static_css_content']->propertyName = 'static_css_content';
-$def->properties['static_css_content']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// Main CSS attributes
-$def->properties['css_attributes'] = new ezcPersistentObjectProperty();
-$def->properties['css_attributes']->columnName   = 'css_attributes';
-$def->properties['css_attributes']->propertyName = 'css_attributes';
-$def->properties['css_attributes']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// User ID
-$def->properties['user_id'] = new ezcPersistentObjectProperty();
-$def->properties['user_id']->columnName   = 'user_id';
-$def->properties['user_id']->propertyName = 'user_id';
-$def->properties['user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['user_id'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;

--- a/lhc_web/pos/lhabstract/erlhabstractmodelautoresponderchat.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelautoresponderchat.php
@@ -9,30 +9,12 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['auto_responder_id'] = new ezcPersistentObjectProperty();
-$def->properties['auto_responder_id']->columnName   = 'auto_responder_id';
-$def->properties['auto_responder_id']->propertyName = 'auto_responder_id';
-$def->properties['auto_responder_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['wait_timeout_send'] = new ezcPersistentObjectProperty();
-$def->properties['wait_timeout_send']->columnName   = 'wait_timeout_send';
-$def->properties['wait_timeout_send']->propertyName = 'wait_timeout_send';
-$def->properties['wait_timeout_send']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['pending_send_status'] = new ezcPersistentObjectProperty();
-$def->properties['pending_send_status']->columnName   = 'pending_send_status';
-$def->properties['pending_send_status']->propertyName = 'pending_send_status';
-$def->properties['pending_send_status']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['active_send_status'] = new ezcPersistentObjectProperty();
-$def->properties['active_send_status']->columnName   = 'active_send_status';
-$def->properties['active_send_status']->propertyName = 'active_send_status';
-$def->properties['active_send_status']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['chat_id','auto_responder_id','wait_timeout_send','pending_send_status','active_send_status'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhabstract/erlhabstractmodelchatvariable.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelchatvariable.php
@@ -9,47 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['dep_id'] = new ezcPersistentObjectProperty();
-$def->properties['dep_id']->columnName   = 'dep_id';
-$def->properties['dep_id']->propertyName = 'dep_id';
-$def->properties['dep_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['js_variable','var_name','var_identifier','change_message'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-$def->properties['js_variable'] = new ezcPersistentObjectProperty();
-$def->properties['js_variable']->columnName   = 'js_variable';
-$def->properties['js_variable']->propertyName = 'js_variable';
-$def->properties['js_variable']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['var_name'] = new ezcPersistentObjectProperty();
-$def->properties['var_name']->columnName   = 'var_name';
-$def->properties['var_name']->propertyName = 'var_name';
-$def->properties['var_name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['var_identifier'] = new ezcPersistentObjectProperty();
-$def->properties['var_identifier']->columnName   = 'var_identifier';
-$def->properties['var_identifier']->propertyName = 'var_identifier';
-$def->properties['var_identifier']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['type'] = new ezcPersistentObjectProperty();
-$def->properties['type']->columnName   = 'type';
-$def->properties['type']->propertyName = 'type';
-$def->properties['type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['persistent'] = new ezcPersistentObjectProperty();
-$def->properties['persistent']->columnName   = 'persistent';
-$def->properties['persistent']->propertyName = 'persistent';
-$def->properties['persistent']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Log message on chat variable change
-$def->properties['change_message'] = new ezcPersistentObjectProperty();
-$def->properties['change_message']->columnName   = 'change_message';
-$def->properties['change_message']->propertyName = 'change_message';
-$def->properties['change_message']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// Log message on chat variable change
-$def->properties['inv'] = new ezcPersistentObjectProperty();
-$def->properties['inv']->columnName   = 'inv';
-$def->properties['inv']->propertyName = 'inv';
-$def->properties['inv']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['dep_id','type','persistent','inv'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelcannedmsg.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelcannedmsg.php
@@ -9,103 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-/**
- * Explain for canned messages
- * */
-$def->properties['title'] = new ezcPersistentObjectProperty();
-$def->properties['title']->columnName   = 'title';
-$def->properties['title']->propertyName = 'title';
-$def->properties['title']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['title','unique_id','explain','msg','html_snippet','fallback_msg','languages','additional_data'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-/**
- * Unique ID, we use it during import
- */
-$def->properties['unique_id'] = new ezcPersistentObjectProperty();
-$def->properties['unique_id']->columnName   = 'unique_id';
-$def->properties['unique_id']->propertyName = 'unique_id';
-$def->properties['unique_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-/**
- * Can be used as explain for extensions
- * */
-$def->properties['explain'] = new ezcPersistentObjectProperty();
-$def->properties['explain']->columnName   = 'explain';
-$def->properties['explain']->propertyName = 'explain';
-$def->properties['explain']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-/**
- * Main message text
- * */
-$def->properties['msg'] = new ezcPersistentObjectProperty();
-$def->properties['msg']->columnName   = 'msg';
-$def->properties['msg']->propertyName = 'msg';
-$def->properties['msg']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-/**
- * Main message text
- * */
-$def->properties['html_snippet'] = new ezcPersistentObjectProperty();
-$def->properties['html_snippet']->columnName   = 'html_snippet';
-$def->properties['html_snippet']->propertyName = 'html_snippet';
-$def->properties['html_snippet']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-/**
- * If some of the main message replacable variables is not found this one is used
- * */
-$def->properties['fallback_msg'] = new ezcPersistentObjectProperty();
-$def->properties['fallback_msg']->columnName   = 'fallback_msg';
-$def->properties['fallback_msg']->propertyName = 'fallback_msg';
-$def->properties['fallback_msg']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['position'] = new ezcPersistentObjectProperty();
-$def->properties['position']->columnName   = 'position';
-$def->properties['position']->propertyName = 'position';
-$def->properties['position']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['delay'] = new ezcPersistentObjectProperty();
-$def->properties['delay']->columnName   = 'delay';
-$def->properties['delay']->propertyName = 'delay';
-$def->properties['delay']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['department_id'] = new ezcPersistentObjectProperty();
-$def->properties['department_id']->columnName   = 'department_id';
-$def->properties['department_id']->propertyName = 'department_id';
-$def->properties['department_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['user_id'] = new ezcPersistentObjectProperty();
-$def->properties['user_id']->columnName   = 'user_id';
-$def->properties['user_id']->propertyName = 'user_id';
-$def->properties['user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['auto_send'] = new ezcPersistentObjectProperty();
-$def->properties['auto_send']->columnName   = 'auto_send';
-$def->properties['auto_send']->propertyName = 'auto_send';
-$def->properties['auto_send']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['attr_int_1'] = new ezcPersistentObjectProperty();
-$def->properties['attr_int_1']->columnName   = 'attr_int_1';
-$def->properties['attr_int_1']->propertyName = 'attr_int_1';
-$def->properties['attr_int_1']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['attr_int_2'] = new ezcPersistentObjectProperty();
-$def->properties['attr_int_2']->columnName   = 'attr_int_2';
-$def->properties['attr_int_2']->propertyName = 'attr_int_2';
-$def->properties['attr_int_2']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['attr_int_3'] = new ezcPersistentObjectProperty();
-$def->properties['attr_int_3']->columnName   = 'attr_int_3';
-$def->properties['attr_int_3']->propertyName = 'attr_int_3';
-$def->properties['attr_int_3']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['languages'] = new ezcPersistentObjectProperty();
-$def->properties['languages']->columnName   = 'languages';
-$def->properties['languages']->propertyName = 'languages';
-$def->properties['languages']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['additional_data'] = new ezcPersistentObjectProperty();
-$def->properties['additional_data']->columnName   = 'additional_data';
-$def->properties['additional_data']->propertyName = 'additional_data';
-$def->properties['additional_data']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['position','delay','department_id','user_id','auto_send','attr_int_1','attr_int_2','attr_int_3'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelcannedmsg.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelcannedmsg.php
@@ -18,6 +18,14 @@ $def->properties['title']->propertyName = 'title';
 $def->properties['title']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
 
 /**
+ * Unique ID, we use it during import
+ */
+$def->properties['unique_id'] = new ezcPersistentObjectProperty();
+$def->properties['unique_id']->columnName   = 'unique_id';
+$def->properties['unique_id']->propertyName = 'unique_id';
+$def->properties['unique_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+
+/**
  * Can be used as explain for extensions
  * */
 $def->properties['explain'] = new ezcPersistentObjectProperty();

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelchatfile.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelchatfile.php
@@ -9,63 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['name'] = new ezcPersistentObjectProperty();
-$def->properties['name']->columnName   = 'name';
-$def->properties['name']->propertyName = 'name';
-$def->properties['name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['name','upload_name','type','file_path','extension'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-$def->properties['upload_name'] = new ezcPersistentObjectProperty();
-$def->properties['upload_name']->columnName   = 'upload_name';
-$def->properties['upload_name']->propertyName = 'upload_name';
-$def->properties['upload_name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['size'] = new ezcPersistentObjectProperty();
-$def->properties['size']->columnName   = 'size';
-$def->properties['size']->propertyName = 'size';
-$def->properties['size']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-/**
- * We can associate file either with chat either with online user id
- * */
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['online_user_id'] = new ezcPersistentObjectProperty();
-$def->properties['online_user_id']->columnName   = 'online_user_id';
-$def->properties['online_user_id']->propertyName = 'online_user_id';
-$def->properties['online_user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['user_id'] = new ezcPersistentObjectProperty();
-$def->properties['user_id']->columnName   = 'user_id';
-$def->properties['user_id']->propertyName = 'user_id';
-$def->properties['user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['date'] = new ezcPersistentObjectProperty();
-$def->properties['date']->columnName   = 'date';
-$def->properties['date']->propertyName = 'date';
-$def->properties['date']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['type'] = new ezcPersistentObjectProperty();
-$def->properties['type']->columnName   = 'type';
-$def->properties['type']->propertyName = 'type';
-$def->properties['type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['file_path'] = new ezcPersistentObjectProperty();
-$def->properties['file_path']->columnName   = 'file_path';
-$def->properties['file_path']->propertyName = 'file_path';
-$def->properties['file_path']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['extension'] = new ezcPersistentObjectProperty();
-$def->properties['extension']->columnName   = 'extension';
-$def->properties['extension']->propertyName = 'extension';
-$def->properties['extension']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['persistent'] = new ezcPersistentObjectProperty();
-$def->properties['persistent']->columnName   = 'persistent';
-$def->properties['persistent']->propertyName = 'persistent';
-$def->properties['persistent']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['size','chat_id','online_user_id','user_id','date','persistent'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelchatonlineuserfootprint.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelchatonlineuserfootprint.php
@@ -9,25 +9,17 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['online_user_id'] = new ezcPersistentObjectProperty();
-$def->properties['online_user_id']->columnName   = 'online_user_id';
-$def->properties['online_user_id']->propertyName = 'online_user_id';
-$def->properties['online_user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
 $def->properties['page'] = new ezcPersistentObjectProperty();
 $def->properties['page']->columnName   = 'page';
 $def->properties['page']->propertyName = 'page';
 $def->properties['page']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
 
-$def->properties['vtime'] = new ezcPersistentObjectProperty();
-$def->properties['vtime']->columnName   = 'vtime';
-$def->properties['vtime']->propertyName = 'vtime';
-$def->properties['vtime']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['chat_id','online_user_id','vtime'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelgroupchat.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelgroupchat.php
@@ -9,67 +9,20 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['name'] = new ezcPersistentObjectProperty();
-$def->properties['name']->columnName   = 'name';
-$def->properties['name']->propertyName = 'name';
-$def->properties['name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['name','last_msg'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-/**
- * Main chat status
- * */
-$def->properties['status'] = new ezcPersistentObjectProperty();
-$def->properties['status']->columnName   = 'status';
-$def->properties['status']->propertyName = 'status';
-$def->properties['status']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['status','time','user_id','last_msg_op_id','last_user_msg_time','last_msg_id','type','chat_id','tm'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
-$def->properties['time'] = new ezcPersistentObjectProperty();
-$def->properties['time']->columnName   = 'time';
-$def->properties['time']->propertyName = 'time';
-$def->properties['time']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-/**
- * Operator who created a group
-**/
-$def->properties['user_id'] = new ezcPersistentObjectProperty();
-$def->properties['user_id']->columnName   = 'user_id';
-$def->properties['user_id']->propertyName = 'user_id';
-$def->properties['user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['last_msg'] = new ezcPersistentObjectProperty();
-$def->properties['last_msg']->columnName   = 'last_msg';
-$def->properties['last_msg']->propertyName = 'last_msg';
-$def->properties['last_msg']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['last_msg_op_id'] = new ezcPersistentObjectProperty();
-$def->properties['last_msg_op_id']->columnName   = 'last_msg_op_id';
-$def->properties['last_msg_op_id']->propertyName = 'last_msg_op_id';
-$def->properties['last_msg_op_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['last_user_msg_time'] = new ezcPersistentObjectProperty();
-$def->properties['last_user_msg_time']->columnName   = 'last_user_msg_time';
-$def->properties['last_user_msg_time']->propertyName = 'last_user_msg_time';
-$def->properties['last_user_msg_time']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['last_msg_id'] = new ezcPersistentObjectProperty();
-$def->properties['last_msg_id']->columnName   = 'last_msg_id';
-$def->properties['last_msg_id']->propertyName = 'last_msg_id';
-$def->properties['last_msg_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['type'] = new ezcPersistentObjectProperty();
-$def->properties['type']->columnName   = 'type';
-$def->properties['type']->propertyName = 'type';
-$def->properties['type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Total members
-$def->properties['tm'] = new ezcPersistentObjectProperty();
-$def->properties['tm']->columnName   = 'tm';
-$def->properties['tm']->propertyName = 'tm';
-$def->properties['tm']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
 
 return $def;
 

--- a/lhc_web/pos/lhchat/erlhcoreclassmodelmsg.php
+++ b/lhc_web/pos/lhchat/erlhcoreclassmodelmsg.php
@@ -9,36 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['msg'] = new ezcPersistentObjectProperty();
-$def->properties['msg']->columnName   = 'msg';
-$def->properties['msg']->propertyName = 'msg';
-$def->properties['msg']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['msg','meta_msg','name_support'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-// Meta data for message
-$def->properties['meta_msg'] = new ezcPersistentObjectProperty();
-$def->properties['meta_msg']->columnName   = 'meta_msg';
-$def->properties['meta_msg']->propertyName = 'meta_msg';
-$def->properties['meta_msg']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['name_support'] = new ezcPersistentObjectProperty();
-$def->properties['name_support']->columnName   = 'name_support';
-$def->properties['name_support']->propertyName = 'name_support';
-$def->properties['name_support']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['time'] = new ezcPersistentObjectProperty();
-$def->properties['time']->columnName   = 'time';
-$def->properties['time']->propertyName = 'time';
-$def->properties['time']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['user_id'] = new ezcPersistentObjectProperty();
-$def->properties['user_id']->columnName   = 'user_id';
-$def->properties['user_id']->propertyName = 'user_id';
-$def->properties['user_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['time','user_id','chat_id'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhgenericbot/erlhcoreclassmodelgenericbottrigger.php
+++ b/lhc_web/pos/lhgenericbot/erlhcoreclassmodelgenericbottrigger.php
@@ -9,45 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['name'] = new ezcPersistentObjectProperty();
-$def->properties['name']->columnName   = 'name';
-$def->properties['name']->propertyName = 'name';
-$def->properties['name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['name','actions'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-$def->properties['group_id'] = new ezcPersistentObjectProperty();
-$def->properties['group_id']->columnName   = 'group_id';
-$def->properties['group_id']->propertyName = 'group_id';
-$def->properties['group_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['bot_id'] = new ezcPersistentObjectProperty();
-$def->properties['bot_id']->columnName   = 'bot_id';
-$def->properties['bot_id']->propertyName = 'bot_id';
-$def->properties['bot_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['actions'] = new ezcPersistentObjectProperty();
-$def->properties['actions']->columnName   = 'actions';
-$def->properties['actions']->propertyName = 'actions';
-$def->properties['actions']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['default'] = new ezcPersistentObjectProperty();
-$def->properties['default']->columnName   = 'default';
-$def->properties['default']->propertyName = 'default';
-$def->properties['default']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['default_unknown'] = new ezcPersistentObjectProperty();
-$def->properties['default_unknown']->columnName   = 'default_unknown';
-$def->properties['default_unknown']->propertyName = 'default_unknown';
-$def->properties['default_unknown']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['default_always'] = new ezcPersistentObjectProperty();
-$def->properties['default_always']->columnName   = 'default_always';
-$def->properties['default_always']->propertyName = 'default_always';
-$def->properties['default_always']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['default_unknown_btn'] = new ezcPersistentObjectProperty();
-$def->properties['default_unknown_btn']->columnName   = 'default_unknown_btn';
-$def->properties['default_unknown_btn']->propertyName = 'default_unknown_btn';
-$def->properties['default_unknown_btn']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['group_id','bot_id','default','default_unknown','default_always','default_unknown_btn'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 

--- a/lhc_web/pos/lhgenericbot/erlhcoreclassmodelgenericbottriggerevent.php
+++ b/lhc_web/pos/lhgenericbot/erlhcoreclassmodelgenericbottriggerevent.php
@@ -9,50 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['trigger_id'] = new ezcPersistentObjectProperty();
-$def->properties['trigger_id']->columnName   = 'trigger_id';
-$def->properties['trigger_id']->propertyName = 'trigger_id';
-$def->properties['trigger_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['pattern','pattern_exc','configuration'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
 
-$def->properties['bot_id'] = new ezcPersistentObjectProperty();
-$def->properties['bot_id']->columnName   = 'bot_id';
-$def->properties['bot_id']->propertyName = 'bot_id';
-$def->properties['bot_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['pattern'] = new ezcPersistentObjectProperty();
-$def->properties['pattern']->columnName   = 'pattern';
-$def->properties['pattern']->propertyName = 'pattern';
-$def->properties['pattern']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['pattern_exc'] = new ezcPersistentObjectProperty();
-$def->properties['pattern_exc']->columnName   = 'pattern_exc';
-$def->properties['pattern_exc']->propertyName = 'pattern_exc';
-$def->properties['pattern_exc']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-$def->properties['configuration'] = new ezcPersistentObjectProperty();
-$def->properties['configuration']->columnName   = 'configuration';
-$def->properties['configuration']->propertyName = 'configuration';
-$def->properties['configuration']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
-
-// Trigger event type 0 - text, 1 - click
-$def->properties['type'] = new ezcPersistentObjectProperty();
-$def->properties['type']->columnName   = 'type';
-$def->properties['type']->propertyName = 'type';
-$def->properties['type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Do not check on chat start
-// Instant (Executes and continues workflow)
-// Instant block (Executes and blocks workflow)
-// Schedule (Just schedules for futher execution)
-$def->properties['on_start_type'] = new ezcPersistentObjectProperty();
-$def->properties['on_start_type']->columnName   = 'on_start_type';
-$def->properties['on_start_type']->propertyName = 'on_start_type';
-$def->properties['on_start_type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['priority'] = new ezcPersistentObjectProperty();
-$def->properties['priority']->columnName   = 'priority';
-$def->properties['priority']->propertyName = 'priority';
-$def->properties['priority']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['trigger_id','bot_id','type','on_start_type','priority'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
 return $def;
 


### PR DESCRIPTION
1. In master/master replication environment canned messages import did not worked correctly because we did id's comparison. We now will have unique_id field for that.
2. Now you can move triggers between trigger groups.
3. There is now Rest API for files upload.
4. Bugfix - https://github.com/LiveHelperChat/livehelperchat/issues/1624
5. Rest API call now has {{msg_items}} and {{msg_all_html}} replaceable variables. https://doc.livehelperchat.com/docs/bot/rest-api#replaceable-variables
6. Percentages now are rendered at the top instead of the same line.
7. Javascript argument for default department if more than one department is passed. Related section - https://doc.livehelperchat.com/docs/javascript-arguments/#how-to-change-default-department-from-parent-page
8. Changing department in the widget will update it's fields now. You can have custom fields by department now.
9. Bot now supports file upload handling https://doc.livehelperchat.com/docs/bot/collect-custom-attribute#file-expecting-trigger-example
10. Rest API authentication method now supports NTLMauth. Thanks to https://github.com/ProsWeb
11. `addmsgadmin` now will support also system messages. https://api.livehelperchat.com/#/chat/post_restapi_addmsgadmin