### PR TITLE
Switch to new modal confirm window

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhcannedmsg/listreplace.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhcannedmsg/listreplace.tpl.php
@@ -32,7 +32,7 @@
             </td>
             <td nowrap ng-non-bindable><a class="btn btn-secondary csfr-required btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('cannedmsg/clonereplace')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('cannedmsg/deletereplace','Clone');?></a></td>
             <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('cannedmsg/editreplace')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Edit');?></a></td>
-            <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('cannedmsg/deletereplace')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete');?></a></td>
+            <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('cannedmsg/deletereplace')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhchat/cannedmsg.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/cannedmsg.tpl.php
@@ -78,7 +78,7 @@
                     </td>
                     <td nowrap>
                         <?php if (erLhcoreClassUser::instance()->hasAccessTo('lhchat','administratecannedmsg')) : ?>
-                            <a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('chat/cannedmsg')?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a>
+                            <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('chat/cannedmsg')?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a>
                         <?php endif;?>
                     </td>
                 </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchat/onlineusers.tpl.php
@@ -9,7 +9,7 @@
       <?php endif; ?>
 
       <?php if ($currentUser->hasAccessTo('lhchat','allowclearonlinelist')) : ?>
-      <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('chat/onlineusers')?>/(clear_list)/1"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Clear list');?></a>
+      <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('chat/onlineusers')?>/(clear_list)/1"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/onlineusers','Clear list');?></a>
       <?php endif; ?>
 </div>
 

--- a/lhc_web/design/defaulttheme/tpl/lhchatarchive/edit.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchatarchive/edit.tpl.php
@@ -22,7 +22,7 @@
 	
     <?php include(erLhcoreClassDesign::designtpl('lhkernel/csfr_token.tpl.php'));?>
 
-    <input type="submit" class="btn btn-danger float-end" name="Delete_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?>"/>
+    <input type="submit" class="btn btn-danger float-end csfr-post" data-trans="delete_confirm" name="Delete_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?>"/>
 
 	<div class="btn-group" role="group" aria-label="...">
       <input type="submit" class="btn btn-secondary" name="Save_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Save');?>"/>

--- a/lhc_web/design/defaulttheme/tpl/lhchatarchive/viewarchivedchat.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchatarchive/viewarchivedchat.tpl.php
@@ -40,7 +40,7 @@
         <?php if (!isset($modeArchiveView) || $modeArchiveView !== 'popup') : ?>
         <div class="btn-group">
             <a href="<?php echo erLhcoreClassDesign::baseurl('chatarchive/listarchivechats')?>/<?php echo $archive->id?>" class="btn btn-primary"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Return')?></a>
-            <a href="<?php echo erLhcoreClassDesign::baseurl('chatarchive/deletearchivechat')?>/<?php echo $archive->id?>/<?php echo $chat->id?>" class="csfr-required btn btn-secondary" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?')?>')"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/closedchats','Delete chat')?></a>
+            <a href="<?php echo erLhcoreClassDesign::baseurl('chatarchive/deletearchivechat')?>/<?php echo $archive->id?>/<?php echo $chat->id?>" class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" ><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/closedchats','Delete chat')?></a>
         </div>
         <?php endif; ?>
 

--- a/lhc_web/design/defaulttheme/tpl/lhchatbox/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchatbox/list.tpl.php
@@ -22,7 +22,7 @@
 	       <?php echo $chat->id;?>. <?php echo htmlspecialchars($chat->nick);?> <?php echo is_object($chat->chat) ? date(erLhcoreClassModule::$dateDateHourFormat,$chat->chat->time) : '';?>
         </td>
         <td class="small-1" nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('chatbox/edit')?>/<?php echo $chat->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-        <td class="small-1" nowrap><a class="csfr-required btn btn-danger btn-xs" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('chatbox/delete')?>/<?php echo $chat->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
+        <td class="small-1" nowrap><a class="csfr-post csfr-required btn btn-danger btn-xs" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('chatbox/delete')?>/<?php echo $chat->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
     </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhchatsettings/eventlist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchatsettings/eventlist.tpl.php
@@ -19,7 +19,7 @@ if (!isset($gaOptions['ga_enabled']) || $gaOptions['ga_enabled'] == false) : ?>
                 <td><?php echo htmlspecialchars($item->name)?></td>
                 <td><?php echo htmlspecialchars($item->department)?></td>
                 <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/editeventsettings')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/deleteevent')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/deleteevent')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhchatsettings/startsettingslist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhchatsettings/startsettingslist.tpl.php
@@ -16,7 +16,7 @@
         <td><?php echo htmlspecialchars($item->department)?></td>
         <td nowrap><a class="btn btn-secondary btn-xs csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/copyfrom')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Clone');?></a></td>
         <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/editstartsettings')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Edit');?></a></td>
-        <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/deletestartsettings')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+        <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('chatsettings/deletestartsettings')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhdepartment/brands.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhdepartment/brands.tpl.php
@@ -12,7 +12,7 @@
         <tr>
             <td><a href="<?php echo erLhcoreClassDesign::baseurl('department/editbrand')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a></td>
             <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('department/editbrand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Edit');?></a></td>
-            <td nowrap><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('department/deletebrand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
+            <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('department/deletebrand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhdepartment/group.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhdepartment/group.tpl.php
@@ -74,7 +74,7 @@
 
         <td nowrap>
             <?php if ($assignedOperator == 0) : ?>
-                <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('gallery/album_list_admin','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('department/deletegroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a>
+                <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('department/deletegroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a>
             <?php else : ?>
                 <button class="btn btn-danger btn-xs" title="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Disabled because there is assigned operators to it!');?>" disabled ><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></button>
             <?php endif; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhdepartment/limitgroup.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhdepartment/limitgroup.tpl.php
@@ -12,7 +12,7 @@
     <tr>
         <td><?php echo htmlspecialchars($item->name)?></td>
         <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('department/editlimitgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('department/departments','Edit');?></a></td>
-        <td nowrap><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('gallery/album_list_admin','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('department/deletelimitgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
+        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('department/deletelimitgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhfaq/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhfaq/list.tpl.php
@@ -19,7 +19,7 @@
 	        <td><?php echo htmlspecialchars($item->identifier)?></td>	       
 	        <td><?php if ($item->active == 1) : ?><b><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('faq/list','Y');?></b><?php else : ?><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('faq/list','N');?><?php endif;?></td>
 	        <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('faq/view')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('faq/list','Edit');?></a></td>
-	        <td nowrap class="right"><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="btn btn-danger btn-xs csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('faq/delete')?>/<?php echo $item->id; ?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('faq/list','Delete this question');?></a></td>
+	        <td nowrap class="right"><a data-trans="delete_confirm" class="btn btn-danger btn-xs csfr-post csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('faq/delete')?>/<?php echo $item->id; ?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('faq/list','Delete this question');?></a></td>
 	    </tr>
 	<?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhfile/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhfile/list.tpl.php
@@ -51,7 +51,7 @@
         <td nowrap><?php echo htmlspecialchars($file->date_front)?></td>
         <td nowrap>
             <a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('file/edit')?>/<?php echo $file->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('file/list','Edit');?></a>
-            <a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('file/delete')?>/<?php echo $file->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('file/list','Delete the file');?></a>
+            <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('file/delete')?>/<?php echo $file->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('file/list','Delete the file');?></a>
         </td>
     </tr>
 <?php endforeach; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhform/collected.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhform/collected.tpl.php
@@ -51,7 +51,7 @@
 				
 	        </div>
         </td>
-        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('form/collected')?>/<?php echo $form->id?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('form/collected','Delete');?></a></td>
+        <td nowrap><a data-trans="delete_confirm" class="csfr-post csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('form/collected')?>/<?php echo $form->id?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('form/collected','Delete');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/commands.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/commands.tpl.php
@@ -29,7 +29,7 @@
                 </td>
                 <td><?php echo $item->position?></td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editcommand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletecommand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletecommand')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/conditions/conditions.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/conditions/conditions.tpl.php
@@ -20,7 +20,7 @@
                     <?php echo htmlspecialchars($item->identifier)?>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editcondition')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletecondition')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletecondition')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/list.tpl.php
@@ -16,7 +16,9 @@
                 <?php include(erLhcoreClassDesign::designtpl('lhgenericbot/attr/bot_list_item_name.tpl.php'));?>
             </td>
             <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/edit')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-            <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+            <td>
+                <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/delete')?>/<?php echo $item->id?>" ><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a>
+            </td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listexceptions.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listexceptions.tpl.php
@@ -16,7 +16,7 @@
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editexception')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editexception')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deleteexception')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deleteexception')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listrestapi.tpl.php
@@ -22,7 +22,7 @@
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/editrestapi')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deleterestapi')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deleterestapi')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listtranslations.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listtranslations.tpl.php
@@ -15,7 +15,7 @@
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/listtranslationsitems')?>/(group_id)/<?php echo $item->id?>"><?php echo htmlspecialchars($item->name)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/edittrgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletetrgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletetrgroup')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/listtranslationsitems.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/listtranslationsitems.tpl.php
@@ -15,7 +15,7 @@
                     <a title="<?php echo $item->id?>" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/edittritem')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->identifier)?></a>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/edittritem')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletetritem')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('genericbot/deletetritem')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhgroupchat/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgroupchat/list.tpl.php
@@ -26,7 +26,7 @@
             </td>
             <td><?php echo htmlspecialchars($item->time_front)?></td>
             <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('groupchat/edit')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttoms','Edit');?></a></td>
-            <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('groupchat/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+            <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('groupchat/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhmailarchive/edit.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailarchive/edit.tpl.php
@@ -41,7 +41,7 @@
 
     <?php include(erLhcoreClassDesign::designtpl('lhkernel/csfr_token.tpl.php'));?>
 
-    <input type="submit" class="btn btn-danger float-end" name="Delete_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?>"/>
+    <input type="submit" class="btn btn-danger float-end csfr-post" data-trans="delete_confirm" name="Delete_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?>"/>
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
         <input type="submit" class="btn btn-secondary" name="Save_archive" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Save');?>"/>

--- a/lhc_web/design/defaulttheme/tpl/lhmailarchive/listarchivemails.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailarchive/listarchivemails.tpl.php
@@ -102,7 +102,7 @@
                 </td>
                 <?php if ($can_delete === true) : ?>
                     <td ng-non-bindable>
-                        <a class="text-danger csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                        <a class="text-danger csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                     </td>
                 <?php endif; ?>
             </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhmailconv/conversations.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailconv/conversations.tpl.php
@@ -106,7 +106,7 @@
                             </td>
                             <?php if ($can_delete === true) : ?>
                                 <td ng-non-bindable>
-                                    <a class="text-danger csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                                    <a class="text-danger csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                                 </td>
                             <?php endif; ?>
                             </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhmailconv/matchingrules.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailconv/matchingrules.tpl.php
@@ -39,7 +39,7 @@
                 <td>
                     <div class="btn-group" role="group" aria-label="..." style="width:60px;">
                         <a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/editmatchrule')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE254;</i></a>
-                        <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deletematchingrule')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                        <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deletematchingrule')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                     </div>
                 </td>
             </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhmailconv/personalmailboxgroups.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailconv/personalmailboxgroups.tpl.php
@@ -33,7 +33,7 @@
                 <td>
                     <div class="btn-group" role="group" aria-label="..." style="width:60px;">
                         <a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/editpersonalmailboxgroup')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE254;</i></a>
-                        <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deletemailbox')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                        <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deletemailbox')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                     </div>
                 </td>
             </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhmailconv/responsetemplates.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailconv/responsetemplates.tpl.php
@@ -23,7 +23,7 @@
                 <td>
                     <div class="btn-group" role="group" aria-label="..." style="width:60px;">
                         <a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/editresponsetemplate')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE254;</i></a>
-                        <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteresponsetemplate')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                        <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteresponsetemplate')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                     </div>
                 </td>
                 <?php endif; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhmailing/campaign.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailing/campaign.tpl.php
@@ -33,7 +33,7 @@
                     <a class="<?php if ($item->status == erLhcoreClassModelMailconvMailingCampaign::STATUS_FINISHED) : ?>text-muted<?php endif;?>" href="<?php echo erLhcoreClassDesign::baseurl('mailing/campaignrecipient')?>/(campaign)/<?php echo $item->id?>" ><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('module/mailconvmb','List of recipients');?></a>
                 </td>
                 <td>
-                    <a class="text-danger csfr-post csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletecampaign')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
+                    <a class="text-danger csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletecampaign')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhmailing/campaignrecipient.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailing/campaignrecipient.tpl.php
@@ -31,7 +31,7 @@
                         <small class="pl-2 text-muted"><span class="material-icons">mail_outline</span><?php echo htmlspecialchars($item->mailbox_front)?></small>
                     <?php endif; ?>
 
-                    <a class="csfr-required text-muted border rounded px-1" href="<?php echo erLhcoreClassDesign::baseurl('mailing/sendtestemail')?>/<?php echo $item->id?>" onclick="return confirm('Are you sure?')"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('module/mailconvmb','Send test e-mail');?></a>
+                    <a class="csfr-post csfr-required text-muted border rounded px-1" href="<?php echo erLhcoreClassDesign::baseurl('mailing/sendtestemail')?>/<?php echo $item->id?>" data-trans="delete_confirm"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('module/mailconvmb','Send test e-mail');?></a>
                 </td>
                 <td>
                     <?php if ($item->send_at > 0) : ?><?php echo $item->send_at_front?><?php endif;?>
@@ -65,7 +65,7 @@
                     <?php endif; ?>
                 </td>
                 <td>
-                    <a class="text-danger csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletecampaignrecipient')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
+                    <a class="text-danger csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletecampaignrecipient')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhmailing/mailinglist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailing/mailinglist.tpl.php
@@ -22,7 +22,7 @@
                     <?php echo htmlspecialchars($item->user instanceof erLhcoreClassModelUser ? $item->user : ''); ?>
                 </td>
                 <td>
-                    <a class="text-danger csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletemailinglist')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
+                    <a class="text-danger csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deletemailinglist')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
                 </td>
             </tr>
         <?php endforeach; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhmailing/mailingrecipient.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmailing/mailingrecipient.tpl.php
@@ -50,7 +50,7 @@
                 <?php echo htmlspecialchars($item->attr_str_6)?>
             </td>
             <td>
-                <a class="csfr-required text-danger" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deleterecipient')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
+                <a class="csfr-post csfr-required text-danger" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailing/deleterecipient')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
             </td>
         </tr>
     <?php endforeach;endif; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhmobile/sessions.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhmobile/sessions.tpl.php
@@ -32,7 +32,7 @@
                 <td nowrap>
                     <div class="btn-group" role="group" aria-label="..." style="width:60px;">
                         <a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('mobile/editsession')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE254;</i></a>
-                        <a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mobile/deletesession')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
+                        <a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mobile/deletesession')?>/<?php echo $item->id?>" ><i class="material-icons me-0">&#xE872;</i></a>
                     </div>
                 </td>
             </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhnotifications/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhnotifications/list.tpl.php
@@ -39,7 +39,7 @@
                     <?php echo $item->utime_front?>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('notifications/editsubscriber')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('notifications/deletesubscriber')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('notifications/deletesubscriber')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhnotifications/loadsubscriptions.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhnotifications/loadsubscriptions.tpl.php
@@ -29,8 +29,8 @@
                     <?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('notification/list','In-Active');?>
                 <?php endif; ?>
             </td>
-            <td><a class="btn btn-info btn-xs csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('notifications/sendtest')?>/<?php echo $notificationSubscriber->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Test');?></a></td>
-            <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('notifications/opdeletesubscribermy')?>/<?php echo $notificationSubscriber->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+            <td><a class="btn btn-info btn-xs csfr-post csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('notifications/sendtest')?>/<?php echo $notificationSubscriber->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Test');?></a></td>
+            <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('notifications/opdeletesubscribermy')?>/<?php echo $notificationSubscriber->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhnotifications/oplist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhnotifications/oplist.tpl.php
@@ -39,7 +39,7 @@
                     <?php endif; ?>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('notifications/editsubscriberop')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('notifications/opdeletesubscriber')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('notifications/opdeletesubscriber')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhpermission/roles.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhpermission/roles.tpl.php
@@ -19,7 +19,7 @@
         <td><?php echo htmlspecialchars($departament['name'])?></td>
         <?php if ($canEdit) : ?><td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('permission/editrole')?>/<?php echo $departament['id']?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('permission/roles','Edit');?></a></td><?php endif;?>
         <?php if ($canEdit) : ?><td nowrap><a class="btn btn-secondary btn-xs csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('permission/clonerole')?>/<?php echo $departament['id']?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('permission/roles','Clone');?></a></td><?php endif;?>
-        <?php if ($canDelete) : ?><td nowrap><?php if ($departament['id'] != 1 && erLhcoreClassRole::canDeleteRole($departament['id']) === true) : ?><a class="csfr-required btn btn-danger btn-xs" onclick="return confirm('Are you sure?')" href="<?php echo erLhcoreClassDesign::baseurl('permission/deleterole')?>/<?php echo $departament['id']?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('permission/roles','Delete a role');?></a><?php endif;?></td><?php endif;?>
+        <?php if ($canDelete) : ?><td nowrap><?php if ($departament['id'] != 1 && erLhcoreClassRole::canDeleteRole($departament['id']) === true) : ?><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('permission/deleterole')?>/<?php echo $departament['id']?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('permission/roles','Delete a role');?></a><?php endif;?></td><?php endif;?>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhquestionary/answers.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhquestionary/answers.tpl.php
@@ -17,7 +17,7 @@
 	        <td><?php echo date(erLhcoreClassModule::$dateDateHourFormat,$item->ctime)?></td>
 	        <td><?php echo htmlspecialchars($item->ip_front)?></td>
 	        <td nowrap><a class="btn btn-secondary btn-xs" onclick="return lhc.revealModal({'url':'<?php echo erLhcoreClassDesign::baseurl('questionary/previewanswer')?>/<?php echo $item->id?>','height':'500','iframe':true})" href="#"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/answers','View');?></a></td>
-	        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('questionary/deleteanswer')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/answers','Delete the answer');?></a></td>
+	        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('questionary/deleteanswer')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/answers','Delete the answer');?></a></td>
 	    </tr>
 	<?php endforeach; ?>
 	</table>

--- a/lhc_web/design/defaulttheme/tpl/lhquestionary/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhquestionary/list.tpl.php
@@ -24,7 +24,7 @@
         <td><?php if ($item->active == 1) : ?><b><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','Y');?></b><?php else : ?><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','N');?><?php endif;?></td>
         <td><?php echo $item->revote > 0 ? $item->revote : erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','Off') ; ?></td>
         <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('questionary/edit')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','Edit the question');?></a></td>
-        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('questionary/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','Delete the question');?></a></td>
+        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('questionary/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list','Delete the question');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhquestionary/voting.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhquestionary/voting.tpl.php
@@ -42,7 +42,7 @@
         <td><?php echo htmlspecialchars($optionsItem->option_name)?></td>
         <td><?php echo $optionsItem->priority?></td>
         <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('questionary/edit')?>/<?php echo $question->id?>/(option_id)/<?php echo $optionsItem->id?>/(tab)/voting"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/edit','Edit');?></a></td>
-        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('questionary/deleteoption')?>/<?php echo $optionsItem->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/edit','Delete');?></a></td>
+        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('questionary/deleteoption')?>/<?php echo $optionsItem->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/edit','Delete');?></a></td>
 </tr>
 <?php endforeach;?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhspeech/dialects.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhspeech/dialects.tpl.php
@@ -20,7 +20,7 @@
             <td><?php echo htmlspecialchars($item->lang_code)?></td>
             <td><?php echo htmlspecialchars($item->short_code)?></td>
             <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('speech/editdialect')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Edit');?></a></td>
-            <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('speech/deletedialect')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
+            <td nowrap><a class="csfr-post csfr-required btn btn-danger btn-xs" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('speech/deletedialect')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhsurvey/collected/list.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsurvey/collected/list.tpl.php
@@ -45,7 +45,7 @@
     	<?php endif;?>
         <?php if (erLhcoreClassUser::instance()->hasAccessTo('lhsurvey','delete_collected')) : ?>
         <td>
-            <a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('survey/collected')?>/<?php echo $item->survey_id;?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete');?></a>
+            <a class="csfr-post csfr-required btn btn-danger btn-xs" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('survey/collected')?>/<?php echo $item->survey_id;?>/(action)/delete/(id)/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete');?></a>
         </td>
         <?php endif;?>
     </tr>

--- a/lhc_web/design/defaulttheme/tpl/lhtheme/adminthemes.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhtheme/adminthemes.tpl.php
@@ -19,7 +19,7 @@
                 <?php endif; ?>
             </a></td>
         <td><?php echo htmlspecialchars($item->user)?></td>
-        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('theme/adminthemedelete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
+        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('theme/adminthemedelete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/buttons','Delete');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhuser/grouplist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/grouplist.tpl.php
@@ -19,7 +19,7 @@
         <td><?php echo htmlspecialchars($group->name)?></td>
         <?php if ($canEdit) : ?><td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/editgroup')?>/<?php echo $group->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/grouplist','Edit group');?></a></td><?php endif;?>
         <?php if ($canEdit) : ?><td nowrap><a class="btn btn-secondary btn-xs csfr-required" href="<?php echo erLhcoreClassDesign::baseurl('user/clonegroup')?>/<?php echo $group->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('permission/roles','Clone');?></a></td><?php endif;?>
-        <?php if ($canDelete) : ?><td nowrap><?php if ($group->id != 1) : ?><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('gallery/album_list_admin','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('user/deletegroup')?>/<?php echo $group->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/grouplist','Delete group');?></a><?php endif;?></td><?php endif;?>
+        <?php if ($canDelete) : ?><td nowrap><?php if ($group->id != 1) : ?><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('user/deletegroup')?>/<?php echo $group->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/grouplist','Delete group');?></a><?php endif;?></td><?php endif;?>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhuser/parts/canned_messages.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/parts/canned_messages.tpl.php
@@ -79,7 +79,7 @@ if ($pages->items_total > 0) {
         <td><?php echo $message->position?></td>
         <?php include(erLhcoreClassDesign::designtpl('lhuser/parts/cannedmsg/custom_column_content_multiinclude.tpl.php'));?>
         <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(msg)/<?php echo $message->id?>/(tab)/canned"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Edit message');?></a></td>
-        <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(action)/delete/(tab)/canned/(msg)/<?php echo $message->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a></td>
+        <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(action)/delete/(tab)/canned/(msg)/<?php echo $message->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhuser/parts/personal_auto_responder.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/parts/personal_auto_responder.tpl.php
@@ -28,7 +28,7 @@ if ($pages->items_total > 0) {
             <td><?php echo nl2br(htmlspecialchars($autoResponderMessage->name))?></td>
             <td><?php echo nl2br(htmlspecialchars((string)$autoResponderMessage->list_department))?></td>
             <td nowrap><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(msg)/<?php echo $autoResponderMessage->id?>/(tab)/autoresponder"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Edit message');?></a></td>
-            <td nowrap><a onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/message','Are you sure?');?>')" class="csfr-required btn btn-danger btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(action)/delete/(tab)/autoresponder/(msg)/<?php echo $autoResponderMessage->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a></td>
+            <td nowrap><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('user/account')?>/(action)/delete/(tab)/autoresponder/(msg)/<?php echo $autoResponderMessage->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('chat/cannedmsg','Delete message');?></a></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhuser/userlist.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/userlist.tpl.php
@@ -70,7 +70,7 @@
         <?php if ($canLoginAs) : ?>
             <td nowrap=""><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('user/loginas')?>/<?php echo $user->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Login As');?></a></td>
         <?php endif;?>
-        <?php if ($canDelete) : ?><td><?php if ($user->id != 1) : ?><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('user/delete')?>/<?php echo $user->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a><?php endif;?></td><?php endif;?>
+        <?php if ($canDelete) : ?><td><?php if ($user->id != 1) : ?><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('user/delete')?>/<?php echo $user->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a><?php endif;?></td><?php endif;?>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/lhc_web/design/defaulttheme/tpl/lhviews/loadview_mail.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhviews/loadview_mail.tpl.php
@@ -53,7 +53,7 @@
 
                 <span class="mr-2"><?php echo $item->id; ?></span>
             <?php if ($can_delete === true) : ?>
-                          <a class="csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
+                          <a class="csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/deleteconversation')?>/<?php echo $item->id?>" ><i class="material-icons mr-0">&#xE872;</i></a>
             <?php endif; ?>
                 <a class="user-select-none" href="<?php echo erLhcoreClassDesign::baseurl('mailconv/view')?>/<?php echo $item->id?>"><?php echo htmlspecialchars($item->subject)?>&nbsp;<small><?php echo $item->total_messages?></small></a>
 

--- a/lhc_web/design/defaulttheme/tpl/lhwebhooks/configuration.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhwebhooks/configuration.tpl.php
@@ -40,7 +40,7 @@ $webhooksEnabled = $cfg->getSetting( 'webhooks', 'enabled', false );
                     <?php echo htmlspecialchars($item->disabled == 1 ? 'N' : 'Y')?>
                 </td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/edit')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/delete')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>

--- a/lhc_web/design/defaulttheme/tpl/lhwebhooks/incomingwebhooks.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhwebhooks/incomingwebhooks.tpl.php
@@ -24,7 +24,7 @@
                 <td><?php echo htmlspecialchars($item->identifier)?></td>
                 <td nowrap="nowrap"><?php echo htmlspecialchars($item->disabled == 1 ? 'Y' : 'N')?></td>
                 <td><a class="btn btn-secondary btn-xs" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/editincoming')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module','Edit');?></a></td>
-                <td><a class="btn btn-danger btn-xs csfr-required" onclick="return confirm('<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('kernel/messages','Are you sure?');?>')" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/deleteincoming')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
+                <td><a class="btn btn-danger btn-xs csfr-post csfr-required" data-trans="delete_confirm" href="<?php echo erLhcoreClassDesign::baseurl('webhooks/deleteincoming')?>/<?php echo $item->id?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/userlist','Delete');?></a></td>
             </tr>
         <?php endforeach; ?>
     </table>


### PR DESCRIPTION
This pull request updates the delete confirmation mechanism across multiple templates in the project. The changes replace the use of inline `onclick` JavaScript confirmation dialogs with a more consistent approach using the `csfr-post` class and a `data-trans="delete_confirm"` attribute. This improves maintainability, ensures a unified user experience, and enhances security by avoiding inline JavaScript.

### Replace inline JavaScript confirmation with `csfr-post` and `data-trans`:

* **Canned Messages and Related Templates**:
  - Updated delete links in `lhcannedmsg/listreplace.tpl.php` and `lhchat/cannedmsg.tpl.php` to use `csfr-post` and `data-trans="delete_confirm"`. [[1]](diffhunk://#diff-928a28e99a2a57a461f3354e6f7847eed5de83b9f08c8a92281225c4cc59f836L35-R35) [[2]](diffhunk://#diff-598d6b5406bce4830e446614a87d106e8b80676d28e1653293e1c7fa3e034567L81-R81)
  - Similar updates in `lhchat/onlineusers.tpl.php` for clearing the online users list.

* **Archive and Chatbox Management**:
  - Changed delete buttons in `lhchatarchive/edit.tpl.php` and `lhchatarchive/viewarchivedchat.tpl.php` for deleting archives and archived chats. [[1]](diffhunk://#diff-e600ce89cf5dab1912514f31d1cb4404ffa79b872f1108d5f12088241b6cb21eL25-R25) [[2]](diffhunk://#diff-2c3ae76d2b095e87cf4113cbc8a873d4cfe6ba787b36c3db38cdfd8474e7d7e4L43-R43)
  - Updated delete links in `lhchatbox/list.tpl.php` for chatbox entries.

* **Settings and Configuration**:
  - Adjusted delete buttons in `lhchatsettings/eventlist.tpl.php` and `lhchatsettings/startsettingslist.tpl.php` for event and start settings. [[1]](diffhunk://#diff-811690ef18997fa28988c8bdfb121d825501642ba527dbb55024f4486698b935L22-R22) [[2]](diffhunk://#diff-cb7b4cbb6376a431a805497d6319ef77343d5d8dccd20b01c0ddeef97ed61dc8L19-R19)

* **Department and FAQ Management**:
  - Applied the new confirmation mechanism in `lhdepartment/brands.tpl.php`, `lhdepartment/group.tpl.php`, and `lhdepartment/limitgroup.tpl.php` for department-related actions. [[1]](diffhunk://#diff-12a2a5634b783d29dacc85c47c79e8703b84b61e0523c71c8d5c689327616130L15-R15) [[2]](diffhunk://#diff-f977e64077c7b5ed8f646e65fb885259552e9c852a80415509867c920a32b637L77-R77) [[3]](diffhunk://#diff-c8198c64127817ce118b0d62bb62ae2345bf74124eae3988c0477ec91e0d3635L15-R15)
  - Updated delete links in `lhfaq/list.tpl.php` for FAQ entries.

* **Other Templates**:
  - Modified delete buttons in `lhfile/list.tpl.php`, `lhform/collected.tpl.php`, and several `lhgenericbot` templates for files, forms, and bot-related actions. [[1]](diffhunk://#diff-b71b25c900541c5029ae8b473c5ab3945c40d70c5b522caf1d8a1eed469cee7cL54-R54) [[2]](diffhunk://#diff-1bc4d450c4755cf37d504e6ba14153ee429d58a94f8f344aba6aa71286e0549aL54-R54) [[3]](diffhunk://#diff-dc0ed4ad9b60f4b9b77871e8fbb1b12fde554d76d858b8027e6b9f5b75f87b86L32-R32) [[4]](diffhunk://#diff-8431a19df841806069d6e3f0e6818ba82e0b60b5a2f0fd4f5b6215c5fd53960dL23-R23) [[5]](diffhunk://#diff-627f90557dda115742c57beaef023ef9320e4ae6aa318ff4e17609369faec7fcL19-R21)