### PR TITLE
3.69v

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -570,6 +570,7 @@ class Install
                   `question_plain_3_req` int(11) NOT NULL,
                   `question_plain_4_req` int(11) NOT NULL,
                   `question_plain_5_req` int(11) NOT NULL,
+                  `configuration` longtext NOT NULL,
                   PRIMARY KEY (`id`)
         	   ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
 

--- a/lhc_web/design/defaulttheme/tpl/lhabstract/custom/survey.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhabstract/custom/survey.tpl.php
@@ -20,6 +20,14 @@
 <?php echo erLhcoreClassAbstract::renderInput('feedback_text', $fields['feedback_text'], $object)?>
 </div>
 
+<div class="form-group">
+    <label><?php echo $fields['disable_chat_preview']['trans'];?></label>
+    <?php echo erLhcoreClassAbstract::renderInput('disable_chat_preview', $fields['disable_chat_preview'], $object)?>
+</div>
+
+<hr>
+
+
 <?php include(erLhcoreClassDesign::designtpl('lhsurvey/forms/fields_names.tpl.php'));?>
 
 <?php 

--- a/lhc_web/design/defaulttheme/tpl/lhsurvey/fillwidget.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsurvey/fillwidget.tpl.php
@@ -14,7 +14,10 @@
                 <?php if ($survey_item->is_filled == false) : ?>
                     <input type="submit" class="btn btn-success btn-sm" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Submit')?>" name="Vote" />
                 <?php endif;?>
+
+                <?php if (!(isset($survey->configuration_array['disable_chat_preview']) && $survey->configuration_array['disable_chat_preview'] == true)) : ?>
                 <button type="button" class="btn btn-info btn-sm" onclick="return lhc.revealModal({'url':WWW_DIR_JAVASCRIPT+'chat/chatpreview/<?php echo $chat->id?>/<?php echo $chat->hash?>'})"><i class="material-icons">chat</i> <?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('survey/fill','Preview chat')?></button>
+                <?php endif; ?>
             </div>
             
             <?php if ($survey_item->is_filled == true && !in_array($chat->status_sub, array(erLhcoreClassModelChat::STATUS_SUB_SURVEY_SHOW, erLhcoreClassModelChat::STATUS_SUB_SURVEY_COLLECTED))) : ?>

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,15 +1,26 @@
+3.69v
+
+1. Survey control from a bot - https://doc.livehelperchat.com/docs/bot/survey-control-from-bot
+2. Scroll to the bottom UI for the operator and widget
+3. Another option to close widget from website itself. Gracefully https://doc.livehelperchat.com/docs/javascript-arguments/#to-end-the-chat
+4. Do not not close widget if automatic start chat is checked in widget themes.
+5. Rest API file updated to support PUT, DELETE methods.
+6. Custom post survey support - https://doc.livehelperchat.com/docs/integrating/custom-post-survey/
+
+execute doc/update_db/update_242.sql for update
+
 3.68v
 
 1. Support fully https://github.com/open-wa/wa-automate-nodejs integration.
 2. In widget themes you can set that chat remained in widget once was opened in a popup.
 
-execute doc/update_db/update_240.sql for update
+execute doc/update_db/update_241.sql for update
 
 3.67v
 
 1. Incoming webhooks support. You can integrate easily any third party API providers.
 
-execute doc/update_db/update_239.sql for update
+execute doc/update_db/update_240.sql for update
 
 3.66v
 

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -470,6 +470,15 @@
         "collation": "utf8mb4_unicode_ci"
       },
       {
+        "field": "configuration",
+        "type": "longtext",
+        "null": "NO",
+        "key": "",
+        "default": null,
+        "extra": "",
+        "collation": "utf8mb4_unicode_ci"
+      },
+      {
         "field": "max_stars_1_title",
         "type": "varchar(250)",
         "null": "NO",

--- a/lhc_web/doc/update_db/update_242.sql
+++ b/lhc_web/doc/update_db/update_242.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lh_abstract_survey` ADD `configuration` longtext NOT NULL, COMMENT='';

--- a/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelsurvey.php
+++ b/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelsurvey.php
@@ -17,6 +17,16 @@ return array(
         'validation_definition' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
         )),
+    'disable_chat_preview' => array(
+        'type' => 'checkbox',
+        'main_attr' => 'configuration_array',
+        'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Disable chat preview'),
+        'required' => false,
+        'hidden' => true,
+        'nginit' => true,
+        'validation_definition' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+        )),
     'max_stars_1' => array(
         'type' => 'text',
         'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/survey','Max stars for feedback'),

--- a/lhc_web/lib/core/lhcore/lhupdate.php
+++ b/lhc_web/lib/core/lhcore/lhupdate.php
@@ -2,8 +2,8 @@
 
 class erLhcoreClassUpdate
 {
-	const DB_VERSION = 241;
-	const LHC_RELEASE = 368;
+	const DB_VERSION = 242;
+	const LHC_RELEASE = 369;
 
 	public static function doTablesUpdate($definition){
 		$updateInformation = self::getTablesStatus($definition);

--- a/lhc_web/lib/models/lhabstract/erlhabstractmodelsurvey.php
+++ b/lhc_web/lib/models/lhabstract/erlhabstractmodelsurvey.php
@@ -110,7 +110,8 @@ class erLhAbstractModelSurvey {
 			'question_plain_5_enabled' => $this->question_plain_5_enabled,
 			'question_plain_5_req'     => $this->question_plain_5_req,
 		    
-			'feedback_text'            => $this->feedback_text
+			'feedback_text'            => $this->feedback_text,
+			'configuration'            => $this->configuration
 		);
 
 		return $stateArray;
@@ -144,7 +145,22 @@ class erLhAbstractModelSurvey {
 	   	       $this->left_menu = '';
 	   		   return $this->left_menu;
 	   		break;
-	   		
+
+       case 'configuration_array':
+           $attr = str_replace('_array','',$var);
+           if (!empty($this->{$attr})) {
+               $jsonData = json_decode($this->{$attr},true);
+               if ($jsonData !== null) {
+                   $this->{$var} = $jsonData;
+               } else {
+                   $this->{$var} = array();
+               }
+           } else {
+               $this->{$var} = array();
+           }
+           return $this->{$var};
+           break;
+
 	   	case 'question_options_1_items_front':
 	   	case 'question_options_2_items_front':
 	   	case 'question_options_3_items_front':
@@ -224,7 +240,17 @@ class erLhAbstractModelSurvey {
 	public function customForm() {
 	    return 'survey.tpl.php';
 	}
-	
+
+    public function beforeUpdate()
+    {
+        $this->configuration = json_encode($this->configuration_array);
+    }
+
+    public function beforeSave()
+    {
+        $this->configuration = json_encode($this->configuration_array);
+    }
+
    	public $id = null;
 	public $name = '';
 	
@@ -313,7 +339,8 @@ class erLhAbstractModelSurvey {
 	public $question_plain_5_req = 0;
 	
 	public $feedback_text = '';
-	
+	public $configuration = '';
+
 	public $hide_add = false;
 	public $hide_delete = false;
 

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -705,6 +705,7 @@ try {
                   `question_plain_3_req` int(11) NOT NULL,
                   `question_plain_4_req` int(11) NOT NULL,
                   `question_plain_5_req` int(11) NOT NULL,
+                  `configuration` longtext NOT NULL,
                   PRIMARY KEY (`id`)
         	   ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
 

--- a/lhc_web/pos/lhabstract/erlhabstractmodelsurvey.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelsurvey.php
@@ -19,6 +19,11 @@ $def->properties['feedback_text']->columnName   = 'feedback_text';
 $def->properties['feedback_text']->propertyName = 'feedback_text';
 $def->properties['feedback_text']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
 
+$def->properties['configuration'] = new ezcPersistentObjectProperty();
+$def->properties['configuration']->columnName   = 'configuration';
+$def->properties['configuration']->propertyName = 'configuration';
+$def->properties['configuration']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+
 for ($i = 1; $i <= 5; $i++) {
     // Stars
     $def->properties['max_stars_'.$i] = new ezcPersistentObjectProperty();


### PR DESCRIPTION
1. Survey control from a bot - https://doc.livehelperchat.com/docs/bot/survey-control-from-bot
2. Scroll to the bottom UI for the operator and widget
3. Another option to close widget from website itself. Gracefully https://doc.livehelperchat.com/docs/javascript-arguments/#to-end-the-chat
4. Do not not close widget if automatic start chat is checked in widget themes.
5. Rest API file updated to support PUT, DELETE methods.
6. Custom post survey support - https://doc.livehelperchat.com/docs/integrating/custom-post-survey/