### PR TITLE
4.13v

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1192,11 +1192,12 @@ class Install
 				  `ctime` int(11) NOT NULL,
 				  `con_time` int(11) NOT NULL,
 				  `vid_id` bigint(20) DEFAULT NULL,
+				  `variation_id` int(11) NOT NULL DEFAULT '0',
 				  PRIMARY KEY (`id`),
 				  KEY `ctime` (`ctime`),
 				  KEY `campaign_id` (`campaign_id`),
-				  KEY `invitation_id` (`invitation_id`),
-				  KEY `invitation_status` (`invitation_status`)
+				  KEY `invitation_status` (`invitation_status`),
+				  KEY `invitation_id_variation_id` (`invitation_id`, `variation_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
 
@@ -1492,6 +1493,7 @@ class Install
         	   	  `requires_email` int(11) NOT NULL,
         	   	  `iddle_for` int(11) NOT NULL,
         	   	  `event_type` int(11) NOT NULL,
+                  `parent_id` int(11) NOT NULL DEFAULT '0',
         	   	  `requires_username` int(11) NOT NULL,
         	   	  `requires_phone` int(11) NOT NULL,        	   	  
         	   	  `design_data` longtext NOT NULL,        	   	  
@@ -1500,8 +1502,9 @@ class Install
         	      KEY `identifier` (`identifier`),
         	      KEY `dynamic_invitation` (`dynamic_invitation`),
         	      KEY `tag` (`tag`),
-        	      KEY `dep_id` (`dep_id`),
-        	      KEY `show_on_mobile` (`show_on_mobile`)
+        	      KEY `parent_id` (`parent_id`),
+        	      KEY `show_on_mobile` (`show_on_mobile`),
+        	      KEY `dep_id` (`dep_id`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
             $db->query("CREATE TABLE IF NOT EXISTS `lh_chat_accept` (

--- a/lhc_web/design/defaulttheme/tpl/lhabstract/custom/events/invitation.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhabstract/custom/events/invitation.tpl.php
@@ -1,7 +1,32 @@
-<div class="form-group">		
-<label><?php echo $fields['name']['trans'];?></label>
-<?php echo erLhcoreClassAbstract::renderInput('name', $fields['name'], $object)?>
+<div class="row">
+    <div class="col-6">
+        <div class="form-group">
+            <label><?php echo $fields['name']['trans'];?></label>
+            <?php echo erLhcoreClassAbstract::renderInput('name', $fields['name'], $object)?>
+        </div>
+    </div>
+    <div class="col-6">
+        <label><?php echo $fields['parent_id']['trans'];?></label>
+        <?php echo erLhcoreClassRenderHelper::renderMultiDropdown( array (
+            'input_name'     => 'AbstractInput_parent_id',
+            'optional_field' => erTranslationClassLhTranslation::getInstance()->getTranslation('module/mailconvmb', 'Choose a parent invitation'),
+            'selected_id'    => [$object->parent_id],
+            'data_prop'      => 'data-limit="1"',
+            'css_class'      => 'form-control',
+            'type'           => 'radio',
+            'display_name'   => 'name',
+            'no_selector'    => true,
+            'list_function_params' => ($object->id > 0 ? array('limit' => false,'filternot' => ['id' => $object->id]) : ['limit' => false]),
+            'list_function'  => 'erLhAbstractModelProactiveChatInvitation::getList',
+        )); ?>
+    </div>
+    <script>
+        $(function() {
+            $('.btn-block-department').makeDropdown();
+        });
+    </script>
 </div>
+
 
 <div class="form-group">
 <label><?php echo erLhcoreClassAbstract::renderInput('disabled', $fields['disabled'], $object)?> <?php echo $fields['disabled']['trans'];?></label>

--- a/lhc_web/design/defaulttheme/tpl/lhabstract/custom/events/invitation.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhabstract/custom/events/invitation.tpl.php
@@ -6,7 +6,8 @@
         </div>
     </div>
     <div class="col-6">
-        <label><?php echo $fields['parent_id']['trans'];?></label>
+        <label><?php echo $fields['parent_id']['trans'];?><a href="#" onclick="lhc.revealModal({'url':WWW_DIR_JAVASCRIPT+'genericbot/help/parentinvitation'});" class="material-icons text-muted">help</a>
+        </label>
         <?php echo erLhcoreClassRenderHelper::renderMultiDropdown( array (
             'input_name'     => 'AbstractInput_parent_id',
             'optional_field' => erTranslationClassLhTranslation::getInstance()->getTranslation('module/mailconvmb', 'Choose a parent invitation'),

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/help.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/help.tpl.php
@@ -16,6 +16,10 @@
            <?php include(erLhcoreClassDesign::designtpl('lhgenericbot/helpattributes/dropdownoptions.tpl.php'));?>
            <?php include(erLhcoreClassDesign::designtpl('lhgenericbot/helpattributes/customonclick.tpl.php'));?>
 
+            <?php if (preg_match('/^[a-z0-9-]+/i', $context) &&($pathDynamic = erLhcoreClassDesign::designtpldynamic('lhgenericbot/helpattributes/' . $context . '.tpl.php')) && $pathDynamic !== null ) : ?>
+                <?php include $pathDynamic;?>
+            <?php endif; ?>
+
             <?php if ($context == 'text') : ?>
                 <ul>
                     <li>{<translation>__default message__t[show from hour, show till hour]} inclusive is first hour. Few examples

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/helpattributes/parentinvitation.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/helpattributes/parentinvitation.tpl.php
@@ -1,0 +1,5 @@
+<ul>
+    <li>Once you define a parent invitation. Present invitation is considered as child invitation.</li>
+    <li>Only main display attributes are taken as variation.</li>
+    <li>Parent invitation statistic window will show child invitation performance.</li>
+</ul>

--- a/lhc_web/design/defaulttheme/tpl/lhstatistic/campaignmodal.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhstatistic/campaignmodal.tpl.php
@@ -1,7 +1,7 @@
 <?php
 $modalHeaderClass = 'pt-1 pb-1 pl-2 pr-2';
 $modalHeaderTitle = htmlspecialchars($invitation->name);
-$modalSize = 'md';
+$modalSize = 'xl';
 ?>
 
 <?php include(erLhcoreClassDesign::designtpl('lhkernel/modal_header.tpl.php'));?>
@@ -15,6 +15,9 @@ $modalSize = 'md';
         <tr>
             <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Parameter');?></th>
             <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Value');?></th>
+            <?php foreach (erLhAbstractModelProactiveChatInvitation::getList(['filter' => ['parent_id' => $invitation->id]]) as $childInvitation) : $statsChild[$childInvitation->id] = erLhcoreClassChatStatistic::getProactiveStatistic(array('filter' => array('filter' => array('invitation_id' => $invitation->id, 'variation_id' => $childInvitation->id))))?>
+                <th><span class="material-icons">insert_invitation</span><?php echo htmlspecialchars($childInvitation->name);?></th>
+            <?php endforeach; ?>
             <th><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Explanation');?></th>
         </tr>
     </thead>
@@ -25,6 +28,11 @@ $modalSize = 'md';
         <td>
             <?php echo $stats['INV_SEND'];?>
         </td>
+        <?php foreach (erLhAbstractModelProactiveChatInvitation::getList(['filter' => ['parent_id' => $invitation->id]]) as $childInvitation) : ?>
+        <td>
+            <?php echo $statsChild[$childInvitation->id]['INV_SEND'];?>
+        </td>
+        <?php endforeach; ?>
         <td>
             <small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Invitation was assigned to online visitor');?></i></small>
         </td>
@@ -36,6 +44,11 @@ $modalSize = 'md';
         <td>
             <?php echo $stats['INV_SHOWN'];?>
         </td>
+        <?php foreach (erLhAbstractModelProactiveChatInvitation::getList(['filter' => ['parent_id' => $invitation->id]]) as $childInvitation) : ?>
+        <td>
+            <?php echo $statsChild[$childInvitation->id]['INV_SHOWN'];?>
+        </td>
+        <?php endforeach; ?>
         <td>
             <small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','widget was opened with invitation content');?></i></small>
         </td>
@@ -47,6 +60,11 @@ $modalSize = 'md';
         <td>
             <?php echo $stats['INV_SEEN'];?>
         </td>
+        <?php foreach (erLhAbstractModelProactiveChatInvitation::getList(['filter' => ['parent_id' => $invitation->id]]) as $childInvitation) : ?>
+            <td>
+                <?php echo $statsChild[$childInvitation->id]['INV_SEEN'];?>
+            </td>
+        <?php endforeach; ?>
         <td>
             <small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Widget was shown but visitor closed it without starting a chat');?></i></small>
         </td>
@@ -58,6 +76,11 @@ $modalSize = 'md';
         <td>
             <?php echo $stats['INV_CHAT_STARTED'];?>
         </td>
+        <?php foreach (erLhAbstractModelProactiveChatInvitation::getList(['filter' => ['parent_id' => $invitation->id]]) as $childInvitation) : ?>
+            <td>
+                <?php echo $statsChild[$childInvitation->id]['INV_CHAT_STARTED'];?>
+            </td>
+        <?php endforeach; ?>
         <td>
             <small><i><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('statistic/campaign','Visitor started chat by online invitation');?></i></small>
         </td>

--- a/lhc_web/doc/CHANGELOG.txt
+++ b/lhc_web/doc/CHANGELOG.txt
@@ -1,3 +1,19 @@
+4.13v
+
+* Proactive invitations can have child invitation which works as A/B testing workflow.
+    * Once you define a parent invitation. Present invitation is considered as child invitation.
+    * Only main display attributes are taken as variation.
+    * Parent invitation statistic window will show child invitation performance.
+* Bot pause trigger. https://github.com/LiveHelperChat/livehelperchat/pull/1797
+* Proactive invitation have two new options
+    * Hide content on click - clicking it will close invitation without triggering widget open. E.g you have some sale running and want to share some code with users.
+    * Custom on click event - in combination with above option can work as independent and just execute javascript on click.
+* Users/Groups/Roles list/edit windows UX improvements. Sorts by module etc.
+* Modifying department group will update it stats also now.
+* Export CSV for survey option.
+
+execute doc/update_db/update_285.sql for update
+
 4.12v
 
 * Start chat form settings can be assigned to more than one department.

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -1393,6 +1393,14 @@
         "key": "PRI",
         "default": null,
         "extra": "auto_increment"
+      },
+      {
+        "field": "variation_id",
+        "type": "int(11)",
+        "null": "NO",
+        "key": "",
+        "default": "0",
+        "extra": ""
       }
     ],
     "lh_incoming_webhook": [
@@ -2686,6 +2694,14 @@
         "null": "NO",
         "key": "MUL",
         "default": null,
+        "extra": ""
+      },
+      {
+        "field": "parent_id",
+        "type": "int(11)",
+        "null": "NO",
+        "key": "MUL",
+        "default": "0",
         "extra": ""
       },
       {

--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -10328,15 +10328,19 @@
       "new" : {
         "tag" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `tag` (`tag`);",
         "dynamic_invitation" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `dynamic_invitation` (`dynamic_invitation`);",
-        "show_on_mobile" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `show_on_mobile` (`show_on_mobile`)"
+        "show_on_mobile" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `show_on_mobile` (`show_on_mobile`)",
+        "parent_id" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `parent_id` (`parent_id`)"
       },
       "old" : []
     },
     "lh_abstract_proactive_chat_campaign_conv" : {
       "new" : {
-        "ctime" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `ctime` (`ctime`);"
+        "ctime" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `ctime` (`ctime`);",
+        "invitation_id_variation_id" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `invitation_id_variation_id` (`invitation_id`, `variation_id`);"
       },
-      "old" : []
+      "old" : [
+        "invitation_id"
+      ]
     },
     "lh_group_chat" : {
       "new" : {

--- a/lhc_web/doc/update_db/update_285.sql
+++ b/lhc_web/doc/update_db/update_285.sql
@@ -1,2 +1,6 @@
 ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD `parent_id` int(11) NOT NULL DEFAULT '0', COMMENT='';
+ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `parent_id` (`parent_id`);
+
 ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD `variation_id` int(11) NOT NULL DEFAULT '0', COMMENT='';
+ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` DROP INDEX `invitation_id`;
+ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `invitation_id_variation_id` (`invitation_id`, `variation_id`);

--- a/lhc_web/doc/update_db/update_285.sql
+++ b/lhc_web/doc/update_db/update_285.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD `parent_id` int(11) NOT NULL DEFAULT '0', COMMENT='';
+ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD `variation_id` int(11) NOT NULL DEFAULT '0', COMMENT='';

--- a/lhc_web/lib/core/lhabstract/fields/erlhabstractmodeleproactivechatinvitation.php
+++ b/lhc_web/lib/core/lhabstract/fields/erlhabstractmodeleproactivechatinvitation.php
@@ -230,6 +230,14 @@ $proactiveAttr = array(
         'params_call' => array_merge(['limit' => false, 'sort' => '`name` ASC'],$departmentFilterdefault),
         'validation_definition' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int')
     ),
+    'parent_id' => array(
+        'type' => 'text',
+        'default_value' => 0,
+        'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/proactivechatinvitation', 'Parent invitation'),
+        'required' => false,
+        'hidden' => true,
+        'validation_definition' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int')
+    ),
     'campaign_id' => array(
         'type' => 'combobox',
         'trans' => erTranslationClassLhTranslation::getInstance()->getTranslation('abstract/proactivechatinvitation', 'Campaign'),

--- a/lhc_web/lib/core/lhabstract/lhabstract.php
+++ b/lhc_web/lib/core/lhabstract/lhabstract.php
@@ -421,6 +421,8 @@ class erLhcoreClassAbstract
                     $object->$key = $form->{'AbstractInput_' . $key};
                 }
 
+            } elseif (!$form->hasValidData('AbstractInput_' . $key) && ($field['type'] == 'combobox' || $field['type'] == 'text' || $field['type'] == 'number') && isset($field['default_value']) && $field['default_value'] != '') {
+                $object->$key = $field['default_value'];
             } elseif ($form->hasValidData('AbstractInput_' . $key) && (($field['required'] == false) || ($field['type'] == 'combobox') || ($field['required'] == true && ($field['type'] == 'text' || $field['type'] == 'number') && $form->{'AbstractInput_' . $key} != ''))) {
 
                 if (isset($field['multilanguage']) && $field['multilanguage'] == true) {

--- a/lhc_web/lib/core/lhcore/lhdbtrait.php
+++ b/lhc_web/lib/core/lhcore/lhdbtrait.php
@@ -478,7 +478,6 @@ trait erLhcoreClassDBTrait
             }
 
             $conditions[] = $q->expr->lOr($conditionsLor);
-
         }
 
         if (isset($params['filterlorf']) && count($params['filterlorf']) > 0) {

--- a/lhc_web/lib/core/lhcore/lhdesign.php
+++ b/lhc_web/lib/core/lhcore/lhdesign.php
@@ -82,6 +82,10 @@ class erLhcoreClassDesign
             ));
     }
 
+    public static function designtpldynamic($path) {
+        return self::designtpl($path);
+    }
+
     public static function designtpl($path)
     {
         $debugOutput = erConfigClassLhConfig::getInstance()->getSetting('site', 'debug_output');

--- a/lhc_web/lib/core/lhcore/lhupdate.php
+++ b/lhc_web/lib/core/lhcore/lhupdate.php
@@ -2,8 +2,8 @@
 
 class erLhcoreClassUpdate
 {
-	const DB_VERSION = 284;
-	const LHC_RELEASE = 412;
+	const DB_VERSION = 285;
+	const LHC_RELEASE = 413;
 
 	public static function doTablesUpdate($definition){
 		$updateInformation = self::getTablesStatus($definition);

--- a/lhc_web/lib/models/lhabstract/erlhabstractmodeleproactivechatinvitation.php
+++ b/lhc_web/lib/models/lhabstract/erlhabstractmodeleproactivechatinvitation.php
@@ -274,6 +274,7 @@ class erLhAbstractModelProactiveChatInvitation {
 				AND (`lh_abstract_proactive_chat_invitation`.`id` IN (SELECT `invitation_id` FROM `lh_abstract_proactive_chat_invitation_dep` WHERE `dep_id` = ' . (int)$item->dep_id . ') OR `dep_id` = ' . (int)$item->dep_id . ' OR `dep_id` = 0)
 	            AND `inject_only_html` = 1
 	            AND `disabled` = 0
+	            AND `parent_id` = 0
 				AND ('.$q->expr->like( $session->database->quote(trim($referrer)), 'concat(referrer,\'%\')' ).' OR referrer = \'\')'
         )
         ->orderBy('position ASC')
@@ -326,6 +327,7 @@ class erLhAbstractModelProactiveChatInvitation {
 	            AND `inject_only_html` = 0
 	            AND `dynamic_invitation` = 1
 	            AND `disabled` = 0
+	            AND `parent_id` = 0
 				AND ('.$q->expr->like( $session->database->quote(trim($referrer)), 'concat(referrer,\'%\')' ).' OR referrer = \'\')'
 	    )
 	    ->orderBy('position ASC, RAND()')
@@ -337,26 +339,34 @@ class erLhAbstractModelProactiveChatInvitation {
 	}
 	
 	public static function setInvitation(erLhcoreClassModelChatOnlineUser & $item, $invitationId) {
-	    
-	    $message = self::fetch($invitationId);
 
-	    $message->translateByLocale();
+        $messageContent = $message = self::fetch($invitationId);
 
-	    if ($item->total_visits == 1 || $message->message_returning == '') {
-	        $item->operator_message = $message->message;
+        // This is a variation message
+        if (isset($item->online_attr_system_array['lhc_inv_var_id'])) {
+            $messageContent = self::fetch($item->online_attr_system_array['lhc_inv_var_id']);
+            if (!($messageContent instanceof erLhAbstractModelProactiveChatInvitation)){
+                $messageContent = $message;
+            }
+        }
+
+        $messageContent->translateByLocale();
+
+	    if ($item->total_visits == 1 || $messageContent->message_returning == '') {
+	        $item->operator_message = $messageContent->message;
 	    } else {
 	        if ($item->chat !== false && $item->chat->nick != '') {
 	            $nick = $item->chat->nick;
-	        } elseif ($message->message_returning_nick != '') {
-	            $nick = $message->message_returning_nick;
+	        } elseif ($messageContent->message_returning_nick != '') {
+	            $nick = $messageContent->message_returning_nick;
 	        } else {
 	            $nick = '';
 	        }
 	    
-	        $item->operator_message = str_replace('{nick}', $nick, $message->message_returning);
+	        $item->operator_message = str_replace('{nick}', $nick, $messageContent->message_returning);
 	    }
 
-	    $item->operator_user_proactive = $message->operator_name;
+	    $item->operator_user_proactive = $messageContent->operator_name;
 	    $item->invitation_id = $message->id;
 	    $item->invitation_seen_count = 1;
 	    $item->requires_email = $message->requires_email;
@@ -367,12 +377,12 @@ class erLhAbstractModelProactiveChatInvitation {
 	    $item->invitation_assigned = true;
 	    $item->last_visit = time();
 	    
-	    if ($message->show_random_operator == 1) {
-	        $item->operator_user_id = erLhcoreClassChat::getRandomOnlineUserID(array('operators' => explode(',',trim($message->operator_ids))));
+	    if ($messageContent->show_random_operator == 1) {
+	        $item->operator_user_id = erLhcoreClassChat::getRandomOnlineUserID(array('operators' => explode(',',trim($messageContent->operator_ids))));
 
 	        // Assign same operator as invitation was shown from
 	        $onlineAttrSystem = $item->online_attr_system_array;
-            $attributesDesignData = $message->design_data_array;
+            $attributesDesignData = $messageContent->design_data_array;
 
             if ($item->operator_user_id > 0 && !isset($onlineAttrSystem['lhc_assign_to_me']) && isset($attributesDesignData['assign_to_randomop']) && $attributesDesignData['assign_to_randomop'] == 1) {
                 $onlineAttrSystem['lhc_assign_to_me'] = 1;
@@ -387,10 +397,19 @@ class erLhAbstractModelProactiveChatInvitation {
         $message->updateThis(array('update' => array(
             'executed_times'
         )));
-	    	
+
+        if ($message->id != $messageContent->id) {
+            $messageContent->executed_times += 1;
+            $messageContent->updateThis(array('update' => array(
+                'executed_times'
+            )));
+        }
+
 	    $item->saveThis();
 	    
-	    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('onlineuser.proactive_triggered', array('message' => & $message, 'ou' => & $item));
+	    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('onlineuser.proactive_triggered', array('message' => & $message, 'variation' => & $messageContent, 'ou' => & $item));
+
+        return ['invitation' => $message, 'variation' => $messageContent];
 	}
 
 	public function translateByLocale()
@@ -485,6 +504,7 @@ class erLhAbstractModelProactiveChatInvitation {
 				' . $appendDevice . '
 		        AND `dynamic_invitation` = 0
 		        AND `disabled` = 0
+		        AND `parent_id` = 0
 		        AND `inject_only_html` = 0
 		        ' . $appendInvitationsId . '
 				AND (`lh_abstract_proactive_chat_invitation`.`id` IN (SELECT `invitation_id` FROM `lh_abstract_proactive_chat_invitation_dep` WHERE `dep_id` = ' . (int)$item->dep_id . ') OR `dep_id` = ' . (int)$item->dep_id . ' OR `dep_id` = 0)
@@ -677,24 +697,27 @@ class erLhAbstractModelProactiveChatInvitation {
                     }
                 }
 
-                $message->translateByLocale();
+                // Variation message either original either some child
+                // We should always find one even yourself
+                $messageContent = erLhAbstractModelProactiveChatInvitation::findOne(['sort' => 'rand()', 'filter' => ['disabled' => 0], 'filterlor' => ['parent_id' => [$message->id], 'id' => [$message->id]]]);
+                $messageContent->translateByLocale();
 
                 // Use default message if first time visit or returning message is empty
-                if ($item->total_visits == 1 || $message->message_returning == '') {
-                    $item->operator_message = $message->message;
+                if ($item->total_visits == 1 || $messageContent->message_returning == '') {
+                    $item->operator_message = $messageContent->message;
                 } else {
                     if ($item->chat !== false && $item->chat->nick != '') {
                         $nick = $item->chat->nick;
-                    } elseif ($message->message_returning_nick != '') {
-                        $nick = $message->message_returning_nick;
+                    } elseif ($messageContent->message_returning_nick != '') {
+                        $nick = $messageContent->message_returning_nick;
                     } else {
                         $nick = '';
                     }
 
-                    $item->operator_message = str_replace('{nick}', $nick, $message->message_returning);
+                    $item->operator_message = str_replace('{nick}', $nick, $messageContent->message_returning);
                 }
 
-                $item->operator_user_proactive = $message->operator_name;
+                $item->operator_user_proactive = $messageContent->operator_name;
                 $item->invitation_id = $message->id;
                 $item->invitation_seen_count = 1;
                 $item->requires_email = $message->requires_email;
@@ -705,16 +728,16 @@ class erLhAbstractModelProactiveChatInvitation {
                 $item->invitation_assigned = true;
                 $item->last_visit = time();
 
-                if ($message->show_random_operator == 1) {
-                    $item->operator_user_id = erLhcoreClassChat::getRandomOnlineUserID(array('operators' => (isset($operatorsOnlineId) && !empty($operatorsOnlineId)) ? $operatorsOnlineId : explode(',',trim($message->operator_ids))));
+                if ($messageContent->show_random_operator == 1) {
+                    $item->operator_user_id = erLhcoreClassChat::getRandomOnlineUserID(array('operators' => (isset($operatorsOnlineId) && !empty($operatorsOnlineId)) ? $operatorsOnlineId : explode(',',trim($messageContent->operator_ids))));
                 } else {
                     $item->operator_user_id = 0;
                 }
 
                 $onlineAttrSystem = $item->online_attr_system_array;
 
-                if (isset($message->design_data_array['next_inv_time']) && (int)$message->design_data_array['next_inv_time'] > 0) {
-                    $onlineAttrSystem['lhcnxt_ivt'] = (int)$message->design_data_array['next_inv_time'];
+                if (isset($messageContent->design_data_array['next_inv_time']) && (int)$messageContent->design_data_array['next_inv_time'] > 0) {
+                    $onlineAttrSystem['lhcnxt_ivt'] = (int)$messageContent->design_data_array['next_inv_time'];
                     $item->online_attr_system = json_encode($onlineAttrSystem);
                     $item->online_attr_system_array = $onlineAttrSystem;
                 } elseif (isset($onlineAttrSystem['lhcnxt_ivt'])) {
@@ -723,8 +746,8 @@ class erLhAbstractModelProactiveChatInvitation {
                     $item->online_attr_system_array = $onlineAttrSystem;
                 }
 
-                if (isset($message->design_data_array['expires_after']) && (int)$message->design_data_array['expires_after'] > 0) {
-                    $onlineAttrSystem['lhcinv_exp'] = (int)$message->design_data_array['expires_after'] + time();
+                if (isset($messageContent->design_data_array['expires_after']) && (int)$messageContent->design_data_array['expires_after'] > 0) {
+                    $onlineAttrSystem['lhcinv_exp'] = (int)$messageContent->design_data_array['expires_after'] + time();
                     $item->online_attr_system = json_encode($onlineAttrSystem);
                     $item->online_attr_system_array = $onlineAttrSystem;
                 } elseif (isset($onlineAttrSystem['lhcinv_exp'])) {
@@ -733,12 +756,22 @@ class erLhAbstractModelProactiveChatInvitation {
                     $item->online_attr_system_array = $onlineAttrSystem;
                 }
 
-                if (isset($message->design_data_array['ignore_bot']) && $message->design_data_array['ignore_bot'] == true) {
+                if (isset($messageContent->design_data_array['ignore_bot']) && $messageContent->design_data_array['ignore_bot'] == true) {
                     $onlineAttrSystem['lhc_ignore_bot'] = 1;
                     $item->online_attr_system = json_encode($onlineAttrSystem);
                     $item->online_attr_system_array = $onlineAttrSystem;
                 } elseif (isset($onlineAttrSystem['lhc_ignore_bot'])) {
                     unset($onlineAttrSystem['lhc_ignore_bot']);
+                    $item->online_attr_system = json_encode($onlineAttrSystem);
+                    $item->online_attr_system_array = $onlineAttrSystem;
+                }
+
+                if ($message->id != $messageContent->id) {
+                    $onlineAttrSystem['lhc_inv_var_id'] = $messageContent->id;
+                    $item->online_attr_system = json_encode($onlineAttrSystem);
+                    $item->online_attr_system_array = $onlineAttrSystem;
+                } elseif (isset($onlineAttrSystem['lhc_inv_var_id'])) {
+                    unset($onlineAttrSystem['lhc_inv_var_id']);
                     $item->online_attr_system = json_encode($onlineAttrSystem);
                     $item->online_attr_system_array = $onlineAttrSystem;
                 }
@@ -753,6 +786,13 @@ class erLhAbstractModelProactiveChatInvitation {
                     'executed_times'
                 )));
 
+                if ($message->id != $messageContent->id) {
+                    $messageContent->executed_times += 1;
+                    $messageContent->updateThis(array('update' => array(
+                        'executed_times'
+                    )));
+                }
+
                 // Campaign tracking
                 if (!($campaign instanceof erLhAbstractModelProactiveChatCampaignConversion)) {
                     $campaign = new erLhAbstractModelProactiveChatCampaignConversion();
@@ -766,23 +806,27 @@ class erLhAbstractModelProactiveChatInvitation {
                 $campaign->invitation_id = $message->id;
                 $campaign->invitation_type = 1;
                 $campaign->campaign_id = $message->campaign_id;
+                $campaign->variation_id = $messageContent->id;
 
                 $detect = new Mobile_Detect;
                 $detect->setUserAgent($item->user_agent);
                 $campaign->device_type = ($detect->isMobile() ? ($detect->isTablet() ? 2 : 1) : 0);
                 $campaign->saveThis();
 
-                // Set conversion for trackback for online visitor record
+                // Set conversion for track back for online visitor record
                 $item->conversion_id = $campaign->id;
 
-                erLhcoreClassChatEventDispatcher::getInstance()->dispatch('onlineuser.proactive_triggered', array('message' => & $message, 'ou' => & $item));
+                erLhcoreClassChatEventDispatcher::getInstance()->dispatch('onlineuser.proactive_triggered', array('variation' => & $messageContent, 'message' => & $message, 'ou' => & $item));
             } else {
 			    // We know there is invitation based on current criteria just time on site is still not matched.
                 $item->next_reschedule = $message->time_on_site - $item->time_on_site;
             }
 		}
 	}
-	
+
+
+
+
 	public function customForm(){
 	    return 'proactive_invitation.tpl.php';
 	}

--- a/lhc_web/lib/models/lhabstract/erlhabstractmodeleproactivechatinvitation.php
+++ b/lhc_web/lib/models/lhabstract/erlhabstractmodeleproactivechatinvitation.php
@@ -51,7 +51,8 @@ class erLhAbstractModelProactiveChatInvitation {
 			'disabled' => $this->disabled,
 			'campaign_id' => $this->campaign_id,
 			'design_data' => $this->design_data,
-			'inject_only_html' => $this->inject_only_html
+			'inject_only_html' => $this->inject_only_html,
+			'parent_id' => $this->parent_id
 		);
 			
 		return $stateArray;
@@ -985,6 +986,7 @@ class erLhAbstractModelProactiveChatInvitation {
 	public $campaign_id = 0;
 	public $design_data = '';
 	public $inject_only_html = 0;
+	public $parent_id = 0;
 
 	public $next_reschedule = 0;
 	public $hide_add = false;

--- a/lhc_web/lib/models/lhabstract/erlhabstractmodelproactivechatcampaignconv.php
+++ b/lhc_web/lib/models/lhabstract/erlhabstractmodelproactivechatcampaignconv.php
@@ -25,7 +25,8 @@ class erLhAbstractModelProactiveChatCampaignConversion
             'department_id'     => $this->department_id,
             'ctime'             => $this->ctime,
             'con_time'          => $this->con_time,
-            'vid_id'            => $this->vid_id
+            'vid_id'            => $this->vid_id,
+            'variation_id'      => $this->variation_id
         );
 
         return $stateArray;
@@ -56,6 +57,7 @@ class erLhAbstractModelProactiveChatCampaignConversion
     public $ctime = 0;
     public $con_time = 0;
     public $vid_id = 0;
+    public $variation_id = 0;
 }
 
 ?>

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1362,11 +1362,12 @@ try {
 				  `ctime` int(11) NOT NULL,
 				  `con_time` int(11) NOT NULL,
 				  `vid_id` bigint(20) DEFAULT NULL,
+				  `variation_id` int(11) NOT NULL DEFAULT '0',
 				  PRIMARY KEY (`id`),
 				  KEY `ctime` (`ctime`),
 				  KEY `campaign_id` (`campaign_id`),
-				  KEY `invitation_id` (`invitation_id`),
-				  KEY `invitation_status` (`invitation_status`)
+				  KEY `invitation_status` (`invitation_status`),
+				  KEY `invitation_id_variation_id` (`invitation_id`, `variation_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 
 
@@ -1663,6 +1664,7 @@ try {
         	   	  `requires_email` int(11) NOT NULL,
         	   	  `iddle_for` int(11) NOT NULL,
         	   	  `event_type` int(11) NOT NULL,
+                  `parent_id` int(11) NOT NULL DEFAULT '0',
         	   	  `requires_username` int(11) NOT NULL,
         	   	  `requires_phone` int(11) NOT NULL,        	   	  
         	   	  `design_data` longtext NOT NULL,        	   	  
@@ -1671,6 +1673,7 @@ try {
         	      KEY `identifier` (`identifier`),
         	      KEY `dynamic_invitation` (`dynamic_invitation`),
         	      KEY `tag` (`tag`),
+        	      KEY `parent_id` (`parent_id`),
         	      KEY `show_on_mobile` (`show_on_mobile`),
         	      KEY `dep_id` (`dep_id`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");

--- a/lhc_web/modules/lhwidgetrestapi/getinvitation.php
+++ b/lhc_web/modules/lhwidgetrestapi/getinvitation.php
@@ -20,7 +20,7 @@ if (!($onlineUser instanceof erLhcoreClassModelChatOnlineUser) || $onlineUser->v
 }
 
 if (is_numeric($payload['invitation']) && $payload['invitation'] > 0) {
-    erLhAbstractModelProactiveChatInvitation::setInvitation($onlineUser, (int)$payload['invitation']);
+    $invitationData = erLhAbstractModelProactiveChatInvitation::setInvitation($onlineUser, (int)$payload['invitation']);
 }
 
 // Make conversion if any exists
@@ -93,7 +93,7 @@ if (isset($payload['theme']) && ($themeId = erLhcoreClassChat::extractTheme($pay
 // Bot message as full widget body
 if ($outputResponse['invitation_id'] > 0) {
 
-    $invitation = erLhAbstractModelProactiveChatInvitation::fetch($outputResponse['invitation_id']);
+    $invitation = $invitationData['variation'];// erLhAbstractModelProactiveChatInvitation::fetch($outputResponse['invitation_id']);
 
     if ($invitation instanceof erLhAbstractModelProactiveChatInvitation && isset($invitation->design_data_array['append_bot']) && $invitation->design_data_array['append_bot'] == 1 && $invitation->bot_id > 0 && $invitation->trigger_id > 0) {
 

--- a/lhc_web/pos/lhabstract/erlhabstractmodelproactivechatcampaignconversion.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelproactivechatcampaignconversion.php
@@ -9,63 +9,19 @@ $def->idProperty->columnName = 'id';
 $def->idProperty->propertyName = 'id';
 $def->idProperty->generator = new ezcPersistentGeneratorDefinition(  'ezcPersistentNativeGenerator' );
 
-$def->properties['device_type'] = new ezcPersistentObjectProperty();
-$def->properties['device_type']->columnName   = 'device_type';
-$def->properties['device_type']->propertyName = 'device_type';
-$def->properties['device_type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+foreach (['device_type','invitation_type','invitation_status','chat_id','campaign_id','invitation_id','variation_id','department_id','ctime','con_time','vid_id'] as $posAttr) {
+    $def->properties[$posAttr] = new ezcPersistentObjectProperty();
+    $def->properties[$posAttr]->columnName   = $posAttr;
+    $def->properties[$posAttr]->propertyName = $posAttr;
+    $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
+}
 
-// 0 - Manual, 1 - Automatic
-$def->properties['invitation_type'] = new ezcPersistentObjectProperty();
-$def->properties['invitation_type']->columnName   = 'invitation_type';
-$def->properties['invitation_type']->propertyName = 'invitation_type';
-$def->properties['invitation_type']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
+//
+// invitation_status
 // 0 - Invitation Send
 // 1 - Invitation Shown
 // 2 - Invitation Seen
 // 3 - Chat started
-$def->properties['invitation_status'] = new ezcPersistentObjectProperty();
-$def->properties['invitation_status']->columnName   = 'invitation_status';
-$def->properties['invitation_status']->propertyName = 'invitation_status';
-$def->properties['invitation_status']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['chat_id'] = new ezcPersistentObjectProperty();
-$def->properties['chat_id']->columnName   = 'chat_id';
-$def->properties['chat_id']->propertyName = 'chat_id';
-$def->properties['chat_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['campaign_id'] = new ezcPersistentObjectProperty();
-$def->properties['campaign_id']->columnName   = 'campaign_id';
-$def->properties['campaign_id']->propertyName = 'campaign_id';
-$def->properties['campaign_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['invitation_id'] = new ezcPersistentObjectProperty();
-$def->properties['invitation_id']->columnName   = 'invitation_id';
-$def->properties['invitation_id']->propertyName = 'invitation_id';
-$def->properties['invitation_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-$def->properties['department_id'] = new ezcPersistentObjectProperty();
-$def->properties['department_id']->columnName   = 'department_id';
-$def->properties['department_id']->propertyName = 'department_id';
-$def->properties['department_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Create time
-$def->properties['ctime'] = new ezcPersistentObjectProperty();
-$def->properties['ctime']->columnName   = 'ctime';
-$def->properties['ctime']->propertyName = 'ctime';
-$def->properties['ctime']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Conversion time
-$def->properties['con_time'] = new ezcPersistentObjectProperty();
-$def->properties['con_time']->columnName   = 'con_time';
-$def->properties['con_time']->propertyName = 'con_time';
-$def->properties['con_time']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
-
-// Online Visitor ID
-$def->properties['vid_id'] = new ezcPersistentObjectProperty();
-$def->properties['vid_id']->columnName   = 'vid_id';
-$def->properties['vid_id']->propertyName = 'vid_id';
-$def->properties['vid_id']->propertyType = ezcPersistentObjectProperty::PHP_TYPE_INT;
 
 return $def;
 

--- a/lhc_web/pos/lhabstract/erlhabstractmodelproactivechatinvitation.php
+++ b/lhc_web/pos/lhabstract/erlhabstractmodelproactivechatinvitation.php
@@ -16,7 +16,7 @@ foreach (['design_data','tag','message_returning_nick','message_returning','refe
     $def->properties[$posAttr]->propertyType = ezcPersistentObjectProperty::PHP_TYPE_STRING;
 }
 
-foreach (['campaign_id','disabled','bot_offline','trigger_id','bot_id','event_invitation','event_type','iddle_for','dynamic_invitation','show_on_mobile','show_random_operator','requires_username','inject_only_html','delay','delay_init','show_instant','pageviews','executed_times','position','dep_id','autoresponder_id','requires_email','requires_phone'] as $posAttr) {
+foreach (['parent_id','campaign_id','disabled','bot_offline','trigger_id','bot_id','event_invitation','event_type','iddle_for','dynamic_invitation','show_on_mobile','show_random_operator','requires_username','inject_only_html','delay','delay_init','show_instant','pageviews','executed_times','position','dep_id','autoresponder_id','requires_email','requires_phone'] as $posAttr) {
     $def->properties[$posAttr] = new ezcPersistentObjectProperty();
     $def->properties[$posAttr]->columnName   = $posAttr;
     $def->properties[$posAttr]->propertyName = $posAttr;


### PR DESCRIPTION
* Proactive invitations can have child invitation which works as A/B testing workflow.
    * Once you define a parent invitation. Present invitation is considered as child invitation.
    * Only main display attributes are taken as variation.
    * Parent invitation statistic window will show child invitation performance.
* Bot pause trigger. https://github.com/LiveHelperChat/livehelperchat/pull/1797
* Proactive invitation have two new options
    * Hide content on click - clicking it will close invitation without triggering widget open. E.g you have some sale running and want to share some code with users.
    * Custom on click event - in combination with above option can work as independent and just execute javascript on click.
* Users/Groups/Roles list/edit windows UX improvements. Sorts by module etc.
* Modifying department group will update it stats also now.
* Export CSV for survey option.

execute doc/update_db/update_285.sql for update