### PR TITLE
3.66

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1578,7 +1578,7 @@ class Install
                   KEY `dep_group_id` (`dep_group_id`)
                 ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
-            $db->query("CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(20) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+            $db->query("CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(50) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
             $db->query("CREATE TABLE `lh_departament_group` (
                       `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/form.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/form.tpl.php
@@ -8,12 +8,12 @@
     <div role="tabpanel" class="tab-pane active" id="general">
         <div class="form-group">
             <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','Name');?></label>
-            <input type="text" class="form-control" name="name"  value="<?php echo htmlspecialchars($item->name);?>" />
+            <input maxlength="20" type="text" class="form-control" name="name"  value="<?php echo htmlspecialchars($item->name);?>" />
         </div>
 
         <div class="form-group">
             <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','Nick, what should be operator nick. E.g Support Bot');?></label>
-            <input type="text" class="form-control" name="nick"  value="<?php echo htmlspecialchars($item->nick);?>" />
+            <input maxlength="250" type="text" class="form-control" name="nick"  value="<?php echo htmlspecialchars($item->nick);?>" />
         </div>
 
         <div class="row">

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/import.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/import.tpl.php
@@ -13,7 +13,7 @@
 
     <div class="form-group">
         <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','File')?> (json)</label>
-        <input type="file" name="botfile" value="" />
+        <input type="file" accept=".json" name="botfile" value="" />
     </div>
 
     <input type="submit" name="ImportBot" class="btn btn-secondary" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','Import')?>" />

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
@@ -1,4 +1,9 @@
+
 <h1><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/list','Rest API Calls')?></h1>
+
+<?php if (isset($imported_rest)) : $msg = erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','Rest API imported'); ?>
+    <?php include(erLhcoreClassDesign::designtpl('lhkernel/alert_success.tpl.php'));?>
+<?php endif; ?>
 
 <?php if (isset($items)) : ?>
 
@@ -13,6 +18,7 @@
         <?php foreach ($items as $item) : ?>
             <tr>
                 <td>
+                    <a title="Download" href="?id=<?php echo $item->id?>"><i class="material-icons">cloud_download</i></a>
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
@@ -29,4 +35,16 @@
 
 <?php endif; ?>
 
-<a class="btn btn-secondary" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/newrestapi')?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/list','New')?></a>
+<form action="" method="post" class="form-inline" autocomplete="off" enctype="multipart/form-data">
+    <div class="form-group mr-2">
+        <a class="btn btn-secondary btn-sm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/newrestapi')?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/list','New')?></a>
+    </div>
+
+    <?php include(erLhcoreClassDesign::designtpl('lhkernel/csfr_token.tpl.php'));?>
+    <div class="form-group">
+        <input title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','File')?> (json)" accept=".json" type="file" class="form-control-file" name="restfile" value="" />
+    </div>
+    <input type="submit" name="ImportRestAPI" class="btn btn-secondary btn-sm" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','Import')?>" />
+</form>
+
+

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
@@ -18,7 +18,7 @@
         <?php foreach ($items as $item) : ?>
             <tr>
                 <td>
-                    <a title="Download" href="?id=<?php echo $item->id?>"><i class="material-icons">cloud_download</i></a>
+                    <a title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/list','Download')?>" href="?id=<?php echo $item->id?>"><i class="material-icons">cloud_download</i></a>
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,3 +1,12 @@
+3.66v
+
+1. Now you can also import/export Rest API configuration.
+2. `Collect information` response type `Ask user to confirm information by checking checkbox` was not working.
+3. `Check for conditions to proceed` response type now can check is there any operator online or not https://doc.livehelperchat.com/docs/bot/check-conditions/
+4. Canned messages import changed the workflow so master-master replication won't break it.
+
+execute doc/update_db/update_239.sql for update
+
 3.65v
 
 1. In master/master replication environment canned messages import did not worked correctly because we did id's comparison. We now will have unique_id field for that.

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -4,6 +4,7 @@
 2. `Collect information` response type `Ask user to confirm information by checking checkbox` was not working.
 3. `Check for conditions to proceed` response type now can check is there any operator online or not https://doc.livehelperchat.com/docs/bot/check-conditions/
 4. Canned messages import changed the workflow so master-master replication won't break it.
+5. Rest API name length changed from 20 to 50 characters
 
 execute doc/update_db/update_239.sql for update
 

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -5262,6 +5262,15 @@
         "key": "PRI",
         "default": null,
         "extra": "auto_increment"
+      },
+      {
+        "field": "name",
+        "type": "varchar(50)",
+        "null": "NO",
+        "key": "MUL",
+        "default": null,
+        "extra": "",
+        "collation": "utf8mb4_unicode_ci"
       }
     ],
     "lh_abstract_chat_column": [
@@ -9715,7 +9724,7 @@
     "lh_abstract_proactive_chat_campaign_conv": "CREATE TABLE `lh_abstract_proactive_chat_campaign_conv` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `device_type` tinyint(1) NOT NULL, `invitation_type` tinyint(1) NOT NULL,`invitation_status` tinyint(1) NOT NULL,`chat_id` bigint(20) NOT NULL, `campaign_id` int(11) NOT NULL,`invitation_id` int(11) NOT NULL,`department_id` int(11) NOT NULL,`ctime` int(11) NOT NULL,`con_time` int(11) NOT NULL, `vid_id` bigint(20) DEFAULT NULL, PRIMARY KEY (`id`), KEY `campaign_id` (`campaign_id`), KEY `invitation_id` (`invitation_id`), KEY `invitation_status` (`invitation_status`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_audits": "CREATE TABLE `lh_audits` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `category` varchar(255) NOT NULL, `file` varchar(255), `object_id` bigint(20) DEFAULT '0', `line` bigint(20), `message` longtext NOT NULL, `severity` varchar(255) NOT NULL, `source` varchar(255) NOT NULL, `time` timestamp NOT NULL, KEY `object_id` (`object_id`), KEY `source` (`source`(191)), KEY `category` (`category`(191))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_generic_bot_repeat_restrict": "CREATE TABLE `lh_generic_bot_repeat_restrict` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `chat_id` bigint(20) NOT NULL, `trigger_id` bigint(20), `counter` int(11) DEFAULT '0', KEY `chat_id_trigger_id` (`chat_id`,`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_rest_api": "CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(20) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+    "lh_generic_bot_rest_api": "CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(50) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_group_chat": "CREATE TABLE `lh_group_chat` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  `status` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, `time` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `last_msg_op_id` bigint(20) NOT NULL,\n  `last_msg` varchar(200) NOT NULL,\n  `last_user_msg_time` int(11) NOT NULL,  `last_msg_id` bigint(20) NOT NULL,  `type` tinyint(1) NOT NULL DEFAULT 0,  `tm` int(11) NOT NULL,  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`), KEY `chat_id` (`chat_id`),\n  KEY `type` (`type`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_group_msg": "CREATE TABLE `lh_group_msg` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `time` int(11) NOT NULL,\n  `chat_id` int(11) NOT NULL DEFAULT 0,\n  `user_id` int(11) NOT NULL DEFAULT 0,\n  `name_support` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `meta_msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_group_chat_member": "CREATE TABLE `lh_group_chat_member` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` bigint(20) NOT NULL, `type` tinyint(1) NOT NULL DEFAULT '0',\n  `group_id` bigint(20) NOT NULL, `last_msg_id` bigint(20) NOT NULL DEFAULT '0', `last_activity` int(11) NOT NULL,\n  `jtime` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`group_id`), KEY `user_id` (`user_id`), KEY `type` (`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",

--- a/lhc_web/doc/update_db/update_239.sql
+++ b/lhc_web/doc/update_db/update_239.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lh_generic_bot_rest_api` CHANGE `name` `name` varchar(50) NOT NULL;

--- a/lhc_web/lib/core/lhcore/lhupdate.php
+++ b/lhc_web/lib/core/lhcore/lhupdate.php
@@ -2,8 +2,8 @@
 
 class erLhcoreClassUpdate
 {
-	const DB_VERSION = 238;
-	const LHC_RELEASE = 365;
+	const DB_VERSION = 239;
+	const LHC_RELEASE = 366;
 
 	public static function doTablesUpdate($definition){
 		$updateInformation = self::getTablesStatus($definition);

--- a/lhc_web/modules/lhgenericbot/listrestapi.php
+++ b/lhc_web/modules/lhgenericbot/listrestapi.php
@@ -10,6 +10,49 @@ if (isset($_GET['doSearch'])) {
     $filterParams['is_search'] = false;
 }
 
+// Export
+if (isset($_GET['id']) && is_numeric($_GET['id'])) {
+    $restAPI = erLhcoreClassModelGenericBotRestAPI::fetch($_GET['id']);
+    $exportData = $restAPI->getState();
+    unset($exportData['id']);
+    header('Content-Disposition: attachment; filename="rest-api-'.$restAPI->id.'.json"');
+    header('Content-Type: application/json');
+    echo json_encode($exportData);
+    exit;
+}
+
+// Import
+if (ezcInputForm::hasPostData()) {
+
+    if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
+        erLhcoreClassModule::redirect('genericbot/listrestapi');
+        exit;
+    }
+
+    if (erLhcoreClassSearchHandler::isFile('restfile',array('json'))) {
+        $dir = 'var/tmpfiles/';
+        erLhcoreClassChatEventDispatcher::getInstance()->dispatch('theme.temppath',array('dir' => & $dir));
+
+        erLhcoreClassFileUpload::mkdirRecursive( $dir );
+
+        $filename = erLhcoreClassSearchHandler::moveUploadedFile('restfile',$dir);
+        $content = file_get_contents($dir . $filename);
+        unlink($dir . $filename);
+        $data = json_decode($content,true);
+
+        if ($data !== null) {
+            $restAPI = new erLhcoreClassModelGenericBotRestAPI();
+            $restAPI->name = substr(erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/import','Copy of') . ' ' .$data['name'],0,50);
+            $restAPI->description = $data['description'];
+            $restAPI->configuration = $data['configuration'];
+            $restAPI->saveThis();
+            $tpl->set('imported_rest',true);
+        }
+    }
+}
+
+
+
 erLhcoreClassChatStatistic::formatUserFilter($filterParams);
 
 $append = erLhcoreClassSearchHandler::getURLAppendFromInput($filterParams['input_form']);

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1742,7 +1742,7 @@ try {
                   KEY `dep_group_id` (`dep_group_id`)
                 ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
-                    $db->query("CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(20) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+                    $db->query("CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(50) NOT NULL, `description` varchar(250), `configuration` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
                     $db->query("CREATE TABLE `lh_departament_group` (
                       `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
1. Now you can also import/export Rest API configuration.
2. `Collect information` response type `Ask user to confirm information by checking checkbox` was not working.
3. `Check for conditions to proceed` response type now can check is there any operator online or not https://doc.livehelperchat.com/docs/bot/check-conditions/
4. Canned messages import changed the workflow so master-master replication won't break it.
5. Rest API name length changed from 20 to 50 characters