### PR TITLE
feat(captcha): add provider-based captcha support (Google v3 + Cloudflare Turnstile)

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -1376,7 +1376,7 @@ class Install
                 ('track_domain',	'',	0,	'Set your domain to enable user tracking across different domain subdomains.',	0),
                 ('max_message_length','500',0,'Maximum message length in characters', '0'),
                 ('need_help_tip','1',0,'Show need help tooltip?', '0'),
-                ('recaptcha_data','a:4:{i:0;b:0;s:8:\"site_key\";s:0:\"\";s:10:\"secret_key\";s:0:\"\";s:7:\"enabled\";i:0;}','0','Re-captcha configuration','1'),
+                ('recaptcha_data','a:7:{i:0;b:0;s:8:\"site_key\";s:0:\"\";s:10:\"secret_key\";s:0:\"\";s:7:\"enabled\";i:0;s:8:\"provider\";s:6:\"google\";s:18:\"turnstile_site_key\";s:0:\"\";s:20:\"turnstile_secret_key\";s:0:\"\";}','0','Re-captcha configuration','1'),
                 ('need_help_tip_timeout','24',0,'Need help tooltip timeout, after how many hours show again tooltip?', '0'),
                 ('use_secure_cookie','0',0,'Use secure cookie, check this if you want to force SSL all the time', '0'),
                 ('faq_email_required','0',0,'Is visitor e-mail required for FAQ', '0'),

--- a/lhc_web/design/defaulttheme/tpl/lhkernel/recaptcha.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhkernel/recaptcha.tpl.php
@@ -1,16 +1,22 @@
-<?php $recaptchaData = erLhcoreClassModelChatConfig::fetch('recaptcha_data')->data_value; ?>
+<?php $recaptchaData = erLhcoreClassUserValidator::getCaptchaSettings(); ?>
+<?php $captchaAction = isset($captchaAction) ? $captchaAction : 'login_action'; ?>
 
-<?php if (is_array($recaptchaData) && isset($recaptchaData['enabled']) && $recaptchaData['enabled'] == 1) : ?>
-<input type="hidden" name="g-recaptcha" id="recaptcha-content" value="">
+<?php if ((int)$recaptchaData['enabled'] === 1 && $recaptchaData['provider'] === 'google') : ?>
+    <input type="hidden" name="g-recaptcha" id="recaptcha-content" value="">
 
-<script src='https://www.google.com/recaptcha/api.js?render=<?php echo htmlspecialchars($recaptchaData['site_key'])?>'></script>
-
-<script>
-    grecaptcha.ready(function() {
-        grecaptcha.execute('<?php echo htmlspecialchars($recaptchaData['site_key'])?>', {action: 'login_action'})
-            .then(function(token) {
-                $('#recaptcha-content').val(token);
-            });
-    });
-</script>
+    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo htmlspecialchars($recaptchaData['site_key'])?>"></script>
+    <script>
+        grecaptcha.ready(function() {
+            grecaptcha.execute('<?php echo htmlspecialchars($recaptchaData['site_key'])?>', {action: '<?php echo htmlspecialchars($captchaAction)?>'})
+                .then(function(token) {
+                    $('#recaptcha-content').val(token);
+                });
+        });
+    </script>
+<?php elseif ((int)$recaptchaData['enabled'] === 1 && $recaptchaData['provider'] === 'turnstile') : ?>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <div class="cf-turnstile mt-2"
+         data-sitekey="<?php echo htmlspecialchars($recaptchaData['turnstile_site_key'])?>"
+         data-action="<?php echo htmlspecialchars($captchaAction)?>">
+    </div>
 <?php endif; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhsystem/configuration_links/recaptcha.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsystem/configuration_links/recaptcha.tpl.php
@@ -1,3 +1,3 @@
 <?php if ($currentUser->hasAccessTo('lhsystem','configurerecaptcha')) : ?>
-    <li><a href="<?php echo erLhcoreClassDesign::baseurl('system/recaptcha')?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration','Re-captcha settings');?></a></li>
+    <li><a href="<?php echo erLhcoreClassDesign::baseurl('system/recaptcha')?>"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration','Captcha settings');?></a></li>
 <?php endif; ?>

--- a/lhc_web/design/defaulttheme/tpl/lhsystem/recaptcha.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhsystem/recaptcha.tpl.php
@@ -1,4 +1,4 @@
-<h1><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Re-captcha settings');?></h1>
+<h1><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Captcha settings');?></h1>
 
 <?php if (isset($updated) && $updated == 'done') : $msg = erTranslationClassLhTranslation::getInstance()->getTranslation('system/smtp','Settings updated'); ?>
     <?php include(erLhcoreClassDesign::designtpl('lhkernel/alert_success.tpl.php'));?>
@@ -6,22 +6,66 @@
 
 <form action="" method="post" autocomplete="off" ng-non-bindable>
 
-    <p><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','This works with V3 re-captcha.');?> <a href="https://www.google.com/recaptcha/admin#v3signup" target="_blank"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Get Re-captcha keys');?></a></p>
-
     <div class="form-group">
         <label><input type="checkbox" value="on" name="enabled" <?php (isset($rc_data['enabled']) && $rc_data['enabled'] == 1) ? print 'checked="checked"' : ''?> /> <?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/timezone','Enable');?></label>
     </div>
 
     <div class="form-group">
-        <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Site key');?></label>
-        <input type="text" class="form-control" name="site_key" value="<?php isset($rc_data['site_key']) ? print htmlspecialchars($rc_data['site_key']) : ''?>" />
+        <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Captcha provider');?></label>
+        <select class="form-control" name="provider" id="id-captcha-provider">
+            <option value="google" <?php (isset($rc_data['provider']) && $rc_data['provider'] === 'google') ? print 'selected="selected"' : ''?>><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Google reCAPTCHA v3');?></option>
+            <option value="turnstile" <?php (isset($rc_data['provider']) && $rc_data['provider'] === 'turnstile') ? print 'selected="selected"' : ''?>><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Cloudflare Turnstile');?></option>
+        </select>
     </div>
 
-    <div class="form-group">
-        <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key');?></label>
-        <input type="text" class="form-control" name="secret_key" value="" />
-        <p><i><small><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key is not shown!');?></small></i></p>
+    <div id="provider-settings-google" class="provider-settings">
+        <p>
+            <?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','This works with Google reCAPTCHA v3.');?>
+            <a href="https://www.google.com/recaptcha/admin#v3signup" target="_blank"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Get Google reCAPTCHA keys');?></a>
+        </p>
+
+        <div class="form-group">
+            <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Site key');?></label>
+            <input type="text" class="form-control" name="site_key" value="<?php isset($rc_data['site_key']) ? print htmlspecialchars($rc_data['site_key']) : ''?>" />
+        </div>
+
+        <div class="form-group">
+            <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key');?></label>
+            <input type="text" class="form-control" name="secret_key" value="" />
+            <p><i><small><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key is not shown!');?></small></i></p>
+        </div>
     </div>
+
+    <div id="provider-settings-turnstile" class="provider-settings">
+        <p>
+            <?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','This works with Cloudflare Turnstile.');?>
+            <a href="https://dash.cloudflare.com/?to=/:account/turnstile" target="_blank"><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Get Cloudflare Turnstile keys');?></a>
+        </p>
+
+        <div class="form-group">
+            <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Site key');?></label>
+            <input type="text" class="form-control" name="turnstile_site_key" value="<?php isset($rc_data['turnstile_site_key']) ? print htmlspecialchars($rc_data['turnstile_site_key']) : ''?>" />
+        </div>
+
+        <div class="form-group">
+            <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key');?></label>
+            <input type="text" class="form-control" name="turnstile_secret_key" value="" />
+            <p><i><small><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('system/recaptcha','Secret key is not shown!');?></small></i></p>
+        </div>
+    </div>
+
+    <script>
+        (function() {
+            function toggleCaptchaProviderSettings() {
+                var provider = document.getElementById('id-captcha-provider').value;
+                document.getElementById('provider-settings-google').style.display = provider === 'google' ? 'block' : 'none';
+                document.getElementById('provider-settings-turnstile').style.display = provider === 'turnstile' ? 'block' : 'none';
+            }
+
+            document.getElementById('id-captcha-provider').addEventListener('change', toggleCaptchaProviderSettings);
+            toggleCaptchaProviderSettings();
+        })();
+    </script>
 
     <?php include(erLhcoreClassDesign::designtpl('lhkernel/csfr_token.tpl.php'));?>
 

--- a/lhc_web/design/defaulttheme/tpl/lhuser/forgotpassword.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/forgotpassword.tpl.php
@@ -13,6 +13,7 @@
 
 <?php include(erLhcoreClassDesign::designtpl('lhkernel/csfr_token.tpl.php'));?>
 
+<?php $captchaAction = 'forgot_password_action'; ?>
 <?php include(erLhcoreClassDesign::designtpl('lhkernel/recaptcha.tpl.php'));?>
 
 <input type="submit" class="btn btn-primary btn-sm" value="<?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('user/forgotpassword','Restore password')?>" name="Forgotpassword" />

--- a/lhc_web/design/defaulttheme/tpl/lhuser/login.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhuser/login.tpl.php
@@ -50,6 +50,7 @@
 
 <input type="hidden" name="redirect" value="<?php echo htmlspecialchars($redirect_url);?>" />
 
+<?php $captchaAction = 'login_action'; ?>
 <?php include(erLhcoreClassDesign::designtpl('lhkernel/recaptcha.tpl.php'));?>
 
 

--- a/lhc_web/doc/translation_default/translation_web.ts
+++ b/lhc_web/doc/translation_default/translation_web.ts
@@ -15606,6 +15606,10 @@
       <translation type="unfinished"/>
     </message>
     <message>
+      <source>Captcha settings</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
       <source>Rest API</source>
       <translation type="unfinished"/>
     </message>
@@ -23550,7 +23554,19 @@
   <context>
     <name>system/recaptcha</name>
     <message>
-      <source>Re-captcha settings</source>
+      <source>Captcha settings</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -23558,7 +23574,23 @@
       <translation type="unfinished"/>
     </message>
     <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
       <source>Get Re-captcha keys</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
       <translation type="unfinished"/>
     </message>
     <message>
@@ -24335,6 +24367,10 @@
     </message>
     <message>
       <source>Google re-captcha validation failed</source>
+      <translation type="unfinished"/>
+    </message>
+    <message>
+      <source>Captcha validation failed</source>
       <translation type="unfinished"/>
     </message>
     <message>

--- a/lhc_web/lib/core/lhuser/lhuservalidator.php
+++ b/lhc_web/lib/core/lhuser/lhuservalidator.php
@@ -75,6 +75,250 @@ class erLhcoreClassUserValidator {
         return $Errors;
     }
 
+    public static function getCaptchaSettings(): array
+    {
+        $recaptchaData = erLhcoreClassModelChatConfig::fetch('recaptcha_data')->data_value;
+
+        if (!is_array($recaptchaData)) {
+            $recaptchaData = array();
+        }
+
+        $normalizedData = array_merge(array(
+            'enabled' => 0,
+            'provider' => 'google',
+            'site_key' => '',
+            'secret_key' => '',
+            'turnstile_site_key' => '',
+            'turnstile_secret_key' => '',
+        ), $recaptchaData);
+
+        $normalizedData['enabled'] = (int)$normalizedData['enabled'];
+        $normalizedData['provider'] = in_array($normalizedData['provider'], array('google', 'turnstile')) ? $normalizedData['provider'] : 'google';
+        $normalizedData['site_key'] = (string)$normalizedData['site_key'];
+        $normalizedData['secret_key'] = (string)$normalizedData['secret_key'];
+        $normalizedData['turnstile_site_key'] = (string)$normalizedData['turnstile_site_key'];
+        $normalizedData['turnstile_secret_key'] = (string)$normalizedData['turnstile_secret_key'];
+
+        return $normalizedData;
+    }
+
+    public static function validateAuthCaptcha(array $postData, string $context): array
+    {
+        $captchaSettings = self::getCaptchaSettings();
+
+        if ((int)$captchaSettings['enabled'] !== 1) {
+            return array(
+                'valid' => true,
+                'provider' => $captchaSettings['provider'],
+                'reason' => 'disabled'
+            );
+        }
+
+        if ($captchaSettings['provider'] === 'google') {
+            if ($captchaSettings['site_key'] === '' || $captchaSettings['secret_key'] === '') {
+                return array(
+                    'valid' => false,
+                    'provider' => 'google',
+                    'reason' => 'config_missing'
+                );
+            }
+
+            $token = isset($postData['g-recaptcha']) ? trim((string)$postData['g-recaptcha']) : '';
+
+            if ($token === '') {
+                return array(
+                    'valid' => false,
+                    'provider' => 'google',
+                    'reason' => 'missing_token'
+                );
+            }
+
+            return self::verifyGoogleRecaptchaV3($captchaSettings['secret_key'], $token, $context);
+        }
+
+        if ($captchaSettings['provider'] === 'turnstile') {
+            if ($captchaSettings['turnstile_site_key'] === '' || $captchaSettings['turnstile_secret_key'] === '') {
+                return array(
+                    'valid' => false,
+                    'provider' => 'turnstile',
+                    'reason' => 'config_missing'
+                );
+            }
+
+            $token = isset($postData['cf-turnstile-response']) ? trim((string)$postData['cf-turnstile-response']) : '';
+
+            if ($token === '') {
+                return array(
+                    'valid' => false,
+                    'provider' => 'turnstile',
+                    'reason' => 'missing_token'
+                );
+            }
+
+            return self::verifyCloudflareTurnstile($captchaSettings['turnstile_secret_key'], $token, $context);
+        }
+
+        return array(
+            'valid' => false,
+            'provider' => 'unknown',
+            'reason' => 'provider_invalid'
+        );
+    }
+
+    public static function verifyGoogleRecaptchaV3(string $secretKey, string $token, string $context): array
+    {
+        $response = self::postCaptchaVerifyRequest('https://www.google.com/recaptcha/api/siteverify', array(
+            'secret' => $secretKey,
+            'response' => $token,
+        ));
+
+        if ($response['success'] !== true || !is_array($response['data'])) {
+            return array(
+                'valid' => false,
+                'provider' => 'google',
+                'reason' => 'request_failed'
+            );
+        }
+
+        $result = $response['data'];
+
+        if (!(isset($result['success']) && ($result['success'] == 1 || $result['success'] === true))) {
+            return array(
+                'valid' => false,
+                'provider' => 'google',
+                'reason' => 'provider_rejected'
+            );
+        }
+
+        if (!(isset($result['score']) && (float)$result['score'] >= 0.1)) {
+            return array(
+                'valid' => false,
+                'provider' => 'google',
+                'reason' => 'low_score'
+            );
+        }
+
+        if (!(isset($result['action']) && $result['action'] === $context)) {
+            return array(
+                'valid' => false,
+                'provider' => 'google',
+                'reason' => 'action_mismatch'
+            );
+        }
+
+        return array(
+            'valid' => true,
+            'provider' => 'google',
+            'reason' => 'validated'
+        );
+    }
+
+    public static function verifyCloudflareTurnstile(string $secretKey, string $token, string $context): array
+    {
+        $params = array(
+            'secret' => $secretKey,
+            'response' => $token,
+        );
+
+        $visitorIp = erLhcoreClassIPDetect::getIP();
+        if ($visitorIp !== '') {
+            $params['remoteip'] = $visitorIp;
+        }
+
+        $response = self::postCaptchaVerifyRequest('https://challenges.cloudflare.com/turnstile/v0/siteverify', $params);
+
+        if ($response['success'] !== true || !is_array($response['data'])) {
+            return array(
+                'valid' => false,
+                'provider' => 'turnstile',
+                'reason' => 'request_failed'
+            );
+        }
+
+        $result = $response['data'];
+
+        if (!(isset($result['success']) && ($result['success'] == 1 || $result['success'] === true))) {
+            return array(
+                'valid' => false,
+                'provider' => 'turnstile',
+                'reason' => 'provider_rejected'
+            );
+        }
+
+        if (isset($result['action']) && $result['action'] !== '' && $result['action'] !== $context) {
+            return array(
+                'valid' => false,
+                'provider' => 'turnstile',
+                'reason' => 'action_mismatch'
+            );
+        }
+
+        return array(
+            'valid' => true,
+            'provider' => 'turnstile',
+            'reason' => 'validated'
+        );
+    }
+
+    public static function postCaptchaVerifyRequest(string $url, array $params): array
+    {
+        if (!function_exists('curl_init')) {
+            return array(
+                'success' => false,
+                'data' => null,
+                'reason' => 'curl_missing'
+            );
+        }
+
+        $ch = curl_init();
+
+        if ($ch === false) {
+            return array(
+                'success' => false,
+                'data' => null,
+                'reason' => 'curl_init_failed'
+            );
+        }
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        @curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+
+        $responseBody = curl_exec($ch);
+
+        if ($responseBody === false) {
+            curl_close($ch);
+            return array(
+                'success' => false,
+                'data' => null,
+                'reason' => 'curl_exec_failed'
+            );
+        }
+
+        curl_close($ch);
+
+        $decodedResponse = json_decode($responseBody, true);
+
+        if (!is_array($decodedResponse)) {
+            return array(
+                'success' => false,
+                'data' => null,
+                'reason' => 'invalid_json'
+            );
+        }
+
+        return array(
+            'success' => true,
+            'data' => $decodedResponse
+        );
+    }
+
     public static function validateAliasDepartment(& $userDepAlias, $params = array())
     {
         $definition = array(

--- a/lhc_web/modules/lhinstall/install.php
+++ b/lhc_web/modules/lhinstall/install.php
@@ -1595,7 +1595,7 @@ try {
                 ('max_message_length','500',0,'Maximum message length in characters', '0'),
                 ('need_help_tip','1',0,'Show need help tooltip?', '0'),
                 ('unban_ip_range','','0','Which ip should not be allowed to be blocked','0'),
-                ('recaptcha_data','a:4:{i:0;b:0;s:8:\"site_key\";s:0:\"\";s:10:\"secret_key\";s:0:\"\";s:7:\"enabled\";i:0;}','0','Re-captcha configuration','1'),
+                ('recaptcha_data','a:7:{i:0;b:0;s:8:\"site_key\";s:0:\"\";s:10:\"secret_key\";s:0:\"\";s:7:\"enabled\";i:0;s:8:\"provider\";s:6:\"google\";s:18:\"turnstile_site_key\";s:0:\"\";s:20:\"turnstile_secret_key\";s:0:\"\";}','0','Re-captcha configuration','1'),
                 ('need_help_tip_timeout','24',0,'Need help tooltip timeout, after how many hours show again tooltip?', '0'),
                 ('use_secure_cookie','0',0,'Use secure cookie, check this if you want to force SSL all the time', '0'),
                 ('faq_email_required','0',0,'Is visitor e-mail required for FAQ', '0'),

--- a/lhc_web/modules/lhsystem/recaptcha.php
+++ b/lhc_web/modules/lhsystem/recaptcha.php
@@ -3,14 +3,23 @@
 $tpl = erLhcoreClassTemplate::getInstance( 'lhsystem/recaptcha.tpl.php');
 
 $rcData = erLhcoreClassModelChatConfig::fetch('recaptcha_data');
-$data = (array)$rcData->data;
+$data = erLhcoreClassUserValidator::getCaptchaSettings();
 
 if ( isset($_POST['StoreRecaptchaSettings']) ) {
     $definition = array(
+        'provider' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+        ),
         'site_key' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
         ),
         'secret_key' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+        ),
+        'turnstile_site_key' => new ezcInputFormDefinitionElement(
+            ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+        ),
+        'turnstile_secret_key' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
         ),
         'enabled' => new ezcInputFormDefinitionElement(
@@ -19,7 +28,7 @@ if ( isset($_POST['StoreRecaptchaSettings']) ) {
     );
 
     if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
-        erLhcoreClassModule::redirect('system/smtp');
+        erLhcoreClassModule::redirect('system/recaptcha');
         exit;
     }
 
@@ -28,14 +37,30 @@ if ( isset($_POST['StoreRecaptchaSettings']) ) {
     $form = new ezcInputForm( INPUT_POST, $definition );
     $Errors = array();
 
+    if ( $form->hasValidData( 'provider' ) && in_array($form->provider, array('google', 'turnstile'))) {
+        $data['provider'] = $form->provider;
+    } else {
+        $data['provider'] = 'google';
+    }
+
     if ( $form->hasValidData( 'site_key' )) {
-        $data['site_key'] = $form->site_key;
+        $data['site_key'] = trim($form->site_key);
     } else {
         $data['site_key'] = '';
     }
 
     if ($form->hasValidData( 'secret_key' ) && $form->secret_key != '') {
-        $data['secret_key'] = $form->secret_key;
+        $data['secret_key'] = trim($form->secret_key);
+    }
+
+    if ( $form->hasValidData( 'turnstile_site_key' )) {
+        $data['turnstile_site_key'] = trim($form->turnstile_site_key);
+    } else {
+        $data['turnstile_site_key'] = '';
+    }
+
+    if ($form->hasValidData( 'turnstile_secret_key' ) && $form->turnstile_secret_key != '') {
+        $data['turnstile_secret_key'] = trim($form->turnstile_secret_key);
     }
 
     if ( $form->hasValidData( 'enabled' ) && $form->enabled == 1) {
@@ -57,6 +82,6 @@ $tpl->set('rc_data',$data);
 
 $Result['content'] = $tpl->fetch();
 $Result['path'] = array(array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/htmlcode','System configuration')),
-    array('title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/smtp','Re-captcha settings')));
+    array('title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration','Captcha settings')));
 
 ?>

--- a/lhc_web/modules/lhuser/forgotpassword.php
+++ b/lhc_web/modules/lhuser/forgotpassword.php
@@ -53,31 +53,9 @@ if (isset($_POST['Forgotpassword'])) {
         $Errors[] =  erTranslationClassLhTranslation::getInstance()->getTranslation('user/forgotpassword','Invalid e-mail address!');
     }
 
-    $recaptchaData = erLhcoreClassModelChatConfig::fetch('recaptcha_data')->data_value;
-
-    if (is_array($recaptchaData) && isset($recaptchaData['enabled']) && $recaptchaData['enabled'] == 1) {
-        $params = [
-            'secret'    => $recaptchaData['secret_key'],
-            'response'  => $_POST['g-recaptcha']
-        ];
-
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, 'https://www.google.com/recaptcha/api/siteverify');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
-        curl_setopt($ch,CURLOPT_POST,1);
-        curl_setopt($ch,CURLOPT_POSTFIELDS,$params);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT , 5);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        @curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // Some hostings produces warning...
-        $res = curl_exec($ch);
-
-        $res = json_decode($res,true);
-
-        if (!(isset($res['success']) && $res['success'] == 1 && isset($res['score']) && $res['score'] >= 0.1 && $res['action'] == 'login_action')) {
-            $Errors[] = 'Invalid recaptcha!';
-        }
+    $captchaValidation = erLhcoreClassUserValidator::validateAuthCaptcha($_POST, 'forgot_password_action');
+    if ($captchaValidation['valid'] !== true) {
+        $Errors[] = erTranslationClassLhTranslation::getInstance()->getTranslation('user/login','Captcha validation failed');
     }
 
 	if (count($Errors) == 0) {

--- a/lhc_web/modules/lhuser/login.php
+++ b/lhc_web/modules/lhuser/login.php
@@ -107,33 +107,11 @@ if (isset($_POST['Login']))
         }
     } else {
 
-        $recaptchaData = erLhcoreClassModelChatConfig::fetch('recaptcha_data')->data_value;
-
         $valid = true;
 
-        if (is_array($recaptchaData) && isset($recaptchaData['enabled']) && $recaptchaData['enabled'] == 1) {
-           $params = [
-                'secret' 	=> $recaptchaData['secret_key'],
-                'response' 	=> $_POST['g-recaptcha']
-            ];
-
-            $ch = curl_init();
-            curl_setopt($ch, CURLOPT_URL, 'https://www.google.com/recaptcha/api/siteverify');
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
-            curl_setopt($ch,CURLOPT_POST,1);
-            curl_setopt($ch,CURLOPT_POSTFIELDS,$params);
-            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT , 5);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-            @curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // Some hostings produces warning...
-            $res = curl_exec($ch);
-
-            $res = json_decode($res,true);
-
-            if (!(isset($res['success']) && $res['success'] == 1 && isset($res['score']) && $res['score'] >= 0.1 && $res['action'] == 'login_action')) {
-                $valid = false;
-            }
+        $captchaValidation = erLhcoreClassUserValidator::validateAuthCaptcha($_POST, 'login_action');
+        if ($captchaValidation['valid'] !== true) {
+            $valid = false;
         }
 
         // Check IP restrictions for login
@@ -177,7 +155,7 @@ if (isset($_POST['Login']))
                 if (isset($validIP) && $validIP === false) {
                     $Error = erTranslationClassLhTranslation::getInstance()->getTranslation('user/login','You can not login because of IP restrictions');
                 } else {
-                    $Error = erTranslationClassLhTranslation::getInstance()->getTranslation('user/login','Google re-captcha validation failed');
+                    $Error = erTranslationClassLhTranslation::getInstance()->getTranslation('user/login','Captcha validation failed');
                 }
             } else {
 

--- a/lhc_web/translations/ar_EG/translation.ts
+++ b/lhc_web/translations/ar_EG/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>إعدادات الكابتشا</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>مفتاح الموقع</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>المفتاح السري</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>المفتاح السري غير معروض!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>إعدادات الكابتشا</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>موفر الكابتشا</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>يعمل هذا مع Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>احصل على مفاتيح Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>يعمل هذا مع Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>احصل على مفاتيح Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>فشل التحقق من الكابتشا</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/bg_BG/translation.ts
+++ b/lhc_web/translations/bg_BG/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Нов файл</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Настройки на captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Ключ за сайт</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Таен ключ</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Тайният ключ не се показва!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Настройки на captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Доставчик на captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Това работи с Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Вземете ключовете за Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Това работи с Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Вземете ключовете за Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Проверката на captcha бе неуспешна</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/ca_ES/translation.ts
+++ b/lhc_web/translations/ca_ES/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nou fitxer</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuració de captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Clau del lloc</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Clau secreta</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>La clau secreta no es mostra!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuració de captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Proveïdor de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Això funciona amb Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obtén les claus de Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Això funciona amb Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obtén les claus de Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>La validació del captcha ha fallat</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/cs_CS/translation.ts
+++ b/lhc_web/translations/cs_CS/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nový soubor</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Nastavení captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Tajný klíč není viditelný!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Nastavení captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Poskytovatel captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Toto funguje s Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Získat klíče Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Toto funguje s Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Získat klíče Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Neúspěšné přihlášení. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Ověření captcha selhalo</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/da_DA/translation.ts
+++ b/lhc_web/translations/da_DA/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Ny fil</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-indstillinger</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Webstedsnøgle</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Hemmelig nøgle</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Hemmelig nøgle vises ikke!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-indstillinger</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-udbyder</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Dette virker med Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Hent Google reCAPTCHA-nøgler</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Dette virker med Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Hent Cloudflare Turnstile-nøgler</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-validering mislykkedes</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/de_DE/translation.ts
+++ b/lhc_web/translations/de_DE/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Neue Datei</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-Einstellungen</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Geheimer Schlüssel wird verborgen!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-Einstellungen</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-Anbieter</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Dies funktioniert mit Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA-Schlüssel abrufen</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Dies funktioniert mit Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare-Turnstile-Schlüssel abrufen</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Anmeldung fehlgeschlagen. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-Validierung fehlgeschlagen</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/el_EL/translation.ts
+++ b/lhc_web/translations/el_EL/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Νέο αρχείο</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Ρυθμίσεις captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Κλειδί ιστότοπου</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Μυστικό κλειδί</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Το μυστικό κλειδί δεν εμφανίζεται!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Ρυθμίσεις captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Πάροχος captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Αυτό λειτουργεί με Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Λήψη κλειδιών Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Αυτό λειτουργεί με Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Λήψη κλειδιών Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Η επικύρωση captcha απέτυχε</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/en_EN/translation.ts
+++ b/lhc_web/translations/en_EN/translation.ts
@@ -1,1 +1,65 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="en"></TS>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS language="en">
+  <context>
+    <name>system/configuration</name>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha settings</translation>
+    </message>
+  </context>
+  <context>
+    <name>system/recaptcha</name>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha settings</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha provider</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>This works with Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Get Google reCAPTCHA keys</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>This works with Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Get Cloudflare Turnstile keys</translation>
+    </message>
+    <message>
+      <source>Site key</source>
+      <translation>Site key</translation>
+    </message>
+    <message>
+      <source>Secret key</source>
+      <translation>Secret key</translation>
+    </message>
+    <message>
+      <source>Secret key is not shown!</source>
+      <translation>Secret key is not shown!</translation>
+    </message>
+  </context>
+  <context>
+    <name>user/login</name>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha validation failed</translation>
+    </message>
+  </context>
+</TS>

--- a/lhc_web/translations/es_CO/translation.ts
+++ b/lhc_web/translations/es_CO/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nuevo archivo</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuración de captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>¡No se muestra la clave secreta!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuración de captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Proveedor de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Esto funciona con Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obtener claves de Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Esto funciona con Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obtener claves de Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Failed login. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>La validación del captcha falló</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/es_MX/translation.ts
+++ b/lhc_web/translations/es_MX/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nuevo archivo</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuración de captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>¡No se muestra la clave secreta!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configuración de captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Proveedor de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Esto funciona con Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obtener claves de Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Esto funciona con Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obtener claves de Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Falló el acceso. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>La validación del captcha falló</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/fa_FA/translation.ts
+++ b/lhc_web/translations/fa_FA/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>فایل جدید</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>تنظیمات کپچا</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Secret key نمایش داده نمی شود!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>تنظیمات کپچا</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>ارائه دهنده کپچا</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>این با Google reCAPTCHA v3 کار می کند.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>دریافت کلیدهای Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>این با Cloudflare Turnstile کار می کند.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>دریافت کلیدهای Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>اعتبارسنجی کپچا ناموفق بود</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/fi_FI/translation.ts
+++ b/lhc_web/translations/fi_FI/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Uusi tiedosto</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-asetukset</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Sivustoavain</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Salainen avain</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Salaista avainta ei näytetä!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-asetukset</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-palveluntarjoaja</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Tämä toimii Google reCAPTCHA v3:n kanssa.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Hae Google reCAPTCHA -avaimet</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Tämä toimii Cloudflare Turnstilen kanssa.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Hae Cloudflare Turnstile -avaimet</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-vahvistus epäonnistui</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/fr_FR/translation.ts
+++ b/lhc_web/translations/fr_FR/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nouveau fichier</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Paramètres captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>La clé secrète n&apos;est pas affichée !</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Paramètres captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Fournisseur de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Cela fonctionne avec Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obtenir les clés Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Cela fonctionne avec Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obtenir les clés Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Échec de la connexion. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Échec de la validation du captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/he_HE/translation.ts
+++ b/lhc_web/translations/he_HE/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>קובץ חדש</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>הגדרות captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>מפתח אתר</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>מפתח סודי</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>המפתח הסודי אינו מוצג!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>הגדרות captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>ספק captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>זה עובד עם Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>קבל מפתחות Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>זה עובד עם Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>קבל מפתחות Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>אימות captcha נכשל</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/hr_HR/translation.ts
+++ b/lhc_web/translations/hr_HR/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nova datoteka</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Postavke captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Ključ web-mjesta</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Tajni ključ</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Tajni ključ nije prikazan!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Postavke captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Pružatelj captcha usluge</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Ovo radi s Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Preuzmi Google reCAPTCHA ključeve</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Ovo radi s Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Preuzmi Cloudflare Turnstile ključeve</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha provjera nije uspjela</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/hu_HU/translation.ts
+++ b/lhc_web/translations/hu_HU/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Új fájl</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha beállítások</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>A titkos kulcs nem jelenik meg</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha beállítások</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha szolgáltató</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Ez Google reCAPTCHA v3-mal működik.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA kulcsok lekérése</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Ez Cloudflare Turnstile-lel működik.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare Turnstile kulcsok lekérése</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Sikertelen bejelentkezés (XML_CHECK_LOGIN)</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>A captcha érvényesítése sikertelen</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/id_ID/translation.ts
+++ b/lhc_web/translations/id_ID/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>File baru</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Pengaturan captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Kunci situs</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Kunci rahasia</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Kunci rahasia tidak ditampilkan!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Pengaturan captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Penyedia captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Ini berfungsi dengan Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Dapatkan kunci Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Ini berfungsi dengan Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Dapatkan kunci Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Validasi captcha gagal</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/it_IT/translation.ts
+++ b/lhc_web/translations/it_IT/translation.ts
@@ -15865,6 +15865,11 @@ Icona colonna, testo icone materiale</translation>
       <source>New file</source>
       <translation>Nuovo file</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Impostazioni captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23577,6 +23582,39 @@ Icona colonna, testo icone materiale</translation>
       <source>Secret key is not shown!</source>
       <translation>La chiave segreta non viene mostrata!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Impostazioni captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Provider captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Funziona con Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Ottieni le chiavi Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Funziona con Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Ottieni le chiavi Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24365,6 +24403,11 @@ Icona colonna, testo icone materiale</translation>
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Accesso fallito. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Convalida captcha non riuscita</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/ja_JP/translation.ts
+++ b/lhc_web/translations/ja_JP/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>新規ファイル</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>CAPTCHA設定</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>秘密鍵は表示されない！</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>CAPTCHA設定</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>CAPTCHA プロバイダー</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>これは Google reCAPTCHA v3 で動作します。</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA キーを取得</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>これはCloudflare Turnstileで動作します。</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare Turnstile キーを取得</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>ログインに失敗しました。xml_check_login</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>CAPTCHA の検証に失敗しました</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/ka_KA/translation.ts
+++ b/lhc_web/translations/ka_KA/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>ახალი ფაილი</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-ის პარამეტრები</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>საიტის გასაღები</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>საიდუმლო გასაღები</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>საიდუმლო გასაღები არ არის ნაჩვენები!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-ის პარამეტრები</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-ის მომწოდებელი</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>ეს მუშაობს Google reCAPTCHA v3-თან.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA გასაღებების მიღება</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>ეს მუშაობს Cloudflare Turnstile-თან.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare Turnstile გასაღებების მიღება</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-ის ვალიდაცია ვერ მოხერხდა</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/lt_LT/translation.ts
+++ b/lhc_web/translations/lt_LT/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Naujas failas</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha nustatymai</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Svetainės raktas</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Slaptasis raktas</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Slaptasis raktas nerodomas!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha nustatymai</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha tiekėjas</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Tai veikia su Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Gauti Google reCAPTCHA raktus</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Tai veikia su Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Gauti Cloudflare Turnstile raktus</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha patvirtinimas nepavyko</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/nl_NL/translation.ts
+++ b/lhc_web/translations/nl_NL/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nieuw bestand</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-instellingen</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Sitesleutel</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Geheime sleutel</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Geheime sleutel wordt niet weergegeven!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-instellingen</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-provider</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Dit werkt met Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA-sleutels ophalen</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Dit werkt met Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare Turnstile-sleutels ophalen</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-validatie mislukt</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/no_NO/translation.ts
+++ b/lhc_web/translations/no_NO/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-innstillinger</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Nettstedsnøkkel</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Hemmelig nøkkel</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Hemmelig nøkkel vises ikke!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-innstillinger</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-leverandør</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Dette fungerer med Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Hent Google reCAPTCHA-nøkler</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Dette fungerer med Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Hent Cloudflare Turnstile-nøkler</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-validering mislyktes</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/pl_PL/translation.ts
+++ b/lhc_web/translations/pl_PL/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nowy plik</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Ustawienia captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Tajny klucz nie jest wyświetlany!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Ustawienia captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Dostawca captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>To działa z Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Pobierz klucze Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>To działa z Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Pobierz klucze Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Logowanie nie powiodło się. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Walidacja captcha nie powiodła się</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/pt_BR/translation.ts
+++ b/lhc_web/translations/pt_BR/translation.ts
@@ -15860,6 +15860,11 @@
       <source>New file</source>
       <translation>Novo arquivo</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configurações de captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23572,6 +23577,39 @@
       <source>Secret key is not shown!</source>
       <translation>A chave secreta não é exibida!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Configurações de captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Provedor de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Funciona com o Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obter chaves do Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Funciona com o Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obter chaves do Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24360,6 +24398,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Falha no login. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Falha na validação do captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/pt_PT/translation.ts
+++ b/lhc_web/translations/pt_PT/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Novo arquivo</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Definições de captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>A chave secreta não é exibida!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Definições de captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Provedor de captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Isto funciona com o Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obter chaves do Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Isto funciona com o Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obter chaves do Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Falha na validação do captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/ro_RO/translation.ts
+++ b/lhc_web/translations/ro_RO/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Fișier nou</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Setări captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Cheia secretă nu este afișată!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Setări captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Furnizor captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Acest lucru funcționează cu Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Obțineți cheile Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Acest lucru funcționează cu Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Obțineți cheile Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Conectare nereușită. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Validarea captcha a eșuat</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/ru_RU/translation.ts
+++ b/lhc_web/translations/ru_RU/translation.ts
@@ -15860,6 +15860,11 @@
       <source>New file</source>
       <translation>Новый файл</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Настройки captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23572,6 +23577,39 @@
       <source>Secret key is not shown!</source>
       <translation>Секретный ключ не отображается!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Настройки captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Провайдер captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Это работает с Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Получить ключи Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Это работает с Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Получить ключи Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24360,6 +24398,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Не удалось войти в систему. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Проверка captcha не прошла</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/sk_SK/translation.ts
+++ b/lhc_web/translations/sk_SK/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Nový súbor</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Nastavenia captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Kľúč webu</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Tajný kľúč</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Tajný kľúč sa nezobrazuje!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Nastavenia captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Poskytovateľ captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Toto funguje s Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Získať kľúče Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Toto funguje s Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Získať kľúče Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Overenie captcha zlyhalo</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/sq_AL/translation.ts
+++ b/lhc_web/translations/sq_AL/translation.ts
@@ -15860,6 +15860,11 @@
       <source>New file</source>
       <translation>Skedar i ri</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Cilësimet e captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23562,16 +23567,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Çelësi i faqes</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Çelësi sekret</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Çelësi sekret nuk shfaqet!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Cilësimet e captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Ofruesi i captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Kjo funksionon me Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Merr çelësat e Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Kjo funksionon me Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Merr çelësat e Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24360,6 +24398,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Verifikimi i captcha dështoi</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/sv_SV/translation.ts
+++ b/lhc_web/translations/sv_SV/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Ny fil</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-inställningar</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Webbplatsnyckel</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Hemlig nyckel</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Den hemliga nyckeln visas inte!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha-inställningar</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha-leverantör</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Detta fungerar med Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Hämta Google reCAPTCHA-nycklar</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Detta fungerar med Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Hämta Cloudflare Turnstile-nycklar</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha-valideringen misslyckades</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/th_TH/translation.ts
+++ b/lhc_web/translations/th_TH/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>การตั้งค่า captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>คีย์ไซต์</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>คีย์ลับ</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>ไม่แสดงคีย์ลับ!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>การตั้งค่า captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>ผู้ให้บริการ captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>ใช้งานได้กับ Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>รับคีย์ Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>ใช้งานได้กับ Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>รับคีย์ Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>การตรวจสอบ captcha ล้มเหลว</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/tr_TR/translation.ts
+++ b/lhc_web/translations/tr_TR/translation.ts
@@ -15861,6 +15861,11 @@
       <source>New file</source>
       <translation>Yeni dosya</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha ayarları</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23573,6 +23578,39 @@
       <source>Secret key is not shown!</source>
       <translation>Gizli anahtar gösterilmiyor!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Captcha ayarları</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Captcha sağlayıcısı</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Bu, Google reCAPTCHA v3 ile çalışır.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Google reCAPTCHA anahtarlarını alın</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Bu, Cloudflare Turnstile ile çalışır.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Cloudflare Turnstile anahtarlarını alın</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24361,6 +24399,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Giriş başarısız. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Captcha doğrulaması başarısız oldu</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/uk_UK/translation.ts
+++ b/lhc_web/translations/uk_UK/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Новий файл</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Налаштування captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>Секретний ключ не відображається!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Налаштування captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Постачальник captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Це працює з Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Отримайте ключі Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Це працює з Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Отримайте ключі Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation>Помилка входу. XML_CHECK_LOGIN</translation>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Перевірка captcha не пройшла</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/vi_VN/translation.ts
+++ b/lhc_web/translations/vi_VN/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>Tập tin mới</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Cài đặt captcha</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>Khóa trang web</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>Khóa bí mật</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>Không hiển thị khóa bí mật!</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>Cài đặt captcha</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>Nhà cung cấp captcha</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>Tính năng này hoạt động với Google reCAPTCHA v3.</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>Lấy khóa Google reCAPTCHA</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>Tính năng này hoạt động với Cloudflare Turnstile.</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>Lấy khóa Cloudflare Turnstile</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>Xác thực captcha thất bại</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/zh_CN/translation.ts
+++ b/lhc_web/translations/zh_CN/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>新增档案</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>验证码设置</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>不显示密钥！</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>验证码设置</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>验证码提供商</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>这适用于V3验证码。</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>获取验证码</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>这适用于 Cloudflare Turnstile。</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>获取 Cloudflare Turnstile 密钥</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>验证码验证失败</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/zh_HK/translation.ts
+++ b/lhc_web/translations/zh_HK/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>新增檔案</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>驗證碼設置</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>不顯示密鑰！</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>驗證碼設置</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>驗證碼供應商</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>這適用於V3驗證碼。</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>獲取驗證碼</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>這適用於 Cloudflare Turnstile。</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>取得 Cloudflare Turnstile 金鑰</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>驗證碼驗證失敗</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/zh_TW/translation.ts
+++ b/lhc_web/translations/zh_TW/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>新增檔案</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>驗證碼設置</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23571,6 +23576,39 @@
       <source>Secret key is not shown!</source>
       <translation>不顯示密鑰！</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>驗證碼設置</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>驗證碼供應商</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>這適用於V3驗證碼。</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>獲取驗證碼</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>這適用於 Cloudflare Turnstile。</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>取得 Cloudflare Turnstile 金鑰</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>驗證碼驗證失敗</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>

--- a/lhc_web/translations/zh_ZH/translation.ts
+++ b/lhc_web/translations/zh_ZH/translation.ts
@@ -15859,6 +15859,11 @@
       <source>New file</source>
       <translation>新的文件</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>验证码设置</translation>
+    </message>
+
   </context>
   <context>
     <name>chat/listchatconfig</name>
@@ -23561,16 +23566,49 @@
     </message>
     <message>
       <source>Site key</source>
-      <translation type="unfinished"/>
+      <translation>站点密钥</translation>
     </message>
     <message>
       <source>Secret key</source>
-      <translation type="unfinished"/>
+      <translation>机密密钥</translation>
     </message>
     <message>
       <source>Secret key is not shown!</source>
-      <translation type="unfinished"/>
+      <translation>机密密钥不会显示！</translation>
     </message>
+    <message>
+      <source>Captcha settings</source>
+      <translation>验证码设置</translation>
+    </message>
+    <message>
+      <source>Captcha provider</source>
+      <translation>验证码提供商</translation>
+    </message>
+    <message>
+      <source>Google reCAPTCHA v3</source>
+      <translation>Google reCAPTCHA v3</translation>
+    </message>
+    <message>
+      <source>Cloudflare Turnstile</source>
+      <translation>Cloudflare Turnstile</translation>
+    </message>
+    <message>
+      <source>This works with Google reCAPTCHA v3.</source>
+      <translation>此功能适用于 Google reCAPTCHA v3。</translation>
+    </message>
+    <message>
+      <source>Get Google reCAPTCHA keys</source>
+      <translation>获取 Google reCAPTCHA 密钥</translation>
+    </message>
+    <message>
+      <source>This works with Cloudflare Turnstile.</source>
+      <translation>此功能适用于 Cloudflare Turnstile。</translation>
+    </message>
+    <message>
+      <source>Get Cloudflare Turnstile keys</source>
+      <translation>获取 Cloudflare Turnstile 密钥</translation>
+    </message>
+
   </context>
   <context>
     <name>system/transferconfiguration</name>
@@ -24359,6 +24397,11 @@
       <source>Failed login. XML_CHECK_LOGIN</source>
       <translation type="unfinished"/>
     </message>
+    <message>
+      <source>Captcha validation failed</source>
+      <translation>验证码验证失败</translation>
+    </message>
+
   </context>
   <context>
     <name>notifications/accounts</name>


### PR DESCRIPTION
- Add centralized captcha settings/validation methods in `erLhcoreClassUserValidator`:
  `getCaptchaSettings`, `validateAuthCaptcha`, `verifyGoogleRecaptchaV3`,
  `verifyCloudflareTurnstile`, and `postCaptchaVerifyRequest`.
- Replace inline captcha verification in `modules/lhuser/login.php` and
  `modules/lhuser/forgotpassword.php` with shared validation.
- Update auth captcha error handling to use the generic string
  `Captcha validation failed`.
- Extend `system/recaptcha` admin handling with provider support (`google`/`turnstile`),
  new Turnstile fields, and CSRF redirect fix to `system/recaptcha`.
- Update captcha admin template with provider selector and provider-specific sections;
  use shared key labels (`Site key` / `Secret key`) in both provider blocks.
- Update shared captcha rendering template to support:
  Google v3 token flow and Cloudflare Turnstile widget flow.
- Set explicit captcha actions in auth templates:
  `login_action` and `forgot_password_action`.
- Update install defaults (`modules/lhinstall/install.php`, `cli/lib/install.php`)
  to include provider and Turnstile keys in `recaptcha_data`.
- Update translation catalogs (`doc/translation_default/translation_web.ts`,
  `translations/*/translation.ts`, including `translations/en_EN/translation.ts`)
  with the new captcha-related keys used by these changes.
