### PR TITLE
Subject additional attributes

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1646,7 +1646,15 @@ class Install
 
             $db->query("CREATE TABLE `lh_canned_msg_tag_link` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag_id` int(11) NOT NULL,  `canned_id` int(11) NOT NULL,  PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`), KEY `tag_id` (`tag_id`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
             $db->query("CREATE TABLE `lh_canned_msg_tag` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag` varchar(40) NOT NULL, PRIMARY KEY (`id`), KEY `tag` (`tag`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
-            $db->query("CREATE TABLE `lh_abstract_subject` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+            $db->query("CREATE TABLE `lh_abstract_subject` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `internal` tinyint(1) NOT NULL DEFAULT 0,
+  `internal_type` varchar(10) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `internal` (`internal`),
+  KEY `internal_type` (`internal_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
             $db->query("CREATE TABLE `lh_abstract_subject_dep` ( `id` int(11) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `subject_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `subject_id` (`subject_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
             $db->query("CREATE TABLE `lh_abstract_subject_chat` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `subject_id` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
             $db->query("CREATE TABLE `lh_group_object` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `object_id` bigint(20) NOT NULL, `group_id` bigint(20) NOT NULL, `type` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `object_id_type` (`object_id`,`type`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");

--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1650,7 +1650,7 @@ class Install
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
   `internal` tinyint(1) NOT NULL DEFAULT 0,
-  `internal_type` varchar(10) NOT NULL DEFAULT '',
+  `internal_type` varchar(20) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `internal` (`internal`),
   KEY `internal_type` (`internal_type`)

--- a/lhc_web/design/defaulttheme/tpl/lhabstract/custom/subject.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhabstract/custom/subject.tpl.php
@@ -10,11 +10,22 @@
 </div>
 
 <div class="form-group">
-    <label><?php echo $fields['dep_id']['trans'];?></label>
+    <label class="mb-0"><?php echo erLhcoreClassAbstract::renderInput('internal', $fields['internal'], $object)?>&nbsp;<?php echo $fields['internal']['trans'];?></label>
+    <p><small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/subject','Internal subjects will not be shown in a subject choosing modal window for the operators. They are good for setting them in the bot, extensions etc.');?></i></small></p>
+</div>
+
+<div class="form-group">
+    <label class="mb-0"><?php echo $fields['dep_id']['trans'];?></label>
     <p><small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/subject','If you do not choose any department, subject will be visible for all departments');?></i></small></p>
     <div class="row">
         <?php echo erLhcoreClassAbstract::renderInput('dep_id', $fields['dep_id'], $object)?>
     </div>
+</div>
+
+<div class="form-group">
+    <label><?php echo $fields['internal_type']['trans'];?></label>
+    <?php echo erLhcoreClassAbstract::renderInput('internal_type', $fields['internal_type'], $object)?>
+    <p><small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/subject','This is usefull if you need additional filtering for your own purposes. Leave it empty in most cases.');?></i></small></p>
 </div>
 
 <div class="btn-group" role="group" aria-label="...">

--- a/lhc_web/design/defaulttheme/tpl/lhchat/subject.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/subject.tpl.php
@@ -7,6 +7,7 @@
     <?php
         $subjects = erLhAbstractModelSubjectDepartment::getList(array(
                 'customfilter' => array('(dep_id = ' . (int)$chat->dep_id . ' OR dep_id = 0)'),
+                'filter'  => ['`lh_abstract_subject`.`internal`' => 0],
                 'sort' => '`lh_abstract_subject`.`name` ASC',
                 'leftjoin' => array('lh_abstract_subject' => array('`lh_abstract_subject`.`id`','`lh_abstract_subject_dep`.`subject_id`'))
         ));
@@ -18,7 +19,7 @@
     ?>
     <div class="row">
     <?php foreach($subjects as $subject) : ?>
-        <div class="col-3"><label><input type="checkbox" onchange="lhinst.setSubject($(this),<?php echo $chat->id?>)" name="subject" value="<?php echo $subject->subject_id?>" <?php if (in_array($subject->subject_id,$selectedSubjects)) : ?>checked="checked"<?php endif?> ><?php echo htmlspecialchars($subject)?></label></div>
+        <div class="col-3"><label><input type="checkbox" onchange="lhinst.setSubject($(this),<?php echo $chat->id?>)" name="subject" value="<?php echo $subject->subject_id?>" <?php if (in_array($subject->subject_id,$selectedSubjects)) : ?>checked="checked"<?php endif?> >&nbsp;<?php echo htmlspecialchars($subject)?></label></div>
     <?php endforeach; ?>
     </div>
 

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,3 +1,21 @@
+3.91v
+
+1. Survey API. See a swagger survey section.
+2. Fix tricky case if manager is monitoring a chat and chat being transferred to him, chat was not auto accepted. It will be now.
+3. Mobile app now supports android notifications categories.
+4. Further 8.1 PHP support improvements.
+5. System tab will be remembered now on refresh.
+6. If proactive invitation is used with bot append option we should not show next time invitation once a visitor closes it.
+7. SVG Cleanup on upload for security reasons.
+8. Operators statistic directly in online operators widget.
+9. Department statistic link directly in pending/active chats widget.
+10. CSRF token for logout link.
+11. We now have zoom image option directly in the chat widget.
+12. Pre chat conditions.
+
+execute doc/update_db/update_263.sql for update
+
+
 3.90v
 
 Widget theme table columns type changes. On some MySQL servers it was returning that row size to big.

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -1413,6 +1413,22 @@
         "key": "",
         "default": null,
         "extra": ""
+      },
+      {
+        "field": "internal",
+        "type": "tinyint(1)",
+        "null": "NO",
+        "key": "",
+        "default": "0",
+        "extra": ""
+      },
+      {
+        "field": "internal_type",
+        "type": "varchar(20)",
+        "null": "NO",
+        "key": "",
+        "default": "",
+        "extra": ""
       }
     ],
     "lh_abstract_subject_dep": [
@@ -9861,6 +9877,13 @@
       },
       "old" : []
     },
+    "lh_abstract_subject" : {
+      "new" : {
+        "internal" : "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal` (`internal`);",
+        "internal_type" : "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal_type` (`internal_type`);"
+      },
+      "old" : []
+    },
     "lh_departament" : {
       "new" : {
         "alias" : "ALTER TABLE `lh_departament` ADD INDEX `alias` (`alias`);",
@@ -10030,7 +10053,7 @@
     "lh_abstract_proactive_chat_invitation_event": "CREATE TABLE `lh_abstract_proactive_chat_invitation_event` ( `id` int(11) NOT NULL AUTO_INCREMENT, `invitation_id` int(11) NOT NULL, `event_id` int(11) NOT NULL, `min_number` int(11) NOT NULL, `during_seconds` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `invitation_id` (`invitation_id`), KEY `event_id` (`event_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
     "lh_chat_start_settings": "CREATE TABLE `lh_chat_start_settings` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
     "lh_chat_event_track": "CREATE TABLE `lh_chat_event_track` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_subject": "CREATE TABLE `lh_abstract_subject` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+    "lh_abstract_subject": "CREATE TABLE `lh_abstract_subject` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `internal` tinyint(1) NOT NULL DEFAULT 0, `internal_type` varchar(20) NOT NULL DEFAULT '', PRIMARY KEY (`id`), KEY `internal` (`internal`), KEY `internal_type` (`internal_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_abstract_chat_variable": "CREATE TABLE `lh_abstract_chat_variable` ( `id` int(11) NOT NULL AUTO_INCREMENT, `var_name` varchar(255) NOT NULL, `var_identifier` varchar(255) NOT NULL, `inv` tinyint(1) NOT NULL, `change_message` varchar(250) NOT NULL, `type` tinyint(1) NOT NULL, `persistent` tinyint(1) NOT NULL,`js_variable` varchar(255) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_abstract_chat_column": "CREATE TABLE `lh_abstract_chat_column` (`id` int(11) NOT NULL AUTO_INCREMENT,`column_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,`variable` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL, `position` int(11) NOT NULL, `enabled` tinyint(1) NOT NULL, `online_enabled` tinyint(1) NOT NULL, `chat_enabled` tinyint(1) NOT NULL, `conditions` text COLLATE utf8mb4_unicode_ci NOT NULL,`column_icon` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL, `column_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`), KEY `enabled` (`enabled`), KEY `online_enabled` (`online_enabled`), KEY `chat_enabled` (`chat_enabled`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
     "lh_abstract_chat_priority": "CREATE TABLE `lh_abstract_chat_priority` (`id` int(11) NOT NULL AUTO_INCREMENT,`value` text COLLATE utf8mb4_unicode_ci NOT NULL,`dep_id` int(11) NOT NULL,`priority` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",

--- a/lhc_web/doc/update_db/update_263.sql
+++ b/lhc_web/doc/update_db/update_263.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `lh_abstract_subject` ADD `internal` tinyint(1) NOT NULL DEFAULT '0', COMMENT='';
+ALTER TABLE `lh_abstract_subject` ADD `internal_type` varchar(20) NOT NULL, COMMENT='';
+ALTER TABLE `lh_abstract_subject` ADD INDEX `internal` (`internal`);
+ALTER TABLE `lh_abstract_subject` ADD INDEX `internal_type` (`internal_type`);

--- a/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelsubject.php
+++ b/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelsubject.php
@@ -19,6 +19,22 @@ return array(
         'validation_definition' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
         )),
+    'internal' => array(
+        'type' => 'checkbox',
+        'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/chatsubject','Internal'),
+        'required' => false,
+        'validation_definition' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'boolean'
+        )),
+    'internal_type' => array(
+        'type' => 'text',
+        'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/chatsubject','Internal type'),
+        'required' => false,
+        'hidden' => true,
+        'placeholder' => 'custom_string',
+        'validation_definition' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+        )),
     'dep_id' => array(
         'type' => 'checkbox_multi',
         'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/proactivechatinvitation', 'Department'),

--- a/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelwidgettheme.php
+++ b/lhc_web/lib/core/lhabstract/fields/erlhabstractmodelwidgettheme.php
@@ -12,6 +12,7 @@ $fields = array(
    						'type' => 'text',
    						'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Alias for argument. No spaces or slashes.'),
    						'required' => false,
+                    'hidden' => true,
    						'validation_definition' => new ezcInputFormDefinitionElement(
    								ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
    						)),
@@ -26,6 +27,7 @@ $fields = array(
    						'type' => 'text',
                         'main_attr_lang' => 'bot_configuration_array',
                         'translatable' => true,
+                        'hidden' => true,
    						'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Chat status if customer is chatting with a bot'),
                         'placeholder' => erTranslationClassLhTranslation::getInstance()->getTranslation('chat/checkchatstatus','Chat status if customer is chatting with a bot'),
    						'required' => false,
@@ -34,6 +36,7 @@ $fields = array(
    						)),
                     'icons_order' => array(
    						'type' => 'text',
+                        'hidden' => true,
                         'main_attr' => 'bot_configuration_array',
    						'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Header icons order. _print is optional and indicates we should also print a text after an icon'),
                         'placeholder' => 'left_close<_print>,right_min,right_popup',
@@ -210,6 +213,7 @@ $fields = array(
    						'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Online status text [old widget]'),
    						'required' => false,
    						'nginit' => true,
+                    'hidden' => true,
    						'validation_definition' => new ezcInputFormDefinitionElement(
    								ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
    						)),
@@ -217,6 +221,7 @@ $fields = array(
    						'type' => 'text',
    						'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/widgettheme','Offline status text [old widget]'),
    						'required' => false,
+                        'hidden' => true,
    						'nginit' => true,
    						'validation_definition' => new ezcInputFormDefinitionElement(
    								ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'

--- a/lhc_web/lib/core/lhcore/lhupdate.php
+++ b/lhc_web/lib/core/lhcore/lhupdate.php
@@ -2,8 +2,8 @@
 
 class erLhcoreClassUpdate
 {
-	const DB_VERSION = 262;
-	const LHC_RELEASE = 390;
+	const DB_VERSION = 263;
+	const LHC_RELEASE = 391;
 
 	public static function doTablesUpdate($definition){
 		$updateInformation = self::getTablesStatus($definition);

--- a/lhc_web/lib/models/lhabstract/erlhabstractmodelsubject.php
+++ b/lhc_web/lib/models/lhabstract/erlhabstractmodelsubject.php
@@ -16,7 +16,9 @@ class erLhAbstractModelSubject {
     {
         $stateArray = array(
             'id' => $this->id,
-            'name' => $this->name
+            'name' => $this->name,
+            'internal' => $this->internal,
+            'internal_type' => $this->internal_type
         );
 
         return $stateArray;
@@ -141,7 +143,8 @@ class erLhAbstractModelSubject {
 
     }
 
-
     public $id = null;
     public $name = '';
+    public $internal_type = '';
+    public $internal = 0;
 }

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1797,7 +1797,17 @@ try {
 
                     $db->query("CREATE TABLE `lh_canned_msg_tag_link` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag_id` int(11) NOT NULL,  `canned_id` int(11) NOT NULL,  PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`), KEY `tag_id` (`tag_id`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
                     $db->query("CREATE TABLE `lh_canned_msg_tag` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag` varchar(40) NOT NULL, PRIMARY KEY (`id`), KEY `tag` (`tag`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
-                    $db->query("CREATE TABLE `lh_abstract_subject` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+
+                    $db->query("CREATE TABLE `lh_abstract_subject` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `internal` tinyint(1) NOT NULL DEFAULT 0,
+  `internal_type` varchar(20) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `internal` (`internal`),
+  KEY `internal_type` (`internal_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+
                     $db->query("CREATE TABLE `lh_abstract_subject_dep` ( `id` int(11) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `subject_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `subject_id` (`subject_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
                     $db->query("CREATE TABLE `lh_abstract_subject_chat` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `subject_id` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
                     $db->query("CREATE TABLE `lh_group_object` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `object_id` bigint(20) NOT NULL, `group_id` bigint(20) NOT NULL, `type` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `object_id_type` (`object_id`,`type`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");

--- a/lhc_web/pos/lhabstract/erlhabstractmodelsubject.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelsubject.php
@@ -9,10 +9,20 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['name'] = new ezcPersistentObjectProperty();
-$def->properties['name']->columnName   = 'name';
-$def->properties['name']->propertyName = 'name';
-$def->properties['name']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+foreach (['internal_type','name'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
+}
+
+foreach (['internal'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
+
 
 return $def;
 


### PR DESCRIPTION
3.91v

1. Survey API. See a swagger survey section.
2. Fix tricky case if manager is monitoring a chat and chat being transferred to him, chat was not auto accepted. It will be now.
3. Mobile app now supports android notifications categories.
4. Further 8.1 PHP support improvements.
5. System tab will be remembered now on refresh.
6. If proactive invitation is used with bot append option we should not show next time invitation once a visitor closes it.
7. SVG Cleanup on upload for security reasons.
8. Operators statistic directly in online operators widget.
9. Department statistic link directly in pending/active chats widget.
10. CSRF token for logout link.
11. We now have zoom image option directly in the chat widget.
12. Pre chat conditions.

execute doc/update_db/update_263.sql for update