### PR TITLE
refactor: modernize syntax and simplify code

### DIFF
--- a/lhc_web/cli/lib/install.php
+++ b/lhc_web/cli/lib/install.php
@@ -16,20 +16,20 @@ class Install
     }
 
     function step1() {
-        $Errors = array();
+        $Errors = []
         $directories = $this->_scandir('cache');
-        $this->file_is_writable(array('cache'),'', $Errors);
+        $this->file_is_writable(['cache'],'', $Errors);
         $this->file_is_writable($directories, 'cache/', $Errors);
-        $this->file_is_writable(array('settings'), '', $Errors);
-        $var_directories = array(
+        $this->file_is_writable(['settings'], '', $Errors);
+        $var_directories = [
             'var/storage',
             'var/storageform',
             'var/storagetheme',
             'var/storageadmintheme',
             'var/tmpfiles',
             'var/userphoto',
-        );
-        $this->file_is_writable(array('var'),'', $Errors);
+        ];
+        $this->file_is_writable(['var'],'', $Errors);
         $this->file_is_writable($var_directories, '', $Errors);
 
         if (!extension_loaded ('pdo_mysql' ))
@@ -59,7 +59,7 @@ class Install
     }
 
     function step2() {
-        $Errors = array();
+        $Errors = []
         $database = $this->settings['db'];
         foreach ($database as $key => $value) {
             if (!filter_var($database[$key], FILTER_UNSAFE_RAW)) {
@@ -82,9 +82,9 @@ class Install
         if (count($Errors) == 0) {
             $cfgSite = erConfigClassLhConfig::getInstance();
             foreach ($database as $key => $value) {
-                $cfgSite->setSetting( 'db', $key, $value);
+                $cfgSite->setSetting('db', $key, $value);
             }
-            $cfgSite->setSetting( 'site', 'secrethash', erLhcoreClassChat::generateHash(80));
+            $cfgSite->setSetting('site', 'secrethash', erLhcoreClassChat::generateHash(80));
             return true;
         } else {
             return $Errors;
@@ -93,7 +93,7 @@ class Install
 
     function step3() {
 
-        $Errors = array();
+        $Errors = [];
 
         $form = (object)$this->settings['admin'];
         if (!filter_var($form->AdminUsername, FILTER_UNSAFE_RAW))
@@ -2234,56 +2234,56 @@ class Install
             erLhcoreClassRole::getSession()->save($RoleFunction);
 
             // Operators rules and functions
-            $permissionsArray = array(
-                array('module' => 'lhuser',  'function' => 'selfedit'),
-                array('module' => 'lhuser',  'function' => 'changeonlinestatus'),
-                array('module' => 'lhuser',  'function' => 'changeskypenick'),
-                array('module' => 'lhuser',  'function' => 'personalcannedmsg'),
-                array('module' => 'lhuser',  'function' => 'change_visibility_list'),
-                array('module' => 'lhuser',  'function' => 'see_assigned_departments'),
-                array('module' => 'lhuser',  'function' => 'canseedepartmentstats'),
-                array('module' => 'lhchat',  'function' => 'use'),
-                array('module' => 'lhchat',  'function' => 'open_all'),
-                array('module' => 'lhchat',  'function' => 'chattabschrome'),
-                array('module' => 'lhchat',  'function' => 'singlechatwindow'),
-                array('module' => 'lhchat',  'function' => 'allowopenremotechat'),
-                array('module' => 'lhchat',  'function' => 'writeremotechat'),
-                array('module' => 'lhchat',  'function' => 'allowchattabs'),
-                array('module' => 'lhchat',  'function' => 'use_onlineusers'),
-                array('module' => 'lhchat',  'function' => 'take_screenshot'),
-                array('module' => 'lhfront', 'function' => 'use'),
-                array('module' => 'lhchat', 'function' => 'prev_chats'),
-                array('module' => 'lhsystem','function' => 'use'),
-                array('module' => 'lhcannedmsg', 'function' => 'see_global'),
-                array('module' => 'lhtranslation','function' => 'use'),
-                array('module' => 'lhchat',  'function' => 'allowblockusers'),
-                array('module' => 'lhsystem','function' => 'generatejs'),
-                array('module' => 'lhsystem','function' => 'changelanguage'),
-                array('module' => 'lhchat',  'function' => 'allowredirect'),
-                array('module' => 'lhchat',  'function' => 'allowtransfer'),
-                array('module' => 'lhchat',  'function' => 'allowtransferdirectly'),
-                array('module' => 'lhchat',  'function' => 'administratecannedmsg'),
-                array('module' => 'lhchat',  'function' => 'sees_all_online_visitors'),
-                array('module' => 'lhpermission',   'function' => 'see_permissions'),
-                array('module' => 'lhquestionary',  'function' => 'manage_questionary'),
-                array('module' => 'lhfaq',   		'function' => 'manage_faq'),
-                array('module' => 'lhchatbox',   	'function' => 'manage_chatbox'),
-                array('module' => 'lhbrowseoffer',  'function' => 'manage_bo'),
-                array('module' => 'lhxml',   		'function' => '*'),
-                array('module' => 'lhcobrowse',   	'function' => 'browse'),
-                array('module' => 'lhfile',   		'function' => 'use_operator'),
-                array('module' => 'lhfile',   		'function' => 'file_delete_chat'),
-                array('module' => 'lhstatistic',   	'function' => 'use'),
-                array('module' => 'lhspeech', 'function' => 'changedefaultlanguage'),
-                array('module' => 'lhspeech', 'function' => 'use'),
-                array('module' => 'lhcannedmsg', 'function' => 'use'),
-                array('module' => 'lhtheme', 'function' => 'personaltheme'),
-                array('module' => 'lhuser', 'function' => 'userlistonline'),
-                array('module' => 'lhspeech', 'function' => 'change_chat_recognition'),
-                array('module' => 'lhgroupchat', 'function' => 'use'),
-                array('module' => 'lhuser', 'function' => 'see_all_group_users'),
-                array('module' => 'lhvoicevideo', 'function' => 'use'),
-            );
+            $permissionsArray = [
+                ['module' => 'lhuser',        'function' => 'selfedit'],
+                ['module' => 'lhuser',        'function' => 'changeonlinestatus'],
+                ['module' => 'lhuser',        'function' => 'changeskypenick'],
+                ['module' => 'lhuser',        'function' => 'personalcannedmsg'],
+                ['module' => 'lhuser',        'function' => 'change_visibility_list'],
+                ['module' => 'lhuser',        'function' => 'see_assigned_departments'],
+                ['module' => 'lhuser',        'function' => 'canseedepartmentstats'],
+                ['module' => 'lhchat',        'function' => 'use'],
+                ['module' => 'lhchat',        'function' => 'open_all'],
+                ['module' => 'lhchat',        'function' => 'chattabschrome'],
+                ['module' => 'lhchat',        'function' => 'singlechatwindow'],
+                ['module' => 'lhchat',        'function' => 'allowopenremotechat'],
+                ['module' => 'lhchat',        'function' => 'writeremotechat'],
+                ['module' => 'lhchat',        'function' => 'allowchattabs'],
+                ['module' => 'lhchat',        'function' => 'use_onlineusers'],
+                ['module' => 'lhchat',        'function' => 'take_screenshot'],
+                ['module' => 'lhfront',       'function' => 'use'],
+                ['module' => 'lhchat',        'function' => 'prev_chats'],
+                ['module' => 'lhsystem',      'function' => 'use'],
+                ['module' => 'lhcannedmsg',   'function' => 'see_global'],
+                ['module' => 'lhtranslation', 'function' => 'use'],
+                ['module' => 'lhchat',        'function' => 'allowblockusers'],
+                ['module' => 'lhsystem',      'function' => 'generatejs'],
+                ['module' => 'lhsystem',      'function' => 'changelanguage'],
+                ['module' => 'lhchat',        'function' => 'allowredirect'],
+                ['module' => 'lhchat',        'function' => 'allowtransfer'],
+                ['module' => 'lhchat',        'function' => 'allowtransferdirectly'],
+                ['module' => 'lhchat',        'function' => 'administratecannedmsg'],
+                ['module' => 'lhchat',        'function' => 'sees_all_online_visitors'],
+                ['module' => 'lhpermission',  'function' => 'see_permissions'],
+                ['module' => 'lhquestionary', 'function' => 'manage_questionary'],
+                ['module' => 'lhfaq',   	  'function' => 'manage_faq'],
+                ['module' => 'lhchatbox',     'function' => 'manage_chatbox'],
+                ['module' => 'lhbrowseoffer', 'function' => 'manage_bo'],
+                ['module' => 'lhxml',   	  'function' => '*'],
+                ['module' => 'lhcobrowse',    'function' => 'browse'],
+                ['module' => 'lhfile',   	  'function' => 'use_operator'],
+                ['module' => 'lhfile',   	  'function' => 'file_delete_chat'],
+                ['module' => 'lhstatistic',   'function' => 'use'],
+                ['module' => 'lhspeech',      'function' => 'changedefaultlanguage'],
+                ['module' => 'lhspeech',      'function' => 'use'],
+                ['module' => 'lhcannedmsg',   'function' => 'use'],
+                ['module' => 'lhtheme',       'function' => 'personaltheme'],
+                ['module' => 'lhuser',        'function' => 'userlistonline'],
+                ['module' => 'lhspeech',      'function' => 'change_chat_recognition'],
+                ['module' => 'lhgroupchat',   'function' => 'use'],
+                ['module' => 'lhuser',        'function' => 'see_all_group_users'],
+                ['module' => 'lhvoicevideo',  'function' => 'use'],
+            ];
 
             foreach ($permissionsArray as $paramsPermission) {
                 $RoleFunctionOperator = new erLhcoreClassModelRoleFunction();
@@ -2294,31 +2294,31 @@ class Install
             }
 
             $cfgSite = erConfigClassLhConfig::getInstance();
-            $cfgSite->setSetting( 'site', 'installed', true);
-            $cfgSite->setSetting( 'site', 'templatecache', true);
-            $cfgSite->setSetting( 'site', 'templatecompile', true);
-            $cfgSite->setSetting( 'site', 'modulecompile', true);
-            $cfgSite->setSetting( 'site', 'force_virtual_host', $form->ForceVirtualHost == 1);
-            $cfgSite->setSetting( 'webhooks', 'enabled', isset($form->WebhooksEnabled) &&$form->WebhooksEnabled == 1);
-            $cfgSite->setSetting( 'webhooks', 'worker', isset($form->WebhooksWorker) ? $form->WebhooksWorker : 'http');
+            $cfgSite->setSetting('site', 'installed', true);
+            $cfgSite->setSetting('site', 'templatecache', true);
+            $cfgSite->setSetting('site', 'templatecompile', true);
+            $cfgSite->setSetting('site', 'modulecompile', true);
+            $cfgSite->setSetting('site', 'force_virtual_host', $form->ForceVirtualHost == 1);
+            $cfgSite->setSetting('webhooks', 'enabled', isset($form->WebhooksEnabled) &&$form->WebhooksEnabled == 1);
+            $cfgSite->setSetting('webhooks', 'worker', isset($form->WebhooksWorker) ? $form->WebhooksWorker : 'http');
             
             if ($form->Extensions != '') {
                 $extensions = explode(',',str_replace(' ','',$form->Extensions));
                 if (!empty($extensions) ) {
-                    $cfgSite->setSetting( 'site', 'extensions', $extensions);
+                    $cfgSite->setSetting('site', 'extensions', $extensions);
                 }
             }
 
             if ($form->ApacheUserGroupName != '') {
-                $cfgSite->setSetting( 'site', 'default_group', $form->ApacheUserGroupName);
+                $cfgSite->setSetting('site', 'default_group', $form->ApacheUserGroupName);
             }
 
             if ($form->ApacheUserName != '') {
-                $cfgSite->setSetting( 'site', 'default_user', $form->ApacheUserName);
+                $cfgSite->setSetting('site', 'default_user', $form->ApacheUserName);
             }
 
             if ($form->TimeZone != '') {
-                $cfgSite->setSetting( 'site', 'time_zone', $form->TimeZone);
+                $cfgSite->setSetting('site', 'time_zone', $form->TimeZone);
             }
 
             if (isset($form->DefaultConfigs) && is_array($form->DefaultConfigs)) {
@@ -2333,10 +2333,12 @@ class Install
 
             $smtpData = erLhcoreClassModelChatConfig::fetch('smtp_data');
 
-            $data = (array)$smtpData->data;
-            $data['default_from'] = 'info@'.$form->Domain;
-            $data['default_from_name'] = trim($form->AdminName . ' ' . $form->AdminSurname);
-            $data['sender'] = 'info@'.$form->Domain;
+            $data = [
+                ...(array) $smtpData->data,
+                'default_from' => "info@$form->Domain",
+                'default_from_name' => trim("$form->AdminName $form->AdminSurname"),
+                'sender' => "info@$form->Domain"
+            ];
 
             $smtpData->value = serialize($data);
             $smtpData->saveThis();
@@ -2356,7 +2358,7 @@ class Install
 
     function print_errors($errors) {
         foreach($errors as $error) {
-            syslog(LOG_ERR, "ERROR: ".$error);
+            syslog(LOG_ERR, "ERROR: $error");
         }
         exit(-1);
     }
@@ -2374,9 +2376,9 @@ class Install
         foreach ($directories as $directory) {
             $error = false;
             syslog(LOG_DEBUG, "Evaluate $directory if writable");
-            $owner = fileowner($preffix.$directory);
-            $group = filegroup($preffix.$directory);
-            $permission = $this->file_perms($preffix.$directory);
+            $owner = fileowner("{$preffix}{$directory}");
+            $group = filegroup("{$preffix}{$directory}");
+            $permission = $this->file_perms("{$preffix}{$directory}");
             if ($permission[2] == 7) {
                 continue;
             }
@@ -2387,7 +2389,7 @@ class Install
                 $error = true;
             }
             if ($error) {
-                $Errors[] = $preffix.$directory." is not writable";
+                $Errors[] = "{$preffix}{$directory} is not writable";
             }
         }
     }

--- a/lhc_web/doc/autologin/autologin.php
+++ b/lhc_web/doc/autologin/autologin.php
@@ -2,8 +2,8 @@
 
 function generateAutoLoginLink($params){
     
-     $dataRequest = array();
-     $dataRequestAppend = array();
+     $dataRequest = [];
+     $dataRequestAppend = [];
      
      // Destination ID
      if (isset($params['r'])){
@@ -40,4 +40,4 @@ function generateAutoLoginLink($params){
 
 ?>
 
-<a target="_blank" href="http://dev.livehelperchat.com/<?php echo generateAutoLoginLink(array('r' => 'chat/chattabs', 'u' => 1,/* 'l' => 'admin', *//* 't' => time() + 50000 */ 'secret_hash' => '12456456456456fghfghfghfgh'))?>">Login me</a>
+<a target="_blank" href="http://dev.livehelperchat.com/<?php echo generateAutoLoginLink(['r' => 'chat/chattabs', 'u' => 1,/* 'l' => 'admin', *//* 't' => time() + 50000 */ 'secret_hash' => '12456456456456fghfghfghfgh'])?>">Login me</a>

--- a/lhc_web/doc/rest_api/example.php
+++ b/lhc_web/doc/rest_api/example.php
@@ -5,13 +5,13 @@ include 'lhrestapi.php';
 $LHCRestAPI = new LHCRestAPI('<address>', '<username>', '<apikey>');
 
 // Set operator status online or offline
-$response = $LHCRestAPI->execute('setoperatorstatus', array(
+$response = $LHCRestAPI->execute('setoperatorstatus', [
     'status' => 'false', // false - offline, true - online
     // Any argument of below has to be provided
     //'user_id' => '1',
     //'username' => 'admin'
     'email' => 'remdex@gmail.com',
-), true);
+], true);
 print_r($response);
 
 /* 
@@ -25,36 +25,32 @@ print_r($response);
 */
 
 // Fetch chats
-$response = $LHCRestAPI->execute('chats', array(
+$response = $LHCRestAPI->execute('chats', [
     'status' => 1,
     'departament_id' => 5,
     'user_id' => 1,
     'update_activity' => 1 // Forces to update last acitivity, can be used with any call <optional>
-));
+]);
 print_r($response);
 
 // Returns departments
-$response = $LHCRestAPI->execute('departaments', array(   
-));
+$response = $LHCRestAPI->execute('departaments', []);
 print_r($response);
 
 // Fetch chat
-$response = $LHCRestAPI->execute('fetchchat', array(   
-    'chat_id' => 5388
-));
+$response = $LHCRestAPI->execute('fetchchat', ['chat_id' => 5388]);
 print_r($response);
 
-$response = $LHCRestAPI->execute('fetchchatmessages', array(   
+$response = $LHCRestAPI->execute('fetchchatmessages', [
     'chat_id' => 5388,
     'last_message_id' => 3203, // Optional, return messages from this <optional>
-));
+]);
 print_r($response);
 
 // Examples with XML
-$response = $LHCRestAPI->execute('fetchchatmessages', array(
+$response = $LHCRestAPI->execute('fetchchatmessages', [
     'chat_id' => 6724,
     'last_message_id' => 0, // Optional, return messages from this <optional>
     'format' => 'xml'
-),array(),'GET',false);
+],[],'GET',false);
 print_r($response);
-

--- a/lhc_web/doc/rest_api/lhrestapi.php
+++ b/lhc_web/doc/rest_api/lhrestapi.php
@@ -28,17 +28,17 @@ class LHCRestAPI
      *
      * @return string
      */
-    private function executeRequest($function, $params, $uparams = array(), $method = 'GET', $manualAppend = '')
+    private function executeRequest($function, $params, $uparams = [], $method = 'GET', $manualAppend = '')
     {
         $ch = curl_init();
-        $headers = array('Accept' => 'application/json');
+        $headers = ['Accept' => 'application/json'];
 
         $uparamsArg = '';
 
         if (!empty($uparams) && is_array($uparams)) {
-            $parts = array();
+            $parts = [];
             foreach ($uparams as $param => $value) {
-                $parts[] = '/(' . $param . ')/' . $value;
+                $parts[] = "/($param)/$value";
             }
             $uparamsArg = implode('', $parts);
         }
@@ -60,8 +60,8 @@ class LHCRestAPI
         }
 
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-        curl_setopt($ch, CURLOPT_USERPWD, $this->username . ':' . $this->apiKey);
-        curl_setopt($ch, CURLOPT_URL, $this->host . '/restapi/' . $function . $manualAppend . $uparamsArg . $requestArgs);
+        curl_setopt($ch, CURLOPT_USERPWD, "{$this->username}:{$this->apiKey}");
+        curl_setopt($ch, CURLOPT_URL, "{$this->host}/restapi/{$function}{$manualAppend}{$uparamsArg}{$requestArgs}");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);
@@ -75,7 +75,7 @@ class LHCRestAPI
         return $content;
     }
 
-    public function execute($function, $params, $uparams = array(), $method = 'GET', $jsonObject = true, $manualAppend = '')
+    public function execute($function, $params, $uparams = [], $method = 'GET', $jsonObject = true, $manualAppend = '')
     {
         $response = $this->executeRequest($function, $params, $uparams, $method, $manualAppend);
 
@@ -87,10 +87,8 @@ class LHCRestAPI
         if ($jsonData !== null) {
             return $jsonData;
         } else {
-            throw new Exception('Could not parse response - ' . $response);
+            throw new Exception("Could not parse response - $response");
         }
     }
 
 }
-
-?>

--- a/lhc_web/doc/rest_api/live_workflow.php
+++ b/lhc_web/doc/rest_api/live_workflow.php
@@ -63,63 +63,67 @@ if ($vid !== false) {
      * If you want just check is there any pending messages from operator you can execute this request
      * The only different count_page is equal 0
      */
-    $response = $LHCRestAPI->execute('chatcheckoperatormessage', array(
+    $response = $LHCRestAPI->execute('chatcheckoperatormessage', [
         'ip' => '88.118.220.88',
         'dt' => 'APPLICATIN_NAME - Some Application Specific Window',
         'ua' => '', // User Agent
-    	'onattr' => json_encode(array('chat_id' => 'new chat data')) // Store additional chat attributes
-    ), array(
+        'onattr' => json_encode(['chat_id' => 'new chat data']) // Store additional chat attributes
+    ], [
         'vid' => $vid,  // Use VID from previous request
         'count_page' => 0,  // Do not count as page view, just message check from operator
-        'tz' => 0,          
-        'priority' => 0,   
-        'operator' => 0,    
-        'theme' => 0,       
-        'survey' => 0,      
-        'department' => 5,  
-        'uactiv' => 1       
-    ), 'POST');
+        'tz' => 0,
+        'priority' => 0,
+        'operator' => 0,
+        'theme' => 0,
+        'survey' => 0,
+        'department' => 5,
+        'uactiv' => 1
+    ], 'POST');
 exit;
 
     // Count another page view
-    $response = $LHCRestAPI->execute('chatcheckoperatormessage', array(
+    $response = $LHCRestAPI->execute('chatcheckoperatormessage', [
         'ip' => '88.118.220.88',
         'dt' => 'APPLICATIN_NAME - Some Application Specific Window',
         'l' => '#',
         'ua' => '', // User Agent
-    ), array(
+    ], [
         'vid' => $vid,
-        'count_page' => 1,  
-        'tz' => 0,          
-        'priority' => 0,    
-        'operator' => 0,    
-        'survey' => 0,      
-        'uactiv' => 1       
-    ), 'POST',true,'');
+        'count_page' => 1,
+        'tz' => 0,
+        'priority' => 0,
+        'operator' => 0,
+        'survey' => 0,
+        'uactiv' => 1
+    ], 'POST',true,'');
 
     if ($response->error == false && $response->result->action == 'read_message') {
         $urlAppend = $response->result->args->url_append;
         $message = $response->result->args->message;
         
         // Start chat based on proactive invitation
-        $response = $LHCRestAPI->execute('startchat', array(
-            'Email' => 'remdex@gmail.com',  // E-mail of visitor
-            'DepartamentID' => '5',         // Department
-            'Username' => 'Visitor name',   // From what page chat has started
-            'Question' => 'my Question',    // Initial message from user
-            'AcceptTOS' => true,            // Accept TOS
-            'Phone' => '',                  // visitor phone if any
-            'URLRefer' => '',               // From what page chat has started, it can be page or just some application window name
-            'operator' => '',               // To what operator assign chat automatically
-            'ip' => '88.118.220.88',        // IP of original user
-            'data' => json_encode(array('chat_id' =>  array('val' => 'chat_id attribute'))), // Store additional chat information
-            'proactive' => true             // Start chat based on proactive data
-        ), array(
-            'vid' => $vid // You can pass visitor id so chat will be associated with this visitor
-        ), 'POST',
+        $response = $LHCRestAPI->execute(
+            'startchat',
+            [
+                'Email' => 'remdex@gmail.com',  // E-mail of visitor
+                'DepartamentID' => '5',         // Department
+                'Username' => 'Visitor name',   // From what page chat has started
+                'Question' => 'my Question',    // Initial message from user
+                'AcceptTOS' => true,            // Accept TOS
+                'Phone' => '',                  // visitor phone if any
+                'URLRefer' => '',               // From what page chat has started, it can be page or just some application window name
+                'operator' => '',               // To what operator assign chat automatically
+                'ip' => '88.118.220.88',        // IP of original user
+                'data' => json_encode(['chat_id' => ['val' => 'chat_id attribute']]), // Store additional chat information
+                'proactive' => true             // Start chat based on proactive data
+            ],
+            [
+                'vid' => $vid // You can pass visitor id so chat will be associated with this visitor
+            ],
+            'POST',
             true,
-            $urlAppend);
-        
+            $urlAppend
+        );
         
         exit;
         // @todo add message read from operator
@@ -136,22 +140,27 @@ exit;
 if ($hash === false && $id === false)
 {
     // Start chat
-    $response = $LHCRestAPI->execute('startchat', array(
-        'Email' => 'remdex@gmail.com',  // E-mail of visitor
-        'DepartamentID' => '5',         // Department
-        'Username' => 'Visitor name',   // From what page chat has started
-        'Question' => 'my Question',    // Initial message from user
-        'AcceptTOS' => true,            // Accept TOS
-        'Phone' => '',                  // visitor phone if any
-        'URLRefer' => '',               // From what page chat has started, it can be page or just some application window name
-        'operator' => '',               // To what operator assign chat automatically
-        'ip' => '88.118.220.88',        // IP of original user
-        'data' => json_encode(array('chat_id' =>  array('val' => 'chat_id attribute'))) // Store additional chat information
-    ), array(
-        'vid' => $vid // You can pass visitor id so chat will be associated with this visitor
-    ), 'POST', 
-        true, 
-        $urlAppend);
+    $response = $LHCRestAPI->execute(
+        'startchat',
+        [
+            'Email' => 'remdex@gmail.com',  // E-mail of visitor
+            'DepartamentID' => '5',         // Department
+            'Username' => 'Visitor name',   // From what page chat has started
+            'Question' => 'my Question',    // Initial message from user
+            'AcceptTOS' => true,            // Accept TOS
+            'Phone' => '',                  // visitor phone if any
+            'URLRefer' => '',               // From what page chat has started, it can be page or just some application window name
+            'operator' => '',               // To what operator assign chat automatically
+            'ip' => '88.118.220.88',        // IP of original user
+            'data' => json_encode(['chat_id' => ['val' => 'chat_id attribute']]) // Store additional chat information
+        ],
+        [
+            'vid' => $vid // You can pass visitor id so chat will be associated with this visitor
+        ],
+        'POST',
+        true,
+        $urlAppend
+    );
     
     if ($response->error == false) {
         $hash = $response->result->chat->hash;
@@ -160,20 +169,20 @@ if ($hash === false && $id === false)
 }
 
 // Fetch chat data
-$response = $LHCRestAPI->execute('fetchchat', array(
+$response = $LHCRestAPI->execute('fetchchat', [
     'chat_id' => $id,
     'hash' => $hash
-));
+]);
 
 if ($response->error == false) {
     
-    $status = array(
+    $status = [
         0 => 'STATUS_PENDING_CHAT',
         1 => 'STATUS_ACTIVE_CHAT',
         2 => 'STATUS_CLOSED_CHAT',
         3 => 'STATUS_CHATBOX_CHAT',
         4 => 'STATUS_OPERATORS_CHAT',
-    );
+    ];
        
     // Means chat is accepted
     if ($response->chat->status == 1) {
@@ -181,18 +190,18 @@ if ($response->error == false) {
     }
 
     // This request can be executed every 3-5 seconds it checks is there any new messages
-    $response = $LHCRestAPI->execute('fetchchatmessages', array(
+    $response = $LHCRestAPI->execute('fetchchatmessages', [
         'chat_id' => $id,
         'last_message_id' => 0, // Optional, return messages from this <optional>
         'ignore_system_messages' => true,
         'workflow' => true
-    ));
+    ]);
 
     // Check chat status
-    $responseCheckStatus = $LHCRestAPI->execute('checkchatstatus', array(
+    $responseCheckStatus = $LHCRestAPI->execute('checkchatstatus', [
     		'chat_id' => $id,
     		'hash' => $hash
-    ));
+    ]);
 
     if ($responseCheckStatus->error == false) {
     	if ($responseCheckStatus->result->activated == false) {
@@ -214,27 +223,31 @@ if ($response->error == false) {
     // Add message as a user
     if ($addMessage == true) {
 	    // Now add message to chat
-	    $response = $LHCRestAPI->execute('addmsguser', array(
+	    $response = $LHCRestAPI->execute('addmsguser', [
 	        'chat_id' => $id,
 	        'hash' => $hash,
 	        'msg' => 'User message here'
-	    ), array(), 'POST');
+	    ], [], 'POST');
     }
     
     // Close chat as visitor, let say visitor closes remote application etc
     // Operator will see a message, 
-    $response = $LHCRestAPI->execute('closechatasvisitor', array(
-    		'chat_id' => $id,
-    		'hash' => $hash,
-    		// eclose => true if user explicitly closed application
-    ));  
+    $response = $LHCRestAPI->execute('closechatasvisitor', [
+        'chat_id' => $id,
+        'hash' => $hash,
+        // eclose => true if user explicitly closed application
+    ]);
 
     // Update chat attributes
     // We update chat attributes
-    $response = $LHCRestAPI->execute('updatechatattributes', array(
-		'chat_id' => $id,
-		'hash' => $hash,
-    	'data' => json_encode(array('chat_id' =>  array('val' => 'chat_id attribute')))
-    ),
-    array(), 'POST' );    
+    $response = $LHCRestAPI->execute(
+        'updatechatattributes',
+        [
+            'chat_id' => $id,
+            'hash' => $hash,
+            'data' => json_encode(['chat_id' => ['val' => 'chat_id attribute']])
+        ],
+        [],
+        'POST'
+    );
 }

--- a/lhc_web/modules/lhtheme/adminthemes.php
+++ b/lhc_web/modules/lhtheme/adminthemes.php
@@ -1,4 +1,5 @@
 <?php
+
 $tpl = erLhcoreClassTemplate::getInstance('lhtheme/adminthemes.tpl.php');
 
 $pages = new lhPaginator();
@@ -7,26 +8,26 @@ $pages->items_total = erLhAbstractModelAdminTheme::getCount();
 $pages->setItemsPerPage(20);
 $pages->paginate();
 
-$items = array();
+$items = [];
 if ($pages->items_total > 0) {
-    $items = erLhAbstractModelAdminTheme::getList(array(
+    $items = erLhAbstractModelAdminTheme::getList([
         'offset' => $pages->low,
         'limit' => $pages->items_per_page
-    ));
+    ]);
 }
 
 $tpl->set('items', $items);
 $tpl->set('pages', $pages);
 
 $Result['content'] = $tpl->fetch();
-$Result['path'] = array(
-    array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','System configuration')),
-    array(
+$Result['path'] = [
+    ['url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit', 'System configuration')],
+    [
         'url' => erLhcoreClassDesign::baseurl('theme/index'),
         'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('theme/index', 'Themes')
-    ),
-    array(
+    ],
+    [
         'url' => erLhcoreClassDesign::baseurl('theme/adminthemes'),
         'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('questionary/list', 'Admin themes')
-    )
-);
+    ]
+];

--- a/lhc_web/modules/lhtheme/import.php
+++ b/lhc_web/modules/lhtheme/import.php
@@ -1,6 +1,6 @@
 <?php
 
-$tpl = erLhcoreClassTemplate::getInstance( 'lhtheme/import.tpl.php' );
+$tpl = erLhcoreClassTemplate::getInstance('lhtheme/import.tpl.php');
 
 if (ezcInputForm::hasPostData()) {
 		
@@ -9,23 +9,23 @@ if (ezcInputForm::hasPostData()) {
 		exit;
 	}
 	
-	if (erLhcoreClassSearchHandler::isFile('themefile',array('json'))) {
+	if (erLhcoreClassSearchHandler::isFile('themefile', ['json'])) {
 
 		$dir = 'var/tmpfiles/';
-		erLhcoreClassChatEventDispatcher::getInstance()->dispatch('theme.temppath',array('dir' => & $dir));
+		erLhcoreClassChatEventDispatcher::getInstance()->dispatch('theme.temppath', ['dir' => & $dir]);
 		
-		erLhcoreClassFileUpload::mkdirRecursive( $dir );
+		erLhcoreClassFileUpload::mkdirRecursive($dir);
 		
-		$filename = erLhcoreClassSearchHandler::moveUploadedFile('themefile',$dir);
-		$content = file_get_contents($dir . $filename);
-		unlink($dir . $filename);	
+		$filename = erLhcoreClassSearchHandler::moveUploadedFile('themefile', $dir);
+		$content = file_get_contents("{$dir}{$filename}");
+		unlink("{$dir}{$filename}");	
 		$data = json_decode($content);		
 		if ($data !== null) {
 			
 			$widgetTheme = new erLhAbstractModelWidgetTheme();
 			
-			$data = (array)$data;
-			$imgData = array();
+			$data = (array) $data;
+			$imgData = [];
 			if (isset($data['logo_image_data'])){
 				$imgData['logo_image'] = $data['logo_image_data'];
 				unset($data['logo_image_data']);
@@ -90,16 +90,16 @@ if (ezcInputForm::hasPostData()) {
 					     * Allow upload only images
 					     * Security report by https://sentry.co.com
 					     */
-					    if (in_array($data[$attr.'_data_ext'],array ('gif','jpg','jpeg','png','bmp')))
+					    if (in_array($data["{$attr}_data_ext"], ['gif','jpg','jpeg','png','bmp']))
                         {
                             $dir = 'var/tmpfiles/';
-                            $fileName = 'data.'.$data[$attr.'_data_ext'];
+                            $fileName = "data.{$data["{$attr}_data_ext"]}";
 
-                            erLhcoreClassChatEventDispatcher::getInstance()->dispatch('theme.temppath',array('dir' => & $dir));
+                            erLhcoreClassChatEventDispatcher::getInstance()->dispatch('theme.temppath', ['dir' => & $dir]);
 
-                            erLhcoreClassFileUpload::mkdirRecursive( $dir );
+                            erLhcoreClassFileUpload::mkdirRecursive($dir);
 
-                            $imgPath = $dir . $fileName;
+                            $imgPath = "{$dir}{$fileName}";
                             file_put_contents($imgPath, $imgDataItem);
 
                             if (erLhcoreClassImageConverter::isPhotoLocal($imgPath)){
@@ -113,17 +113,19 @@ if (ezcInputForm::hasPostData()) {
 	
 				$widgetTheme->updateThis();
 			} catch (Exception $e) {
-				$tpl->set('errors',array(erTranslationClassLhTranslation::getInstance()->getTranslation('theme/import','Could not import a new theme!')));
+				$tpl->set('errors', [erTranslationClassLhTranslation::getInstance()->getTranslation('theme/import','Could not import a new theme!')]);
 			}			
 		}
 		
 		$tpl->set('updated',true);
 	} else {		
-		$tpl->set('errors',array(erTranslationClassLhTranslation::getInstance()->getTranslation('theme/import','Invalid file!')));		
+		$tpl->set('errors', [erTranslationClassLhTranslation::getInstance()->getTranslation('theme/import','Invalid file!')]);		
 	}
 }
 
-$Result['path'] = array(
-    array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit','System configuration')),
-    array('url' => erLhcoreClassDesign::baseurl('theme/index'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('theme/index','Themes')),array('title' => erTranslationClassLhTranslation::getInstance()->getTranslation('theme/index','Import theme')));
+$Result['path'] = [
+	['url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('department/edit', 'System configuration')],
+	['url' => erLhcoreClassDesign::baseurl('theme/index'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('theme/index', 'Themes')],
+	['title' => erTranslationClassLhTranslation::getInstance()->getTranslation('theme/index', 'Import theme')]
+];
 $Result['content'] = $tpl->fetch();

--- a/lhc_web/modules/lhtheme/module.php
+++ b/lhc_web/modules/lhtheme/module.php
@@ -1,86 +1,79 @@
 <?php
 
-$Module = array( "name" => "Theme",
-				 'variable_params' => true );
+$Module = ['name' => 'Theme', 'variable_params' => true];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['export'] = array(
-    'params' => array('theme'),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['export'] = [
+    'params' => ['theme'],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['import'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['import'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['index'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['index'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['default'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['default'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['editthemebydepgroup'] = array(
-    'params' => array('id'),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['editthemebydepgroup'] = [
+    'params' => ['id'],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['defaultadmintheme'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['defaultadmintheme'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['adminthemes'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['adminthemes'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['personaltheme'] = array(
-    'params' => array(),
-    'functions' => array( 'personaltheme' )
-);
+$ViewList['personaltheme'] = [
+    'params' => [],
+    'functions' => ['personaltheme']
+];
 
-$ViewList['renderpreview'] = array(
-    'params' => array('id'),
-    'functions' => array( 'use_operator' )
-);
+$ViewList['renderpreview'] = [
+    'params' => ['id'],
+    'functions' => ['use_operator']
+];
 
-$ViewList['admincss'] = array(
-    'params' => array('id')
-);
+$ViewList['admincss'] = ['params' => ['id']];
 
-$ViewList['adminnewtheme'] = array(
-    'params' => array(),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['adminnewtheme'] = [
+    'params' => [],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['adminthemedelete'] = array(
-    'params' => array('id'),
-    'uparams' => array('csfr'),
-    'functions' => array('administratethemes'),
-);
+$ViewList['adminthemedelete'] = [
+    'params' => ['id'],
+    'uparams' => ['csfr'],
+    'functions' => ['administratethemes'],
+];
 
-$ViewList['adminthemeedit'] = array(
-    'params' => array('id'),
-    'functions' => array( 'administratethemes' )
-);
+$ViewList['adminthemeedit'] = [
+    'params' => ['id'],
+    'functions' => ['administratethemes']
+];
 
-$ViewList['deleteresource'] = array (
-    'params' => array('id', 'context', 'hash', ),
-    'functions' => array('administratethemes'),
-);
+$ViewList['deleteresource'] = [
+    'params' => ['id', 'context', 'hash'],
+    'functions' => ['administratethemes'],
+];
 
-$ViewList['gethash'] = array (
-    'params' => array(),
-);
+$ViewList['gethash'] = ['params' => []];
 
-$FunctionList['administratethemes'] = array('explain' =>'Allow users to maintain themes');
-$FunctionList['personaltheme'] = array('explain' =>'Allow operators have their own personal back office theme');
-$FunctionList['use_operator'] = array('explain' =>'Allow operator to preview trigger');
-
-?>
+$FunctionList['administratethemes'] = ['explain' =>'Allow users to maintain themes'];
+$FunctionList['personaltheme'] = ['explain' =>'Allow operators have their own personal back office theme'];
+$FunctionList['use_operator'] = ['explain' =>'Allow operator to preview trigger'];

--- a/lhc_web/modules/lhtranslation/configuration.php
+++ b/lhc_web/modules/lhtranslation/configuration.php
@@ -1,23 +1,23 @@
 <?php
 
-$tpl = erLhcoreClassTemplate::getInstance( 'lhtranslation/configuration.tpl.php');
+$tpl = erLhcoreClassTemplate::getInstance('lhtranslation/configuration.tpl.php');
 
 $translationData = erLhcoreClassModelChatConfig::fetch('translation_data');
-$data = (array)$translationData->data;
+$data = (array) $translationData->data;
 
-if ( isset($_POST['DetectLanguage']) ) {
+if (isset($_POST['DetectLanguage'])) {
      try {
         $tpl->set('detected_language',erLhcoreClassTranslate::detectLanguage($_POST['DetectLanguageText']));
      } catch (Exception $e) {
-        $tpl->set('errors',array($e->getMessage()));
+        $tpl->set('errors', [$e->getMessage()]);
      }
 }
 
-if ( isset($_POST['TranslateToLanguage']) ) {
+if (isset($_POST['TranslateToLanguage'])) {
      try {
         $tpl->set('translated_text',erLhcoreClassTranslate::translateTo($_POST['DetectLanguageText'], false, $_POST['LanguageTo']));
      } catch (Exception $e) {
-        $tpl->set('errors',array($e->getMessage()));
+        $tpl->set('errors', [$e->getMessage()]);
      }
 }
 
@@ -30,7 +30,7 @@ if ($Params['user_parameters_unordered']['action'] == 'clearcache') {
 
     // Rest API Cache
     $q = ezcDbInstance::get()->createDeleteQuery();
-    $q->deleteFrom('lh_generic_bot_rest_api_cache')->where( $q->expr->eq( 'rest_api_id', 0 ) );
+    $q->deleteFrom('lh_generic_bot_rest_api_cache')->where($q->expr->eq('rest_api_id', 0));
     $stmt = $q->prepare();
     $stmt->execute();
     
@@ -38,9 +38,9 @@ if ($Params['user_parameters_unordered']['action'] == 'clearcache') {
     exit;
 }
 
-if ( isset($_POST['StoreLanguageSettings']) || isset($_POST['StoreLanguageSettingsTest']) ) {
+if (isset($_POST['StoreLanguageSettings']) || isset($_POST['StoreLanguageSettingsTest'])) {
 
-    $definition = array(
+    $definition = [
         'translation_handler' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'string'
         ),
@@ -86,89 +86,89 @@ if ( isset($_POST['StoreLanguageSettings']) || isset($_POST['StoreLanguageSettin
         'aws_secret_key' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
         ),
-    );
+    ];
 
     if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
         erLhcoreClassModule::redirect('translation/configuration');
         exit;
     }
 
-    $Errors = array();
+    $Errors = [];
 
-    $form = new ezcInputForm( INPUT_POST, $definition );
-    $Errors = array();
+    $form = new ezcInputForm(INPUT_POST, $definition);
+    $Errors = [];
 
-    if ( $form->hasValidData( 'translation_handler' )) {
+    if ( $form->hasValidData('translation_handler')) {
         $data['translation_handler'] = $form->translation_handler;
     } else {
         $data['translation_handler'] = 'bing';
     }
 
-    if ( $form->hasValidData( 'enable_translations' ) && $form->enable_translations == true) {
+    if ( $form->hasValidData('enable_translations' ) && $form->enable_translations == true) {
         $data['enable_translations'] = true;
     } else {
         $data['enable_translations'] = false;
     }
 
-    if ( $form->hasValidData( 'use_cache' ) && $form->use_cache == true) {
+    if ( $form->hasValidData('use_cache') && $form->use_cache == true) {
         $data['use_cache'] = true;
     } else {
         $data['use_cache'] = false;
     }
     
-    if ( $form->hasValidData( 'bing_region' ) && $form->bing_region != '' && $form->bing_region != '0') {
+    if ($form->hasValidData('bing_region') && $form->bing_region != '' && $form->bing_region != '0') {
         $data['bing_region'] = $form->bing_region;
     }
 
-    if ( $form->hasValidData( 'bing_client_secret' ) && $form->bing_client_secret != '') {
+    if ($form->hasValidData('bing_client_secret') && $form->bing_client_secret != '') {
         $data['bing_client_secret'] = $form->bing_client_secret;
     }
 
-    if ( $form->hasValidData( 'google_api_key' ) && $form->google_api_key != '') {
+    if ($form->hasValidData('google_api_key') && $form->google_api_key != '') {
         $data['google_api_key'] = $form->google_api_key;
     }
 
-    if ( $form->hasValidData( 'google_referrer' ) && $form->google_referrer != '') {
+    if ($form->hasValidData('google_referrer') && $form->google_referrer != '') {
         $data['google_referrer'] = $form->google_referrer;
     } else {
         $data['google_referrer'] = '';
     }
 
-    if ( $form->hasValidData( 'aws_region' ) && $form->aws_region != '') {
+    if ($form->hasValidData('aws_region') && $form->aws_region != '') {
         $data['aws_region'] = $form->aws_region;
     } else {
         $data['aws_region'] = '';
     }
 
-    if ( $form->hasValidData( 'aws_access_key' ) && $form->aws_access_key != '') {
+    if ($form->hasValidData('aws_access_key') && $form->aws_access_key != '') {
         $data['aws_access_key'] = $form->aws_access_key;
     }
 
-    if ( $form->hasValidData( 'aws_secret_key' ) && $form->aws_secret_key != '') {
+    if ($form->hasValidData('aws_secret_key') && $form->aws_secret_key != '') {
         $data['aws_secret_key'] = $form->aws_secret_key;
     }
 
-    if ( $form->hasValidData( 'yandex_api_key' ) && $form->yandex_api_key != '') {
+    if ($form->hasValidData('yandex_api_key') && $form->yandex_api_key != '') {
         $data['yandex_api_key'] = $form->yandex_api_key;
     }
     
-    if ( $form->hasValidData( 'deepl_api_key' ) && $form->deepl_api_key != '') {
+    if ($form->hasValidData('deepl_api_key') && $form->deepl_api_key != '') {
         $data['deepl_api_key'] = $form->deepl_api_key;
     }
 
-    if ( $form->hasValidData( 'hide_translate_button' ) && $form->hide_translate_button == true) {
+    if ($form->hasValidData('hide_translate_button') && $form->hide_translate_button == true) {
         $data['hide_translate_button'] = true;
     } else {
         $data['hide_translate_button'] = false;
     }
 
-    if ( $form->hasValidData( 'translate_old_msg' ) && $form->translate_old_msg == true) {
+    if ( $form->hasValidData('translate_old_msg') && $form->translate_old_msg == true) {
         $data['translate_old_msg'] = true;
     } else {
         $data['translate_old_msg'] = false;
     }
 
-    if ( $form->hasValidData( 'show_auto_translate' ) && $form->show_auto_translate == true) {
+    if ( $form->hasValidData('show_auto_translate') && $form->show_auto_translate == true) {
         $data['show_auto_translate'] = true;
     } else {
         $data['show_auto_translate'] = false;
@@ -181,7 +181,7 @@ if ( isset($_POST['StoreLanguageSettings']) || isset($_POST['StoreLanguageSettin
         try {
             $tpl->set('message_send','done');
         } catch (Exception $e) {
-            $tpl->set('errors',array($e->getMessage()));
+            $tpl->set('errors', [$e->getMessage()]);
         }
     }
     
@@ -189,12 +189,10 @@ if ( isset($_POST['StoreLanguageSettings']) || isset($_POST['StoreLanguageSettin
     $CacheManager = erConfigClassLhCacheConfig::getInstance();
     $CacheManager->expireCache();
     
-    $tpl->set('updated','done');
+    $tpl->set('updated', 'done');
 }
 
 $tpl->set('translation_data',$data);
 $Result['require_angular'] = true;
 $Result['content'] = $tpl->fetch();
-$Result['path'] = array(array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('chat/translation','Translation configuration')))
-
-?>
+$Result['path'] = [['url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('chat/translation', 'Translation configuration')]];

--- a/lhc_web/modules/lhtranslation/module.php
+++ b/lhc_web/modules/lhtranslation/module.php
@@ -1,35 +1,33 @@
 <?php
 
-$Module = array( "name" => "Translation module");
+$Module = ['name' => 'Translation module'];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['configuration'] = array(
-		'params' => array(),
-		'functions' => array('configuration'),
-		'uparams' => array('csfr', 'action')
-);
+$ViewList['configuration'] = [
+		'params' => [],
+		'functions' => ['configuration'],
+		'uparams' => ['csfr', 'action']
+];
 
-$ViewList['starttranslation'] = array(
-		'params' => array('chat_id', 'visitor_language', 'operator_language'),
-		'functions' => array('use'),
-		'uparams' => array()
-);
+$ViewList['starttranslation'] = [
+		'params' => ['chat_id', 'visitor_language', 'operator_language'],
+		'functions' => ['use'],
+		'uparams' => []
+];
 
-$ViewList['translateoperatormessage'] = array(
-		'params' => array('chat_id'),
-		'functions' => array('use'),
-		'uparams' => array()
-);
+$ViewList['translateoperatormessage'] = [
+		'params' => ['chat_id'],
+		'functions' => ['use'],
+		'uparams' => []
+];
 
-$ViewList['translatevisitormessage'] = array(
-		'params' => array('chat_id', 'msg_id'),
-		'functions' => array('use'),
-		'uparams' => array()
-);
+$ViewList['translatevisitormessage'] = [
+		'params' => ['chat_id', 'msg_id'],
+		'functions' => ['use'],
+		'uparams' => []
+];
 
-$FunctionList = array();
-$FunctionList['configuration'] = array('explain' => 'Allow operator to configure automatic translations module');
-$FunctionList['use'] = array('explain' => 'Allow operator to use automatic translations');
-
-?>
+$FunctionList = [];
+$FunctionList['configuration'] = ['explain' => 'Allow operator to configure automatic translations module'];
+$FunctionList['use'] = ['explain' => 'Allow operator to use automatic translations'];

--- a/lhc_web/modules/lhtranslation/starttranslation.php
+++ b/lhc_web/modules/lhtranslation/starttranslation.php
@@ -1,16 +1,16 @@
 <?php
 
-header ( 'content-type: application/json; charset=utf-8' );
+header ('content-type: application/json; charset=utf-8');
 
-$visitorLanguage = (string)$Params['user_parameters']['visitor_language'];
-$operatorLanguage = (string)$Params['user_parameters']['operator_language'];
+$visitorLanguage = (string) $Params['user_parameters']['visitor_language'];
+$operatorLanguage = (string) $Params['user_parameters']['operator_language'];
 
 $chat = erLhcoreClassModelChat::fetch($Params['user_parameters']['chat_id']);
 
 if ( erLhcoreClassChat::hasAccessToRead($chat) )
 {
-    $errors = array();
-    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('translate.before_messagetranslated', array('chat' => & $chat, 'errors' => & $errors));
+    $errors = [];
+    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('translate.before_messagetranslated', ['chat' => & $chat, 'errors' => & $errors]);
 
     if (!isset($_SERVER['HTTP_X_CSRFTOKEN']) || !$currentUser->validateCSFRToken($_SERVER['HTTP_X_CSRFTOKEN'])) {
         $errors[] = 'Invalid CSRF token!';
@@ -24,11 +24,11 @@ if ( erLhcoreClassChat::hasAccessToRead($chat) )
             unset($chatVariablesArray['lhc_live_trans']);
             $chat->chat_variables_array = $chatVariablesArray;
             $chat->chat_variables = json_encode($chatVariablesArray);
-            $chat->updateThis(array('update' => array('chat_variables')));
+            $chat->updateThis(['update' => ['chat_variables']]);
         }
 
         try {
-            $data = erLhcoreClassTranslate::setChatLanguages($chat, $visitorLanguage, $operatorLanguage, array('translate_old' => (isset($_POST['translate_old']) && $_POST['translate_old'] == 'true')));
+            $data = erLhcoreClassTranslate::setChatLanguages($chat, $visitorLanguage, $operatorLanguage, ['translate_old' => (isset($_POST['translate_old']) && $_POST['translate_old'] == 'true')]);
             $data['error'] = false;
             $tpl = erLhcoreClassTemplate::getInstance('lhkernel/alert_success.tpl.php');
             $tpl->set('msg', erTranslationClassLhTranslation::getInstance()->getTranslation('chat/translation', 'Settings has been saved'));
@@ -41,22 +41,22 @@ if ( erLhcoreClassChat::hasAccessToRead($chat) )
                 $chatVariablesArray['lhc_live_trans'] = true;
                 $chat->chat_variables_array = $chatVariablesArray;
                 $chat->chat_variables = json_encode($chatVariablesArray);
-                $chat->updateThis(array('update' => array('chat_variables')));
+                $chat->updateThis(['update' => ['chat_variables']]);
             }
 
             echo json_encode($data);
 
         } catch (Exception $e) {
-            $data = array('error' => true);
+            $data = ['error' => true];
             $tpl = erLhcoreClassTemplate::getInstance('lhkernel/validation_error.tpl.php');
-            $tpl->set('errors', array($e->getMessage(), erTranslationClassLhTranslation::getInstance()->getTranslation('chat/translation', 'Please choose translation languages manually and click Auto translate')));
+            $tpl->set('errors', [$e->getMessage(), erTranslationClassLhTranslation::getInstance()->getTranslation('chat/translation', 'Please choose translation languages manually and click Auto translate')]);
             $data['result'] = $tpl->fetch();
             $data['translation_status'] = false;
             echo json_encode($data);
         }
 
     } else {
-        $data = array('error' => true);
+        $data = ['error' => true];
         $tpl = erLhcoreClassTemplate::getInstance('lhkernel/validation_error.tpl.php');
         $tpl->set('errors', $errors);
         $data['result'] = $tpl->fetch();
@@ -66,4 +66,3 @@ if ( erLhcoreClassChat::hasAccessToRead($chat) )
 }
 
 exit;
-?>

--- a/lhc_web/modules/lhvoicevideo/configuration.php
+++ b/lhc_web/modules/lhvoicevideo/configuration.php
@@ -3,7 +3,7 @@
 $tpl = erLhcoreClassTemplate::getInstance('lhvoicevideo/configuration.tpl.php');
 
 $voiceData = erLhcoreClassModelChatConfig::fetch('vvsh_configuration');
-$data = (array)$voiceData->data;
+$data = (array) $voiceData->data;
 
 if (isset($_POST['StoreVoiceConfiguration'])) {
 
@@ -12,7 +12,7 @@ if (isset($_POST['StoreVoiceConfiguration'])) {
         exit;
     }
 
-    $definition = array(
+    $definition = [
         'provider' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'string'
         ),
@@ -31,12 +31,12 @@ if (isset($_POST['StoreVoiceConfiguration'])) {
         'screenshare' => new ezcInputFormDefinitionElement(
             ezcInputFormDefinitionElement::OPTIONAL, 'boolean'
         ),
-    );
+    ];
 
-    $Errors = array();
+    $Errors = [];
 
     $form = new ezcInputForm(INPUT_POST, $definition);
-    $Errors = array();
+    $Errors = [];
 
     if ($form->hasValidData('provider') && $form->provider != '') {
         $data['provider'] = $form->provider;
@@ -96,8 +96,7 @@ if (isset($_POST['StoreVoiceConfiguration'])) {
 
 $tpl->set('voice_data', $data);
 $Result['content'] = $tpl->fetch();
-$Result['path'] = array(
-    array('url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration', 'System configuration')),
-    array('url' => erLhcoreClassDesign::baseurl('file/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration', 'Voice & Video & ScreenShare')));
-
-?>
+$Result['path'] = [
+    ['url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration', 'System configuration')],
+    ['url' => erLhcoreClassDesign::baseurl('file/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/configuration', 'Voice & Video & ScreenShare')]
+];

--- a/lhc_web/modules/lhvoicevideo/module.php
+++ b/lhc_web/modules/lhvoicevideo/module.php
@@ -1,40 +1,38 @@
 <?php
 
-$Module = array( "name" => "Voice & Video & ScreenShare" );
+$Module = ['name' => 'Voice & Video & ScreenShare'];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['configuration'] = array(
-    'params' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['configuration'] = [
+    'params' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['sessions'] = array(
-    'params' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['sessions'] = [
+    'params' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['call'] = array(
-    'params' => array('id','hash')
-);
+$ViewList['call'] = [
+    'params' => ['id', 'hash']
+];
 
-$ViewList['join'] = array(
-    'params' => array('id','hash'),
-    'uparams' => array('action'),
-);
+$ViewList['join'] = [
+    'params' => ['id', 'hash'],
+    'uparams' => ['action'],
+];
 
-$ViewList['joinop'] = array(
-    'params' => array('id'),
-    'uparams' => array('action'),
-    'functions' => array( 'use' )
-);
+$ViewList['joinop'] = [
+    'params' => ['id'],
+    'uparams' => ['action'],
+    'functions' => ['use']
+];
 
-$ViewList['joinoperator'] = array(
-    'params' => array('id'),
-    'functions' => array( 'use' )
-);
+$ViewList['joinoperator'] = [
+    'params' => ['id'],
+    'functions' => ['use']
+];
 
-$FunctionList['configuration'] = array('explain' => 'Voice & Video & ScreenShare module configuration');
-$FunctionList['use'] = array('explain' => 'Allow operator to use Voice & Video & ScreenShare calls');
-
-?>
+$FunctionList['configuration'] = ['explain' => 'Voice & Video & ScreenShare module configuration'];
+$FunctionList['use'] = ['explain' => 'Allow operator to use Voice & Video & ScreenShare calls'];

--- a/lhc_web/modules/lhwebhooks/dispatch.php
+++ b/lhc_web/modules/lhwebhooks/dispatch.php
@@ -59,7 +59,7 @@ if (ezcInputForm::hasPostData()) {
             }
         }
 
-        $args = array();
+        $args = [];
 
         if (isset($_POST['args']) && !empty($_POST['args'])) {
             $argsRows = explode("\n", trim($_POST['args']));
@@ -94,7 +94,3 @@ if (ezcInputForm::hasPostData()) {
     echo $tpl->fetch();
     exit;
 }
-
-
-
-?>

--- a/lhc_web/modules/lhwebhooks/module.php
+++ b/lhc_web/modules/lhwebhooks/module.php
@@ -1,69 +1,67 @@
 <?php
 
-$Module = array( "name" => "Webhooks" );
+$Module = ['name' => 'Webhooks'];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['configuration'] = array(
-    'params' => array(),
-    'uparams' => array('name','enabled','event'),
-    'functions' => array( 'configuration' )
-);
+$ViewList['configuration'] = [
+    'params' => [],
+    'uparams' => ['name','enabled','event'],
+    'functions' => ['configuration']
+];
 
-$ViewList['pushchat'] = array(
-    'params' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['pushchat'] = [
+    'params' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['new'] = array(
-    'params' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['new'] = [
+    'params' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['newincoming'] = array(
-    'params' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['newincoming'] = [
+    'params' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['editincoming'] = array(
-    'params' => array('id'),
-    'functions' => array( 'configuration' )
-);
+$ViewList['editincoming'] = [
+    'params' => ['id'],
+    'functions' => ['configuration']
+];
 
-$ViewList['incoming'] = array(
-    'params' => array('identifier'),
-);
+$ViewList['incoming'] = [
+    'params' => ['identifier'],
+];
 
-$ViewList['edit'] = array(
-    'params' => array('id'),
-    'uparams' => array('action','csfr'),
-    'functions' => array( 'configuration' )
-);
+$ViewList['edit'] = [
+    'params' => ['id'],
+    'uparams' => ['action','csfr'],
+    'functions' => ['configuration']
+];
 
-$ViewList['delete'] = array(
-    'params' => array('id'),
-    'uparams' => array('csfr'),
-    'functions' => array( 'configuration' )
-);
+$ViewList['delete'] = [
+    'params' => ['id'],
+    'uparams' => ['csfr'],
+    'functions' => ['configuration']
+];
 
-$ViewList['deleteincoming'] = array(
-    'params' => array('id'),
-    'uparams' => array('csfr'),
-    'functions' => array( 'configuration' )
-);
+$ViewList['deleteincoming'] = [
+    'params' => ['id'],
+    'uparams' => ['csfr'],
+    'functions' => ['configuration']
+];
 
-$ViewList['incomingwebhooks'] = array(
-    'params' => array(),
-    'uparams' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['incomingwebhooks'] = [
+    'params' => [],
+    'uparams' => [],
+    'functions' => ['configuration']
+];
 
-$ViewList['dispatch'] = array(
-    'params' => array(),
-    'uparams' => array(),
-    'functions' => array( 'configuration' )
-);
+$ViewList['dispatch'] = [
+    'params' => [],
+    'uparams' => [],
+    'functions' => ['configuration']
+];
 
-$FunctionList['configuration'] = array('explain' => 'Webhooks module configuration');
-
-?>
+$FunctionList['configuration'] = ['explain' => 'Webhooks module configuration'];

--- a/lhc_web/modules/lhwebhooks/pushchat.php
+++ b/lhc_web/modules/lhwebhooks/pushchat.php
@@ -1,6 +1,6 @@
 <?php
 
-$tpl = erLhcoreClassTemplate::getInstance( 'lhwebhooks/pushchat.tpl.php');
+$tpl = erLhcoreClassTemplate::getInstance('lhwebhooks/pushchat.tpl.php');
 
 $item = new stdClass();
 $item->incoming_api_id = 0;
@@ -20,16 +20,16 @@ if (ezcInputForm::hasPostData()) {
         exit;
     }
 
-    $definition = array(
-        'incoming_api_id' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int', array('min_range' => 1)),
+    $definition = [
+        'incoming_api_id' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int', ['min_range' => 1]),
         'message' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw', null),
         'chat_id' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw', null),
         'create_chat' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'boolean', null),
         'close_chat' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'boolean', null),
-        'dep_id' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int', array('min_range' => 1)),
-    );
+        'dep_id' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'int', ['min_range' => 1]),
+    ];
 
-    $Errors = array();
+    $Errors = [];
     $form = new ezcInputForm(INPUT_POST, $definition);
 
     if ($form->hasValidData('chat_id') && !empty($form->chat_id)) {
@@ -81,25 +81,23 @@ if (ezcInputForm::hasPostData()) {
 
             $chat = erLhcoreClassChatWebhookIncoming::sendMessage(erLhcoreClassModelChatIncomingWebhook::fetch($item->incoming_api_id), $item);
 
-            $tpl->set('updated',true);
-            $tpl->set('chat',$chat);
+            $tpl->set('updated', true);
+            $tpl->set('chat', $chat);
 
         } catch (Exception $e) {
-            $tpl->set('errors',array($e->getMessage()));
+            $tpl->set('errors', [$e->getMessage()]);
         }
 
     } else {
-        $tpl->set('errors',$Errors);
+        $tpl->set('errors', $Errors);
     }
 }
 
 $tpl->set('item', $item);
 
 $Result['content'] = $tpl->fetch();
-$Result['path'] = array(
-    array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module','System configuration')),
-    array('url' => erLhcoreClassDesign::baseurl('webhooks/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module','Webhooks')),
-    array('title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module','Push chat')),
-)
-
-?>
+$Result['path'] = [
+    ['url' => erLhcoreClassDesign::baseurl('system/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module', 'System configuration')],
+    ['url' => erLhcoreClassDesign::baseurl('webhooks/configuration'), 'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module', 'Webhooks')],
+    ['title' => erTranslationClassLhTranslation::getInstance()->getTranslation('webhooks/module', 'Push chat')],
+];

--- a/lhc_web/modules/lhxml/chatssynchro.php
+++ b/lhc_web/modules/lhxml/chatssynchro.php
@@ -9,7 +9,7 @@ if (!isset($options['notifications']) || !$options['notifications']) {
 }
 
 $currentUser = erLhcoreClassUser::instance();
-if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],$_POST['password']))
+if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'], $_POST['password']))
 {
     exit;
 }
@@ -20,9 +20,9 @@ if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],
 
 if ($currentUser->isLogged() && isset($_POST['chats']))
 {
-    $arrayReturn = array();
+    $arrayReturn = [];
 
-    $chats = explode(';',$_POST['chats']);
+    $chats = explode(';', $_POST['chats']);
 
     foreach ($chats as $chatContent)
     {
@@ -31,7 +31,7 @@ if ($currentUser->isLogged() && isset($_POST['chats']))
         $chat_id = $paramsExecution[0];
         $msgIDs = isset($paramsExecution[1]) ? $paramsExecution[1] : '';
 
-        $chatsMessages = array();
+        $chatsMessages = [];
         $chatStatusMessage = '';
 
         // Get messages from with needs to synchronise
@@ -40,7 +40,7 @@ if ($currentUser->isLogged() && isset($_POST['chats']))
         // From this messages we can fetch msg's
         $minMessageID = min($masgIDArray);
 
-        $Chat = erLhcoreClassChat::getSession()->load( 'erLhcoreClassModelChat', $chat_id);
+        $Chat = erLhcoreClassChat::getSession()->load('erLhcoreClassModelChat', $chat_id);
 
         if ( erLhcoreClassChat::hasAccessToRead($Chat) )
         {
@@ -53,9 +53,9 @@ if ($currentUser->isLogged() && isset($_POST['chats']))
                         if ($msgID < $msg['id']) {
 
                             if (strpos($_SERVER['HTTP_USER_AGENT'],'Dart/') !== false) {
-                                $msg['msg'] = str_replace('"//','"'. (erLhcoreClassSystem::$httpsMode == true ? 'https:' : 'http:') . '//' ,erLhcoreClassBBCode::make_clickable($msg['msg'], array('sender' => $msg['user_id'])));
+                                $msg['msg'] = str_replace('"//','"'. (erLhcoreClassSystem::$httpsMode == true ? 'https:' : 'http:') . '//' ,erLhcoreClassBBCode::make_clickable($msg['msg'], ['sender' => $msg['user_id']]));
                             } else {
-                                $msg['msg'] = erLhcoreClassBBCodePlain::make_clickable($msg['msg'], array('sender' => $msg['user_id']));
+                                $msg['msg'] = erLhcoreClassBBCodePlain::make_clickable($msg['msg'], ['sender' => $msg['user_id']]);
                             }
 
                             if (str_contains($msg['meta_msg'],'whisper')){
@@ -92,14 +92,9 @@ if ($currentUser->isLogged() && isset($_POST['chats']))
         }
     }
 
-    echo json_encode(array("error" => false,'result' => $arrayReturn));
+    echo json_encode(['error' => false, 'result' => $arrayReturn]);
 } else {
-    echo json_encode(array("error" => true));
+    echo json_encode(['error' => true]);
 }
 
-
-
-
-
 exit;
-?>

--- a/lhc_web/modules/lhxml/lists.php
+++ b/lhc_web/modules/lhxml/lists.php
@@ -1,6 +1,6 @@
 <?php
 
-header ( 'content-type: application/json; charset=utf-8' );
+header ('content-type: application/json; charset=utf-8');
 
 $options = erLhcoreClassModelChatConfig::fetch('mobile_options')->data;
 
@@ -9,7 +9,7 @@ if (!isset($options['notifications']) || !$options['notifications']) {
 }
 
 $currentUser = erLhcoreClassUser::instance();
-if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],$_POST['password']))
+if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'], $_POST['password']))
 {
     exit;
 }
@@ -20,7 +20,7 @@ $pendingChats = erLhcoreClassChat::getPendingChats(isset($options['limit_p']) &&
 $transferedChats = erLhcoreClassTransfer::getTransferChats();
 $botChats = erLhcoreClassChat::getBotChats(isset($options['limit_b']) && is_numeric($options['limit_b']) ? $options['limit_b'] : 10);
 
-$unreadChats = array(); // erLhcoreClassChat::getUnreadMessagesChats(10,0);
+$unreadChats = []; // erLhcoreClassChat::getUnreadMessagesChats(10,0);
 
 foreach ($activeChats as $index => $activeChat) {
     $activeChats[$index]->owner = $activeChat->n_off_full;
@@ -43,21 +43,21 @@ foreach ($botChats as $index => $botChat) {
         }
     }
 
-    $botChats[$index]->aicon_front = implode('||',$alertSubjects);
+    $botChats[$index]->aicon_front = implode('||', $alertSubjects);
 }
 
-erLhcoreClassChat::prefillGetAttributes($activeChats,array('department_name','user_status_front'),array('updateIgnoreColumns','department','user'));
-erLhcoreClassChat::prefillGetAttributes($closedChats,array('department_name','user_status_front'),array('updateIgnoreColumns','department','user'));
-erLhcoreClassChat::prefillGetAttributes($pendingChats,array('department_name','user_status_front'),array('updateIgnoreColumns','department','user'));
-erLhcoreClassChat::prefillGetAttributes($unreadChats,array('department_name'),array('updateIgnoreColumns','department','user'));
-erLhcoreClassChat::prefillGetAttributes($botChats,array('department_name','user_status_front'),array('updateIgnoreColumns','department','user'));
+erLhcoreClassChat::prefillGetAttributes($activeChats, ['department_name', 'user_status_front'], ['updateIgnoreColumns', 'department', 'user']);
+erLhcoreClassChat::prefillGetAttributes($closedChats, ['department_name', 'user_status_front'], ['updateIgnoreColumns', 'department', 'user']);
+erLhcoreClassChat::prefillGetAttributes($pendingChats, ['department_name', 'user_status_front'], ['updateIgnoreColumns', 'department', 'user']);
+erLhcoreClassChat::prefillGetAttributes($unreadChats, ['department_name'], ['updateIgnoreColumns', 'department', 'user']);
+erLhcoreClassChat::prefillGetAttributes($botChats, ['department_name', 'user_status_front'], ['updateIgnoreColumns', 'department','user']);
 
-$onlineUsers = array();
+$onlineUsers = [];
 if ($currentUser->hasAccessTo('lhchat','use_onlineusers')) {
     
-    $filter = array('offset' => 0, 'limit' => (isset($options['limit_ov']) && is_numeric($options['limit_ov']) ? $options['limit_ov'] : 50), 'sort' => 'last_visit DESC','filtergt' => array('last_visit' => (time()-3600)));
+    $filter = ['offset' => 0, 'limit' => (isset($options['limit_ov']) && is_numeric($options['limit_ov']) ? $options['limit_ov'] : 50), 'sort' => 'last_visit DESC','filtergt' => ['last_visit' => (time()-3600)]];
 
-    $departmentParams = array();
+    $departmentParams = [];
     $userDepartments = erLhcoreClassUserDep::parseUserDepartmetnsForFilter($currentUser->getUserID());
     if ($userDepartments !== true) {
         $departmentParams['filterin']['id'] = $userDepartments;
@@ -69,33 +69,33 @@ if ($currentUser->hasAccessTo('lhchat','use_onlineusers')) {
     $onlineUsers = erLhcoreClassModelChatOnlineUser::getList($filter);
 }
 
-$columnsToHide = array('user_closed_ts','lsync','uagent','user_status_front','pnd_time','unanswered_chat','tslasign','reinform_timeout','unread_messages_informed','wait_timeout','wait_timeout_send','status_sub','timeout_message','nc_cb_executed','fbst','user_id','transfer_timeout_ts','operator_typing_id','transfer_timeout_ac','transfer_if_na','na_cb_executed','status','remarks','operation','operation_admin','screenshot_id','mail_send','online_user_id','dep_id','last_msg_id','hash','user_status','support_informed','support_informed','country_code','user_typing','user_typing_txt','lat','lon','chat_initiator','chat_variables','chat_duration','operator_typing','has_unread_messages','last_user_msg_time','additional_data');
-$columnsName = array('id' => 'ID','chat_locale' => 'Visitor language','user_tz_identifier' => 'User time zone','department_name' => 'Department','nick' => 'Nick','time' => 'Time','referrer' => 'Referrer','session_referrer' => 'Original referrer','ip' => 'IP','country_name' => 'Country','email' => 'E-mail','priority' => 'Priority','name' => 'Department','phone' => 'Phone','city' => 'City','wait_time' => 'Waited');
+$columnsToHide = ['user_closed_ts','lsync','uagent','user_status_front','pnd_time','unanswered_chat','tslasign','reinform_timeout','unread_messages_informed','wait_timeout','wait_timeout_send','status_sub','timeout_message','nc_cb_executed','fbst','user_id','transfer_timeout_ts','operator_typing_id','transfer_timeout_ac','transfer_if_na','na_cb_executed','status','remarks','operation','operation_admin','screenshot_id','mail_send','online_user_id','dep_id','last_msg_id','hash','user_status','support_informed','support_informed','country_code','user_typing','user_typing_txt','lat','lon','chat_initiator','chat_variables','chat_duration','operator_typing','has_unread_messages','last_user_msg_time','additional_data'];
+$columnsName = ['id' => 'ID','chat_locale' => 'Visitor language','user_tz_identifier' => 'User time zone','department_name' => 'Department','nick' => 'Nick','time' => 'Time','referrer' => 'Referrer','session_referrer' => 'Original referrer','ip' => 'IP','country_name' => 'Country','email' => 'E-mail','priority' => 'Priority','name' => 'Department','phone' => 'Phone','city' => 'City','wait_time' => 'Waited'];
 
-$onlineuserscolumnsToHide = array('requires_phone','lat_check_time','dep_id','requires_email','requires_username','invitation_seen_count','screenshot_id','operation','reopen_chat','vid','user_country_code','invitation_assigned','current_page', 'chat_id', 'operator_user_id', 'message_seen','operator_user_proactive','message_seen_ts','lat','lon','invitation_id','time_on_site','tt_time_on_site','invitation_count','store_chat');
-$onlineuserscolumnsNames = array('last_check_time' => 'Last online check', 'notes' => 'Notes','referrer' => 'Referrer', 'page_title' => 'Page title', 'visitor_tz' => 'Visitor time zone','online_attr' => 'Attributes','id' => 'ID','operator_message' => 'Operator message', 'ip' => 'IP','identifier' => 'Identifier','user_agent' => 'Browser','last_visit' => 'Last visit','first_visit' => 'First visit','total_visits' => 'Total visits','user_country_name' => 'Country','city' => 'City','pages_count' => 'Pages viewed','tt_pages_count' => 'Total pages viewed');
+$onlineuserscolumnsToHide = ['requires_phone','lat_check_time','dep_id','requires_email','requires_username','invitation_seen_count','screenshot_id','operation','reopen_chat','vid','user_country_code','invitation_assigned','current_page', 'chat_id', 'operator_user_id', 'message_seen','operator_user_proactive','message_seen_ts','lat','lon','invitation_id','time_on_site','tt_time_on_site','invitation_count','store_chat'];
+$onlineuserscolumnsNames = ['last_check_time' => 'Last online check', 'notes' => 'Notes','referrer' => 'Referrer', 'page_title' => 'Page title', 'visitor_tz' => 'Visitor time zone','online_attr' => 'Attributes','id' => 'ID','operator_message' => 'Operator message', 'ip' => 'IP','identifier' => 'Identifier','user_agent' => 'Browser','last_visit' => 'Last visit','first_visit' => 'First visit','total_visits' => 'Total visits','user_country_name' => 'Country','city' => 'City','pages_count' => 'Pages viewed','tt_pages_count' => 'Total pages viewed'];
 
 $canListOnlineUsers = false;
 $canListOnlineUsersAll = false;
 
 if (erLhcoreClassModelChatConfig::fetchCache('list_online_operators')->current_value == 1) {
-    $canListOnlineUsers = $currentUser->hasAccessTo('lhuser','userlistonline');
-    $canListOnlineUsersAll = $currentUser->hasAccessTo('lhuser','userlistonlineall');
+    $canListOnlineUsers = $currentUser->hasAccessTo('lhuser', 'userlistonline');
+    $canListOnlineUsersAll = $currentUser->hasAccessTo('lhuser', 'userlistonlineall');
 }
 
 if ($canListOnlineUsers === true || $canListOnlineUsersAll === true) {
-    $onlineOperators = erLhcoreClassModelUserDep::getOnlineOperators($currentUser,$canListOnlineUsersAll, array(),(isset($options['limit_op']) && is_numeric($options['limit_op']) ? $options['limit_op'] : 50),7 * 24 * 3600);
-    erLhcoreClassChat::prefillGetAttributes($onlineOperators,array('lastactivity_ago','offline_since','user_id','id','name_official','pending_chats','inactive_chats','active_chats','departments_names','hide_online','avatar'),array(),array('filter_function' => true, 'remove_all' => true));
+    $onlineOperators = erLhcoreClassModelUserDep::getOnlineOperators($currentUser, $canListOnlineUsersAll, [], (isset($options['limit_op']) && is_numeric($options['limit_op']) ? $options['limit_op'] : 50),7 * 24 * 3600);
+    erLhcoreClassChat::prefillGetAttributes($onlineOperators, ['lastactivity_ago','offline_since','user_id','id','name_official','pending_chats','inactive_chats','active_chats','departments_names','hide_online','avatar'],[],['filter_function' => true, 'remove_all' => true]);
 } else {
     $onlineOperators = [];
 }
 
 foreach ($onlineOperators as $key => $value) {
-    $onlineOperators[$key]->departments_names = erLhcoreClassDesign::shrt(implode(', ',$value->departments_names),10,'...',30,ENT_QUOTES);
+    $onlineOperators[$key]->departments_names = erLhcoreClassDesign::shrt(implode(', ',$value->departments_names), 10,'...', 30, ENT_QUOTES);
 }
 
 $db = ezcDbInstance::get();
-$groupChats = array();
+$groupChats = [];
 foreach ($onlineOperators as $onlineOperator) {
    $sql = "SELECT DISTINCT `lh_group_chat`.`id`,count(`lh_group_chat_member`.`id`) as `tm_live` FROM `lh_group_chat`
     INNER JOIN lh_group_chat_member ON `lh_group_chat_member`.`group_id` = `lh_group_chat`.`id`
@@ -125,11 +125,11 @@ foreach ($onlineOperators as $index => $onlineOperator) {
 }
 
 if (!empty($groupChatsID)) {
-    $groupChats = erLhcoreClassModelGroupChat::getList(array('filterin' => array('id' => $groupChatsID)));
-    $myMembers = erLhcoreClassModelGroupChatMember::getList(array('filterin' => array('group_id' => $groupChatsID)));
+    $groupChats = erLhcoreClassModelGroupChat::getList(['filterin' => ['id' => $groupChatsID]]);
+    $myMembers = erLhcoreClassModelGroupChatMember::getList(['filterin' => ['group_id' => $groupChatsID]]);
 
-    $membersRegrouped = array();
-    $membersRegroupedMy = array();
+    $membersRegrouped = [];
+    $membersRegroupedMy = [];
     foreach ($myMembers as $member) {
         $membersRegrouped[$member->user_id] = $member;
         $membersRegroupedMy[$member->group_id][$member->user_id] = $member;
@@ -146,19 +146,19 @@ if (!empty($groupChatsID)) {
     }
 }
 
-$filter = array('ignore_fields' => erLhcoreClassChat::$chatListIgnoreField);
+$filter = ['ignore_fields' => erLhcoreClassChat::$chatListIgnoreField];
 
 $chatsSubjectChats = erLhcoreClassChat::getSubjectChats(10, 0, $filter);
 
 if (!empty($chatsSubjectChats)) {
-    $subjectsSelected = erLhAbstractModelSubjectChat::getList(array('filter' => array('chat_id' => array_keys($chatsSubjectChats))));
+    $subjectsSelected = erLhAbstractModelSubjectChat::getList(['filter' => ['chat_id' => array_keys($chatsSubjectChats)]]);
     $subjectByChat = [];
     $subject_ids = [];
     foreach ($subjectsSelected as $subjectSelected) {
         $subject_ids[] = $subjectSelected->subject_id;
     }
     if (!empty($subject_ids)) {
-        $subjectsMeta = erLhAbstractModelSubject::getList(array('filterin' => array('id' => array_unique($subject_ids))));
+        $subjectsMeta = erLhAbstractModelSubject::getList(['filterin' => ['id' => array_unique($subject_ids)]]);
     }
     foreach ($subjectsSelected as $subjectSelected) {
         if (isset( $subjectsMeta[$subjectSelected->subject_id])) {
@@ -177,35 +177,34 @@ foreach ($chatsSubjectChats as $index => $subjectChat) {
         }
     }
 
-    $chatsSubjectChats[$index]->aicon_front = implode('||',$alertSubjects);
+    $chatsSubjectChats[$index]->aicon_front = implode('||', $alertSubjects);
 
 }
 
-erLhcoreClassChat::prefillGetAttributes($chatsSubjectChats,array('department_name','user_status_front'),array('updateIgnoreColumns','department','user'));
+erLhcoreClassChat::prefillGetAttributes($chatsSubjectChats, ['department_name', 'user_status_front'], ['updateIgnoreColumns', 'department', 'user']);
 
 foreach ($chatsSubjectChats as $index => $chat) {
     if (isset($subjectByChat[$chat->id])) {
-        $chatsSubjectChats[$index]->subject_front = implode('||',$subjectByChat[$chat->id]);
+        $chatsSubjectChats[$index]->subject_front = implode('||', $subjectByChat[$chat->id]);
     }
 }
 
-$response = array(
+$response = [
     'is_online' => $currentUser->getUserData(true)->hide_online == 0,
-    'active_chats' => array('rows' => $activeChats, 'size' => count($activeChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'unread_chats' => array('rows' => $unreadChats, 'size' => count($unreadChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'online_users' => array('rows' => $onlineUsers, 'size' => count($onlineUsers), 'hidden_columns' => $onlineuserscolumnsToHide,'column_names' => $onlineuserscolumnsNames, 'timestamp_delegate' => array('last_check_time','last_visit','first_visit')),
-    'closed_chats' => array('rows' => $closedChats, 'size' => count($closedChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'pending_chats' => array('rows' => $pendingChats, 'size' => count($pendingChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'transfered_chats' => array('rows' => $transferedChats, 'size' => count($transferedChats), 'hidden_columns' => array_merge($columnsToHide,array('transfer_id')), 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'operators_chats' => array('rows' => $onlineOperators, 'size' => count($onlineOperators), 'hidden_columns' => array(), 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'subject_chats' => array('rows' => $chatsSubjectChats, 'size' => count($chatsSubjectChats), 'hidden_columns' => array(), 'timestamp_delegate' => array('time'),'column_names' => $columnsName),
-    'bot_chats' => array('rows' => $botChats, 'size' => count($botChats), 'hidden_columns' => array(), 'timestamp_delegate' => array('time'),'column_names' => $columnsName)
-);
+    'active_chats' => ['rows' => $activeChats, 'size' => count($activeChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'unread_chats' => ['rows' => $unreadChats, 'size' => count($unreadChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'online_users' => ['rows' => $onlineUsers, 'size' => count($onlineUsers), 'hidden_columns' => $onlineuserscolumnsToHide, 'column_names' => $onlineuserscolumnsNames, 'timestamp_delegate' => ['last_check_time', 'last_visit', 'first_visit']],
+    'closed_chats' => ['rows' => $closedChats, 'size' => count($closedChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'pending_chats' => ['rows' => $pendingChats, 'size' => count($pendingChats), 'hidden_columns' => $columnsToHide, 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'transfered_chats' => ['rows' => $transferedChats, 'size' => count($transferedChats), 'hidden_columns' => [...$columnsToHide, ['transfer_id']], 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'operators_chats' => ['rows' => $onlineOperators, 'size' => count($onlineOperators), 'hidden_columns' => [], 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'subject_chats' => ['rows' => $chatsSubjectChats, 'size' => count($chatsSubjectChats), 'hidden_columns' => [], 'timestamp_delegate' => ['time'], 'column_names' => $columnsName],
+    'bot_chats' => ['rows' => $botChats, 'size' => count($botChats), 'hidden_columns' => [], 'timestamp_delegate' => ['time'], 'column_names' => $columnsName]
+];
 
-erLhcoreClassChatEventDispatcher::getInstance()->dispatch('xml.lists', array('list' => & $response));
+erLhcoreClassChatEventDispatcher::getInstance()->dispatch('xml.lists', ['list' => & $response]);
 
 echo json_encode($response);
 
 $currentUser->updateLastVisit();
 exit;
-?>

--- a/lhc_web/modules/lhxml/module.php
+++ b/lhc_web/modules/lhxml/module.php
@@ -1,77 +1,75 @@
 <?php
 
-$Module = array( "name" => "Live helper Chat XML service");
+$Module = ['name' => 'Live helper Chat XML service'];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['checklogin'] = array(
+$ViewList['checklogin'] = [
     'script' => 'checklogin.php',
-    'params' => array()
-);
+    'params' => []
+];
 
-$ViewList['closedchats'] = array(
+$ViewList['closedchats'] = [
     'script' => 'closedchats.php',
-    'params' => array()
-);
+    'params' => []
+];
 
-$ViewList['lists'] = array(
+$ViewList['lists'] = [
     'script' => 'lists.php',
-    'params' => array()
-);
+    'params' => []
+];
 
-$ViewList['getuseronlinestatus'] = array(
+$ViewList['getuseronlinestatus'] = [
     'script' => 'getuseronlinestatus.php',
-    'params' => array()
-);
+    'params' => []
+];
 
-$ViewList['setonlinestatus'] = array(
-    'params' => array('status')
-);
+$ViewList['setonlinestatus'] = [
+    'params' => ['status']
+];
 
-$ViewList['deletechat'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['deletechat'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['chatdata'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['chatdata'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['cannedresponses'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['cannedresponses'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['chatssynchro'] = array(
-    'params' => array()
-);
+$ViewList['chatssynchro'] = [
+    'params' => []
+];
 
-$ViewList['closechat'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['closechat'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['addmsgadmin'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['addmsgadmin'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['transferchat'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['transferchat'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['transferuser'] = array(
-    'params' => array('chat_id','user_id')
-);
+$ViewList['transferuser'] = [
+    'params' => ['chat_id','user_id']
+];
 
-$ViewList['accepttransfer'] = array(
-    'params' => array('transfer_id')
-);
+$ViewList['accepttransfer'] = [
+    'params' => ['transfer_id']
+];
 
-$ViewList['accepttransferbychat'] = array(
-    'params' => array('chat_id')
-);
+$ViewList['accepttransferbychat'] = [
+    'params' => ['chat_id']
+];
 
-$ViewList['sendnotice'] = array(
-		'params' => array('online_id')
-);
+$ViewList['sendnotice'] = [
+		'params' => ['online_id']
+];
 
-$FunctionList = array();
-
-?>
+$FunctionList = [];

--- a/lhc_web/modules/lhxml/sendnotice.php
+++ b/lhc_web/modules/lhxml/sendnotice.php
@@ -7,22 +7,22 @@ if (!isset($options['notifications']) || !$options['notifications']) {
 }
 
 $currentUser = erLhcoreClassUser::instance();
-if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],$_POST['password']))
+if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'], $_POST['password']))
 {
     exit;
 }
 
 try {
-	$visitor = erLhcoreClassModelChatOnlineUser::fetch((int)$Params['user_parameters']['online_id']);
+	$visitor = erLhcoreClassModelChatOnlineUser::fetch((int) $Params['user_parameters']['online_id']);
 } catch (Exception $e) {
 	exit;
 }
 
-if ( isset($_POST['msg']) && trim($_POST['msg']) != '') {
+if (isset($_POST['msg']) && trim($_POST['msg']) != '') {
 
-	$validationFields = array();
-	$validationFields['msg'] =  new ezcInputFormDefinitionElement( ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw' );
-	$form = new ezcInputForm( INPUT_POST, $validationFields );
+	$validationFields = [];
+	$validationFields['msg'] =  new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw');
+	$form = new ezcInputForm(INPUT_POST, $validationFields);
 
 	$visitor->operator_message = $form->msg;
 	$visitor->message_seen = 0;
@@ -31,4 +31,3 @@ if ( isset($_POST['msg']) && trim($_POST['msg']) != '') {
 }
 
 exit;
-?>

--- a/lhc_web/modules/lhxml/setonlinestatus.php
+++ b/lhc_web/modules/lhxml/setonlinestatus.php
@@ -8,15 +8,14 @@ if (!isset($options['notifications']) || !$options['notifications']) {
 
 $currentUser = erLhcoreClassUser::instance();
 
-if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],$_POST['password']))
+if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'], $_POST['password']))
 {
 	exit;
 }
 
 $UserData = $currentUser->getUserData(true);
 
-if ( $currentUser->hasAccessTo('lhuser','changeonlinestatus') ) {
-
+if ($currentUser->hasAccessTo('lhuser', 'changeonlinestatus')) {
 	if ($Params['user_parameters']['status'] == '0') {
 		$UserData->hide_online = 0;
 	} else {
@@ -29,7 +28,7 @@ if ( $currentUser->hasAccessTo('lhuser','changeonlinestatus') ) {
 
     erLhcoreClassChat::updateActiveChats($UserData->id);
 
-    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.operator_status_changed',array('user' => & $UserData, 'reason' => 'user_action'));
+    erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.operator_status_changed', ['user' => & $UserData, 'reason' => 'user_action']);
 }
+
 exit;
-?>

--- a/lhc_web/modules/lhxml/transferchat.php
+++ b/lhc_web/modules/lhxml/transferchat.php
@@ -9,20 +9,18 @@ if (!isset($options['notifications']) || !$options['notifications']) {
 header('Content-type: application/json');
 
 $currentUser = erLhcoreClassUser::instance();
-if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],$_POST['password']))
+if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'], $_POST['password']))
 {
     exit;
 }
 
-$onlineUsers = erLhcoreClassChat::getOnlineUsers(array($currentUser->getUserID()));
+$onlineUsers = erLhcoreClassChat::getOnlineUsers([$currentUser->getUserID()]);
 
 // Temporary un-till we release a new version of mobile app
 foreach ($onlineUsers as & $onlineUser) {
-    $onlineUser['id'] = (string)$onlineUser['id'];
+    $onlineUser['id'] = (string) $onlineUser['id'];
 }
 
-echo json_encode(array('result' => $onlineUsers));
+echo json_encode(['result' => $onlineUsers]);
 
 exit;
-
-?>

--- a/lhc_web/modules/lhxml/transferuser.php
+++ b/lhc_web/modules/lhxml/transferuser.php
@@ -12,13 +12,12 @@ if (!$currentUser->isLogged() && !$currentUser->authenticate($_POST['username'],
     exit;
 }
 
-$Chat = erLhcoreClassChat::getSession()->load( 'erLhcoreClassModelChat', $Params['user_parameters']['chat_id']);
+$Chat = erLhcoreClassChat::getSession()->load('erLhcoreClassModelChat', $Params['user_parameters']['chat_id']);
 
-if ( erLhcoreClassChat::hasAccessToRead($Chat) )
+if (erLhcoreClassChat::hasAccessToRead($Chat))
 {
-	if (is_numeric( $Params['user_parameters']['chat_id']) && is_numeric($Params['user_parameters']['user_id']))
+	if (is_numeric($Params['user_parameters']['chat_id']) && is_numeric($Params['user_parameters']['user_id']))
 	{
-
 		$Transfer = new erLhcoreClassModelTransfer();
 		$Transfer->chat_id = $Params['user_parameters']['chat_id'];
 		$Transfer->transfer_to_user_id = $Params['user_parameters']['user_id'];
@@ -36,17 +35,17 @@ if ( erLhcoreClassChat::hasAccessToRead($Chat) )
         $userTo = erLhcoreClassModelUser::fetch($Transfer->transfer_to_user_id);
         $msg->name_support = $userTo->name_support;
 
-        \LiveHelperChat\Models\Departments\UserDepAlias::getAlias(array('scope' => 'msg', 'msg' => & $msg, 'chat' => & $Chat, 'user_id' => $userTo->id));
-        erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.before_msg_admin_saved', array('msg' => & $msg, 'chat' => & $Chat, 'user_id' => $userTo->id));
+        \LiveHelperChat\Models\Departments\UserDepAlias::getAlias(['scope' => 'msg', 'msg' => & $msg, 'chat' => & $Chat, 'user_id' => $userTo->id]);
+        erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.before_msg_admin_saved', ['msg' => & $msg, 'chat' => & $Chat, 'user_id' => $userTo->id]);
 
         $userToNick = $msg->name_support;
 
-        $msg->name_support = (string)$currentUser->getUserData()->name_support;
+        $msg->name_support = (string) $currentUser->getUserData()->name_support;
 
-        \LiveHelperChat\Models\Departments\UserDepAlias::getAlias(array('scope' => 'msg', 'msg' => & $msg, 'chat' => & $Chat, 'user_id' => $currentUser->getUserID()));
-        erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.before_msg_admin_saved', array('msg' => & $msg, 'chat' => & $Chat, 'user_id' => $currentUser->getUserID()));
+        \LiveHelperChat\Models\Departments\UserDepAlias::getAlias(['scope' => 'msg', 'msg' => & $msg, 'chat' => & $Chat, 'user_id' => $currentUser->getUserID()]);
+        erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.before_msg_admin_saved', ['msg' => & $msg, 'chat' => & $Chat, 'user_id' => $currentUser->getUserID()]);
 
-        $msg->msg = (string)$msg->name_support . ' ' . erTranslationClassLhTranslation::getInstance()->getTranslation('chat/transferuser', 'has transferred chat to') . ' ' . (string)$userToNick;
+        $msg->msg = (string) $msg->name_support . ' ' . erTranslationClassLhTranslation::getInstance()->getTranslation('chat/transferuser', 'has transferred chat to') . ' ' . (string) $userToNick;
 
         // Save message
         erLhcoreClassChat::getSession()->save($msg);
@@ -56,9 +55,8 @@ if ( erLhcoreClassChat::hasAccessToRead($Chat) )
         $Chat->transfer_uid = $currentUser->getUserID();
         $Chat->saveThis();
 
-		erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.chat_transfered', array('chat' => & $Chat, 'transfer' => $Transfer, 'msg' => $msg));
+		erLhcoreClassChatEventDispatcher::getInstance()->dispatch('chat.chat_transfered', ['chat' => & $Chat, 'transfer' => $Transfer, 'msg' => $msg]);
 	}
 }
 
 exit;
-?>

--- a/lhc_web/modules/lhxmp/configuration.php
+++ b/lhc_web/modules/lhxmp/configuration.php
@@ -1,17 +1,16 @@
 <?php
 
-erLhcoreClassChatEventDispatcher::getInstance()->dispatch('xmp.configuration', array());
+erLhcoreClassChatEventDispatcher::getInstance()->dispatch('xmp.configuration', []);
 
-$tpl = erLhcoreClassTemplate::getInstance( 'lhxmp/xmp.tpl.php');
-
+$tpl = erLhcoreClassTemplate::getInstance('lhxmp/xmp.tpl.php');
 $xmpData = erLhcoreClassModelChatConfig::fetch('xmp_data');
-$data = (array)$xmpData->data;
+$data = (array) $xmpData->data;
 
 if (isset($_POST['StoreXMPGTalkSendeMessage'])) {
 	try {
-        $definition = array(
+        $definition = [
             'test_recipients_gtalk' => new ezcInputFormDefinitionElement(ezcInputFormDefinitionElement::OPTIONAL, 'validate_email')
-        );
+        ];
         
         $form = new ezcInputForm(INPUT_POST, $definition);
 
@@ -21,33 +20,31 @@ if (isset($_POST['StoreXMPGTalkSendeMessage'])) {
 
         if ($form->hasValidData('test_recipients_gtalk')) {
             erLhcoreClassXMP::sendTestXMPGTalk($form->test_recipients_gtalk);
-            $tpl->set('message_send','done');
-            $tpl->set('test_gmail_email',$form->test_recipients_gtalk);
+            $tpl->set('message_send', 'done');
+            $tpl->set('test_gmail_email', $form->test_recipients_gtalk);
         } else {
-            $tpl->set('errors',array(erTranslationClassLhTranslation::getInstance()->getTranslation('system/xmpp','Invalid test e-mail address')));
+            $tpl->set('errors', [erTranslationClassLhTranslation::getInstance()->getTranslation('system/xmpp', 'Invalid test e-mail address')]);
         }
 	    
 	} catch (Exception $e) {
-		$tpl->set('errors',array($e->getMessage()));
+		$tpl->set('errors', [$e->getMessage()]);
 	}
 }
 
-if (isset($_POST['StoreXMPGTalkRevokeToken'])){
+if (isset($_POST['StoreXMPGTalkRevokeToken'])) {
 	try {
-
         if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
             throw new Exception('Invalid CSRF token!');
         }
 
 		erLhcoreClassXMP::revokeAccessToken();
-		$tpl->set('token_revoked','done');
+		$tpl->set('token_revoked', 'done');
 	} catch (Exception $e) {
-		$tpl->set('errors',array($e->getMessage()));
+		$tpl->set('errors', [$e->getMessage()]);
 	}
 }
 
 if ($Params['user_parameters_unordered']['gtalkoauth'] == 'true') {
-	
 	require_once 'lib/core/lhxmp/google/Google_Client.php';
 	require_once 'lib/core/lhxmp/google/contrib/Google_Oauth2Service.php';
 	
@@ -55,7 +52,7 @@ if ($Params['user_parameters_unordered']['gtalkoauth'] == 'true') {
 	$oauth2 = new Google_Oauth2Service($client);
 	
 	$client->setApplicationName('Live Helper Chat');
-	$client->setScopes(array("https://www.googleapis.com/auth/googletalk","https://www.googleapis.com/auth/userinfo.email"));
+	$client->setScopes(['https://www.googleapis.com/auth/googletalk', 'https://www.googleapis.com/auth/userinfo.email']);
 	
 	$client->setClientId($data['gtalk_client_id']);
 	$client->setClientSecret($data['gtalk_client_secret']);
@@ -72,79 +69,76 @@ if ($Params['user_parameters_unordered']['gtalkoauth'] == 'true') {
 						
 			$xmpData->value = serialize($data);
 			$xmpData->saveThis();
-			$tpl->set('token_received','done');
+			$tpl->set('token_received', 'done');
 		} catch (Exception $e) {
-			$tpl->set('errors',array($e->getMessage()));
+			$tpl->set('errors', [$e->getMessage()]);
 		}
 	} else {
-		$tpl->set('errors',array('Could not receive a token!'));
+		$tpl->set('errors', ['Could not receive a token!']);
 	}
 }
 
-
-
-
-if ( isset($_POST['StoreXMPGTalkSettings']) || isset($_POST['StoreXMPGTalkSettingsTest'])) {
-	$definition = array(
-			'gtalk_client_id' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'gtalk_client_secret' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'XMPMessage' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'XMPAcceptedMessage' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),			
-			'use_standard_xmp' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'int'
-			),			
-			'use_xmp' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'int'
-			)
-	);
+if (isset($_POST['StoreXMPGTalkSettings']) || isset($_POST['StoreXMPGTalkSettingsTest'])) {
+	$definition = [
+		'gtalk_client_id' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'gtalk_client_secret' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'XMPMessage' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'XMPAcceptedMessage' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),			
+		'use_standard_xmp' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'int'
+		),			
+		'use_xmp' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'int'
+		)
+	];
 	
 	if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
 		erLhcoreClassModule::redirect('xmp/configuration');
 		exit;
 	}
 		
-	$form = new ezcInputForm( INPUT_POST, $definition );
-	$Errors = array();
+	$form = new ezcInputForm(INPUT_POST, $definition);
+	$Errors = [];
 	
-	if ( $form->hasValidData( 'gtalk_client_id' )) {
+	if ($form->hasValidData('gtalk_client_id')) {
 		$data['gtalk_client_id'] = $form->gtalk_client_id;
 	} else {
 		$data['gtalk_client_id'] = '';
 	}
 	
-	if ( $form->hasValidData( 'gtalk_client_secret' )) {
+	if ($form->hasValidData('gtalk_client_secret')) {
 		$data['gtalk_client_secret'] = $form->gtalk_client_secret;
 	} else {
 		$data['gtalk_client_secret'] = '';
 	}
 	
-	if ( $form->hasValidData( 'use_xmp' ) && $form->use_xmp == true ) {
+	if ($form->hasValidData('use_xmp') && $form->use_xmp == true) {
 		$data['use_xmp'] = 1;
 	} else {
 		$data['use_xmp'] = 0;
 	}
 	
-	if ( $form->hasValidData( 'use_standard_xmp' )) {
+	if ($form->hasValidData('use_standard_xmp')) {
 		$data['use_standard_xmp'] = $form->use_standard_xmp;
 	} else {
 		$data['use_standard_xmp'] = 0;
 	}
 	
-	if ( $form->hasValidData( 'XMPMessage' ) ) {
+	if ($form->hasValidData('XMPMessage')) {
 		$data['xmp_message'] = $form->XMPMessage;
 	} else {
 		$data['xmp_message'] = '';
 	}
 	
-	if ( $form->hasValidData( 'XMPAcceptedMessage' ) ) {
+	if ($form->hasValidData('XMPAcceptedMessage')) {
 		$data['xmp_accepted_message'] = $form->XMPAcceptedMessage;
 	} else {
 		$data['xmp_accepted_message'] = '';
@@ -154,12 +148,11 @@ if ( isset($_POST['StoreXMPGTalkSettings']) || isset($_POST['StoreXMPGTalkSettin
 	$xmpData->saveThis();
 	
 	if (isset($_POST['StoreXMPGTalkSettingsTest'])) {
-	
 		require_once 'lib/core/lhxmp/google/Google_Client.php';
 	
 		$client = new Google_Client();
 		$client->setApplicationName('Live Helper Chat');
-		$client->setScopes(array("https://www.googleapis.com/auth/googletalk","https://www.googleapis.com/auth/userinfo.email"));
+		$client->setScopes(['https://www.googleapis.com/auth/googletalk', 'https://www.googleapis.com/auth/userinfo.email']);
 	
 		// Documentation: http://code.google.com/apis/gdata/docs/2.0/basics.html
 		// Visit https://code.google.com/apis/console?api=contacts to generate your
@@ -170,140 +163,138 @@ if ( isset($_POST['StoreXMPGTalkSettings']) || isset($_POST['StoreXMPGTalkSettin
 		$client->setAccessType('offline');
 		$client->setRedirectUri(erLhcoreClassSystem::getHost() . erLhcoreClassDesign::baseurl('xmp/configuration').'/(gtalkoauth)/true');
 			
-		if ( !$client->getAccessToken() ) {
+		if (!$client->getAccessToken()) {
 			header('Location: '.$client->createAuthUrl());
 			exit;
 		}
 	}
 	
-	$tpl->set('updated','done');
+	$tpl->set('updated', 'done');
 }
 
-
-if ( isset($_POST['StoreXMPSettings']) || isset($_POST['StoreXMPSettingsTest']) ) {
-
-	$definition = array(
-			'host' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'username' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'password' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'port' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'use_xmp' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'boolean'
-			),
-			'resource' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),			
-			'server' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'recipients' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'XMPMessage' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'XMPAcceptedMessage' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'test_recipients' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'test_group_recipients' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
-			),
-			'use_standard_xmp' => new ezcInputFormDefinitionElement(
-					ezcInputFormDefinitionElement::OPTIONAL, 'int'
-			)
-	);
+if (isset($_POST['StoreXMPSettings']) || isset($_POST['StoreXMPSettingsTest'])) {
+	$definition = [
+		'host' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'username' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'password' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'port' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'use_xmp' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'boolean'
+		),
+		'resource' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),			
+		'server' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'recipients' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'XMPMessage' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'XMPAcceptedMessage' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'test_recipients' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'test_group_recipients' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'unsafe_raw'
+		),
+		'use_standard_xmp' => new ezcInputFormDefinitionElement(
+			ezcInputFormDefinitionElement::OPTIONAL, 'int'
+		)
+	];
 
 	if (!isset($_POST['csfr_token']) || !$currentUser->validateCSFRToken($_POST['csfr_token'])) {
 		erLhcoreClassModule::redirect('xmp/configuration');
 		exit;
 	}
 
-	$Errors = array();
+	$Errors = [];
 
-	$form = new ezcInputForm( INPUT_POST, $definition );
-	$Errors = array();
+	$form = new ezcInputForm(INPUT_POST, $definition);
+	$Errors = [];
 
-	if ( $form->hasValidData( 'host' )) {
+	if ($form->hasValidData('host')) {
 		$data['host'] = $form->host;
 	} else {
 		$data['host'] = '';
 	}
 
-	if ( $form->hasValidData( 'server' )) {
+	if ($form->hasValidData('server')) {
 		$data['server'] = $form->server;
 	} else {
 		$data['server'] = '';
 	}
 
-	if ( $form->hasValidData( 'resource' )) {
+	if ($form->hasValidData('resource')) {
 		$data['resource'] = $form->resource;
 	} else {
 		$data['resource'] = '';
 	}
 
-	if ( $form->hasValidData( 'recipients' )) {
+	if ($form->hasValidData('recipients')) {
 		$data['recipients'] = $form->recipients;
 	} else {
 		$data['recipients'] = '';
 	}
 
-	if ( $form->hasValidData( 'port' )) {
+	if ($form->hasValidData('port')) {
 		$data['port'] = $form->port;
 	} else {
 		$data['port'] = '';
 	}
 
-	if ( $form->hasValidData( 'use_xmp' ) && $form->use_xmp == true ) {
+	if ($form->hasValidData('use_xmp') && $form->use_xmp == true) {
 		$data['use_xmp'] = 1;
 	} else {
 		$data['use_xmp'] = 0;
 	}
 
-	if ( $form->hasValidData( 'username' ) ) {
+	if ($form->hasValidData('username')) {
 		$data['username'] = $form->username;
 	} else {
 		$data['username'] = '';
 	}
 
-	if ( $form->hasValidData( 'password' ) && $form->password != '' ) {
+	if ($form->hasValidData('password') && $form->password != '') {
 		$data['password'] = $form->password;
 	}
 
-	if ( $form->hasValidData( 'XMPMessage' ) ) {
+	if ($form->hasValidData('XMPMessage')) {
 		$data['xmp_message'] = $form->XMPMessage;
 	} else {
 		$data['xmp_message'] = '';
 	}
 	
-	if ( $form->hasValidData( 'XMPAcceptedMessage' ) ) {
+	if ($form->hasValidData('XMPAcceptedMessage')) {
 		$data['xmp_accepted_message'] = $form->XMPAcceptedMessage;
 	} else {
 		$data['xmp_accepted_message'] = '';
 	}
 	
-	if ( $form->hasValidData( 'use_standard_xmp' )) {
+	if ($form->hasValidData('use_standard_xmp')) {
 		$data['use_standard_xmp'] = $form->use_standard_xmp;
 	} else {
 		$data['use_standard_xmp'] = 0;
 	}
 	
-	if ( $form->hasValidData( 'test_recipients' )) {
+	if ($form->hasValidData('test_recipients')) {
 		$data['test_recipients'] = $form->test_recipients;
 	} else {
 		$data['test_recipients'] = '';
 	}
-	if ( $form->hasValidData( 'test_group_recipients' )) {
+	if ($form->hasValidData('test_group_recipients')) {
 		$data['test_group_recipients'] = $form->test_group_recipients;
 	} else {
 		$data['test_group_recipients'] = '';
@@ -315,19 +306,22 @@ if ( isset($_POST['StoreXMPSettings']) || isset($_POST['StoreXMPSettingsTest']) 
 	if (isset($_POST['StoreXMPSettingsTest'])){
 		try {
 			erLhcoreClassXMP::sendTestXMP($currentUser->getUserData());
-			$tpl->set('message_send','done');
+			$tpl->set('message_send', 'done');
 		} catch (Exception $e) {
-			$tpl->set('errors',array($e->getMessage()));
+			$tpl->set('errors', [$e->getMessage()]);
 		}
 	}
 
-	$tpl->set('updated','done');
+	$tpl->set('updated', 'done');
 }
 
 $tpl->set('xmp_data',$data);
 
 $Result['content'] = $tpl->fetch();
-$Result['path'] = array(array('url' => erLhcoreClassDesign::baseurl('system/configuration'),'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/htmlcode','System configuration')),
-array('title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/xmpp','XMPP settings')));
-
-?>
+$Result['path'] = [
+	[
+		'url' => erLhcoreClassDesign::baseurl('system/configuration'),
+		'title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/htmlcode', 'System configuration')
+	],
+	['title' => erTranslationClassLhTranslation::getInstance()->getTranslation('system/xmpp', 'XMPP settings')]
+];

--- a/lhc_web/modules/lhxmp/module.php
+++ b/lhc_web/modules/lhxmp/module.php
@@ -1,16 +1,14 @@
 <?php
 
-$Module = array( "name" => "XMPP module configuration");
+$Module = ["name" => "XMPP module configuration"];
 
-$ViewList = array();
+$ViewList = [];
 
-$ViewList['configuration'] = array(
-    'params' => array(),
-    'uparams' => array('gtalkoauth'),
-	'functions' => array( 'configurexmp' )
-);
+$ViewList['configuration'] = [
+    'params' => [],
+    'uparams' => ['gtalkoauth'],
+	'functions' => ['configurexmp']
+];
 
-$FunctionList = array();
-$FunctionList['configurexmp'] = array('explain' => 'Allow user to configure XMPP');
-
-?>
+$FunctionList = [];
+$FunctionList['configurexmp'] = ['explain' => 'Allow user to configure XMPP'];


### PR DESCRIPTION
Some of the changes include replacing array() with [] and simplifying a few array_merge usages. Based on a question I asked on Discord, the project's minimum version is expected to be PHP 8.x, so I plan to introduce further improvements soon to take advantage of more modern syntax.

If this PR gets approved, I’ll continue applying these changes across other files — from what I’ve seen, there are around 999 files that still need these updates, along with a few additional improvements.

I would also like clarification regarding the minimum supported PHP version: should the project continue supporting PHP 8.x (8.0+), or would it be possible to raise it to PHP 8.3+ or even 8.4+, considering their longer support lifecycle and ongoing security updates?

Finally, since we’re already moving in this direction, I’d like to suggest that @remdex starts using [] instead of array() going forward. This will help keep the codebase consistent. For now, I’m not changing any logic — just focusing on this core cleanup of array() and array_merge, which are heavily used throughout the project.