### PR TITLE
fix filename extraction for URL with parameters

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
+++ b/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
@@ -1297,11 +1297,11 @@ class erLhcoreClassChatWebhookIncoming {
             $mediaContent = erLhcoreClassModelChatOnlineUser::executeRequest($url, $headers);
 
             // File name
-            $partsFilename = explode('/',$url);
+            $partsFilename = explode('/',strtok($url, '?'));
             $upload_name = (isset($overrideAttributes['upload_name']) && $overrideAttributes['upload_name'] != '') ? $overrideAttributes['upload_name'] : array_pop($partsFilename);
 
             // File extension
-            $partsExtension = explode('.',$url);
+            $partsExtension = explode('.',strtok($url, '?'));
             $file_extension = array_pop($partsExtension);
 
         } else {


### PR DESCRIPTION
Add function to strip parameters query from URL to proper filename extraction. 
Useful for integration with Viber which uses url like
https://dl-media.viber.com/4/media/2/short/any/sig/image/0x0/02f9/b9e5c2ed2d430171333f8983a200a82c5c6b8fc461a9d4e4e9f4d7f8e02f9.jpg?Expires=1674122113&Signature=fA9SXqzo~rff2rNl1So-zV01DOMR~vNULL0xm~ieW5SZlXnRf-s5NEi02tpieMVI9s~b-nJm1KolXlTZwO2x0bWR1oOHWHVlJvagOFtRHevKHXjdTRO0qkOENxnv~LN6rnNThccy-tKopghVwIbrusz7DcYH~34tvhvucvNQJ1AjhURihInalHGiH3FOQ0QR94nt2p~jS1oHukZ7sjiwpI5Vszq2lNJD16QGDXBDK0eoBXlEHdyhUm0ksSQ9QRvHcWB6vZwLVtY~rLIVDyL4TQo4deZq-av6ijlr-1ni6pJwjhvLbG4UzD2vQ9lrv1n2fn7WGuJLD30cfhSjFlg__&Key-Pair-Id=APKAJ62UNSBCEIPV4HA