### PR TITLE
Remember visitor status on chat close event

### DIFF
--- a/lhc_web/lib/models/lhchat/erlhcoreclassmodelchat.php
+++ b/lhc_web/lib/models/lhchat/erlhcoreclassmodelchat.php
@@ -563,7 +563,11 @@ class erLhcoreClassModelChat {
                     $timeout = 240;
                 }
 
-       	        $this->user_status_front =  (time() - $timeout > $this->lsync || in_array($this->status_sub,array(erLhcoreClassModelChat::STATUS_SUB_SURVEY_COMPLETED, erLhcoreClassModelChat::STATUS_SUB_SURVEY_SHOW,erLhcoreClassModelChat::STATUS_SUB_USER_CLOSED_CHAT,erLhcoreClassModelChat::STATUS_SUB_CONTACT_FORM))) ? 1 : 0;
+       	        if ($this->status == self::STATUS_CLOSED_CHAT) {
+                    $this->user_status_front = ($this->cls_time - $timeout > $this->lsync || $this->cls_time > $this->user_closed_ts) ? 1 : 0;
+                } else {
+                    $this->user_status_front = (time() - $timeout > $this->lsync || in_array($this->status_sub,array(erLhcoreClassModelChat::STATUS_SUB_SURVEY_COMPLETED, erLhcoreClassModelChat::STATUS_SUB_SURVEY_SHOW, erLhcoreClassModelChat::STATUS_SUB_USER_CLOSED_CHAT, erLhcoreClassModelChat::STATUS_SUB_CONTACT_FORM))) ? 1 : 0;
+                }
 
        	    } elseif ($this->online_user !== false) {
        		    $this->user_status_front = erLhcoreClassChat::setActivityByChatAndOnlineUser($this, $this->online_user);

--- a/lhc_web/modules/lhchat/chatwidgetclosed.php
+++ b/lhc_web/modules/lhchat/chatwidgetclosed.php
@@ -76,7 +76,10 @@ if ($Params['user_parameters_unordered']['hash'] != '') {
             // User closed chat
             $chat->user_status = erLhcoreClassModelChat::USER_STATUS_CLOSED_CHAT;
             $chat->support_informed = 1;
-            $chat->user_closed_ts = time();
+
+            if ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT || !in_array($chat->status_sub,array(erLhcoreClassModelChat::STATUS_SUB_SURVEY_COMPLETED, erLhcoreClassModelChat::STATUS_SUB_SURVEY_SHOW, erLhcoreClassModelChat::STATUS_SUB_USER_CLOSED_CHAT, erLhcoreClassModelChat::STATUS_SUB_CONTACT_FORM))) {
+                $chat->user_closed_ts = time();
+            }
 
             if ($chat->user_typing < (time() - 12)) {
                 $chat->user_typing = time() - 5;// Show for shorter period these status messages

--- a/lhc_web/modules/lhchat/syncuser.php
+++ b/lhc_web/modules/lhchat/syncuser.php
@@ -218,8 +218,12 @@ if (is_object($chat) && $chat->hash == $Params['user_parameters']['hash'])
 		    	$saveChat = true;
 		    }
 		    
-		    if ($saveChat === true || $chat->lsync < time()-30) {
-		        $chat->lsync = time();
+		    if ($saveChat === true || ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT && $chat->lsync < time()-30)) {
+
+                if ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT) {
+                    $chat->lsync = time();
+                }
+
 		    	$chat->updateThis(array('update' => array(
 		    	    'unanswered_chat',
 		    	    'has_unread_op_messages',

--- a/lhc_web/modules/lhchat/userclosechat.php
+++ b/lhc_web/modules/lhchat/userclosechat.php
@@ -20,7 +20,11 @@ if (is_object($chat) && $chat->hash == $Params['user_parameters']['hash'])
 		    $chat->support_informed = 1;
 		    $chat->user_typing = time()-5;// Show for shorter period these status messages
 		    $chat->is_user_typing = 1;
-		    $chat->user_closed_ts = time();
+
+            if ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT || !in_array($chat->status_sub,array(erLhcoreClassModelChat::STATUS_SUB_SURVEY_COMPLETED, erLhcoreClassModelChat::STATUS_SUB_SURVEY_SHOW, erLhcoreClassModelChat::STATUS_SUB_USER_CLOSED_CHAT, erLhcoreClassModelChat::STATUS_SUB_CONTACT_FORM))) {
+                $chat->user_closed_ts = time();
+            }
+
 		    $chat->user_typing_txt = htmlspecialchars_decode(erTranslationClassLhTranslation::getInstance()->getTranslation('chat/userleftchat','Visitor has left the chat!'),ENT_QUOTES);
 
 		    $explicitClosed = false;

--- a/lhc_web/modules/lhwidgetrestapi/fetchmessages.php
+++ b/lhc_web/modules/lhwidgetrestapi/fetchmessages.php
@@ -188,8 +188,12 @@ if (is_object($chat) && $chat->hash == $requestPayload['hash'])
 		    	$saveChat = true;
 		    }
 
-		    if ($saveChat === true || $chat->lsync < time()-30) {
-		        $chat->lsync = time();
+		    if ($saveChat === true || ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT && $chat->lsync < time()-30)) {
+
+                if ($chat->status != erLhcoreClassModelChat::STATUS_CLOSED_CHAT) {
+                    $chat->lsync = time();
+                }
+
 		    	$chat->updateThis(array('update' => array(
 		    	    'lsync',
                     'unanswered_chat',


### PR DESCRIPTION
This is required in order to show correct visitor status on closed chats. Managers this way will see what was vistor status on chat close event.