### PR TITLE
Making request to edit webhook

### DIFF
--- a/lhc_web/modules/lhrestapi/editwebhook.php
+++ b/lhc_web/modules/lhrestapi/editwebhook.php
@@ -1,0 +1,40 @@
+GNU nano 7.2                                                                                                   editwebhook.php                                                                                                             <?php
+
+try {
+    erLhcoreClassRestAPIHandler::validateRequest();
+
+    $requestBody = json_decode(file_get_contents('php://input'), true);
+
+    if (!isset($requestBody['id']) || !isset($requestBody['disabled'])) {
+        throw new Exception("Parâmetros inválidos. ID e status são obrigatórios.");
+    }
+
+    $webhook = erLhcoreClassModelChatWebhook::fetch((int)$requestBody['id']);
+
+    if (!$webhook) {
+        throw new Exception("Webhook não encontrado.");
+    }
+
+    if (isset($requestBody['configuration'])) {
+    $webhook->configuration = $requestBody['configuration'];
+    }
+    $webhook->disabled = $requestBody['disabled'];
+    $webhook->updateThis();
+
+    erLhcoreClassRestAPIHandler::outputResponse([
+        'success' => true,
+        'message' => 'Webhook atualizado com sucesso.',
+        'webhook_id' => $webhook->id
+    ]);
+
+} catch (Exception $e) {
+    http_response_code(400);
+    erLhcoreClassRestAPIHandler::outputResponse([
+        'error' => true,
+        'message' => $e->getMessage()
+    ]);
+}
+
+exit();
+?>
+

--- a/lhc_web/modules/lhrestapi/module.php
+++ b/lhc_web/modules/lhrestapi/module.php
@@ -39,6 +39,10 @@ $ViewList['fetchchat'] = array(
     'params' => array()
 );
 
+$ViewList['editwebhook'] = array(
+    'params' => array(),
+);
+
 $ViewList['fetchchatmessages'] = array(
     'params' => array()
 );

--- a/lhc_web/modules/lhrestapi/swagger.json
+++ b/lhc_web/modules/lhrestapi/swagger.json
@@ -56,7 +56,12 @@
     {
       "name": "statistic",
       "description": "API Related to statistic"
+    },
+    {
+      "name": "Webhooks",
+      "description": "API Related to webhooks"
     }
+    
   ],
   "schemes": [
     "https",
@@ -535,6 +540,88 @@
             "login": []
           }
         ]
+      }
+    },
+    "/restapi/editwebhook": {
+      "put": {
+        "summary": "Update a webhook configuration",
+        "description": "Updates the configuration and status of an existing webhook.",
+        "operationId": "updateWebhook",
+        "tags": ["Webhooks"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "description": "The ID of the webhook to update",
+                    "example": 42
+                  },
+                  "configuration": {
+                    "type": "string",
+                    "description": "JSON configuration for the webhook",
+                    "example": "{\"attr\": \"{args.chat.dep_id}\", \"condition\": \"neq\", \"value\": \"3\"}"
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Whether the webhook is disabled",
+                    "example": false
+                  }
+                },
+                "required": ["id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Webhook updated successfully"
+                    },
+                    "webhook_id": {
+                      "type": "integer",
+                      "example": 42
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters or webhook not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid parameters. ID is required."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/restapi/campaignsconversions": {

--- a/lhc_web/modules/lhrestapi/swagger.json
+++ b/lhc_web/modules/lhrestapi/swagger.json
@@ -566,9 +566,9 @@
                     "example": "{\"attr\": \"{args.chat.dep_id}\", \"condition\": \"neq\", \"value\": \"3\"}"
                   },
                   "disabled": {
-                    "type": "boolean",
+                    "type": "integer",
                     "description": "Whether the webhook is disabled",
-                    "example": false
+                    "example": "1 to disabled, 0 to enabled"
                   }
                 },
                 "required": ["id"]


### PR DESCRIPTION
This PR introduces a new REST API functionality that allows updating Webhooks in Live Helper Chat.
Users can now modify existing Webhooks via API calls, enabling activation or deactivation without manual intervention.

Main Changes
Added a new REST API endpoint to update Webhooks.
Implemented validation for id and disabled parameters.
Ensured changes are properly saved to the database.
Motivation
This feature enables automation of Webhook configuration, reducing the need for manual adjustments through the admin panel.

Testing
Tested using Postman to verify that valid requests are processed correctly and invalid inputs return appropriate error messages.
Confirmed that changes persist in the database as expected.
References
Live Helper Chat REST API documentation.
Internal discussions regarding the need for API-based Webhook management.