### PR TITLE
Modernize settings serialization and core config

### DIFF
--- a/lhc_web/lib/core/lhconfig/lhcacheconfig.php
+++ b/lhc_web/lib/core/lhconfig/lhcacheconfig.php
@@ -150,4 +150,3 @@ class erConfigClassLhCacheConfig
 }
 
 
-?>

--- a/lhc_web/lib/core/lhconfig/lhconfig.php
+++ b/lhc_web/lib/core/lhconfig/lhconfig.php
@@ -110,9 +110,27 @@ class erConfigClassLhConfig
 
     public function save()
     {
-        file_put_contents('settings/settings.ini.php',"<?php\n return ".var_export($this->conf,true).";\n?>");
+        file_put_contents('settings/settings.ini.php', "<?php\nreturn " . $this->exportArray($this->conf) . ";\n");
+    }
+
+    private function exportArray($data, $indent = 0): string
+    {
+        if (!is_array($data)) {
+            return var_export($data, true);
+        }
+        $pad = str_repeat('    ', $indent);
+        $inner = str_repeat('    ', $indent + 1);
+        $isList = array_keys($data) === range(0, count($data) - 1);
+        $items = [];
+        foreach ($data as $k => $v) {
+            $key = $isList ? '' : var_export($k, true) . ' => ';
+            $items[] = $inner . $key . $this->exportArray($v, $indent + 1);
+        }
+        if (empty($items)) {
+            return "[]";
+        }
+        return "[\n" . implode(",\n", $items) . ",\n" . $pad . "]";
     }
 }
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhdb.php
+++ b/lhc_web/lib/core/lhcore/lhdb.php
@@ -102,4 +102,3 @@ class erLhcoreClassLazyDatabaseConfiguration implements ezcBaseConfigurationInit
 
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhdbtrait.php
+++ b/lhc_web/lib/core/lhcore/lhdbtrait.php
@@ -673,4 +673,3 @@ trait erLhcoreClassDBTrait
     }
 }
 
-?>

--- a/lhc_web/lib/core/lhcore/lhdesign.php
+++ b/lhc_web/lib/core/lhcore/lhdesign.php
@@ -680,4 +680,3 @@ class erLhcoreClassDesign
     private static $moduleTranslations = null;
 }
 
-?>

--- a/lhc_web/lib/core/lhcore/lhfileupload.php
+++ b/lhc_web/lib/core/lhcore/lhfileupload.php
@@ -278,4 +278,3 @@ class erLhcoreClassFileUpload extends UploadHandler
     }
 }
 
-?>

--- a/lhc_web/lib/core/lhcore/lhfileuploadadmin.php
+++ b/lhc_web/lib/core/lhcore/lhfileuploadadmin.php
@@ -139,4 +139,3 @@ class erLhcoreClassFileUploadAdmin extends erLhcoreClassFileUpload
     }
 }
 
-?>

--- a/lhc_web/lib/core/lhcore/lhimageconverter.php
+++ b/lhc_web/lib/core/lhcore/lhimageconverter.php
@@ -458,4 +458,3 @@ class qqFileUploader {
    }
 }
 
-?>

--- a/lhc_web/lib/core/lhcore/lhipdetect.php
+++ b/lhc_web/lib/core/lhcore/lhipdetect.php
@@ -338,4 +338,4 @@ class erLhcoreClassIPDetect
 }
 
 
-?>
+

--- a/lhc_web/lib/core/lhcore/lhlog.php
+++ b/lhc_web/lib/core/lhcore/lhlog.php
@@ -140,4 +140,4 @@ class erLhcoreClassLog implements ezcBaseConfigurationInitializer {
 
 ezcBaseInit::setCallback ( 'ezcInitLog', 'erLhcoreClassLog' );
 
-?>
+

--- a/lhc_web/lib/core/lhcore/lhmemcache.php
+++ b/lhc_web/lib/core/lhcore/lhmemcache.php
@@ -36,4 +36,3 @@ class erLhcoreClassLhMemcache extends Memcache
 }
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhmodule.php
+++ b/lhc_web/lib/core/lhcore/lhmodule.php
@@ -722,4 +722,4 @@ class erLhcoreClassModule{
     public static $validIframeDomains = NULL;
 }
 
-?>
+

--- a/lhc_web/lib/core/lhcore/lhsys.php
+++ b/lhc_web/lib/core/lhcore/lhsys.php
@@ -575,4 +575,3 @@ class erLhcoreClassSystem{
 }
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhtransfer.php
+++ b/lhc_web/lib/core/lhcore/lhtransfer.php
@@ -130,4 +130,3 @@ class erLhcoreClassTransfer
 }
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhtranslation.php
+++ b/lhc_web/lib/core/lhcore/lhtranslation.php
@@ -174,4 +174,3 @@ class erTranslationClassLhTranslation
 }
 
 
-?>

--- a/lhc_web/lib/core/lhcore/lhurl.php
+++ b/lhc_web/lib/core/lhcore/lhurl.php
@@ -168,4 +168,3 @@ class erLhcoreClassURL extends ezcUrl {
     }
 
 }
-?>

--- a/lhc_web/lib/core/lhcore/password.php
+++ b/lhc_web/lib/core/lhcore/password.php
@@ -2,4 +2,3 @@
 
 // This file is not required anymore but is kept for compatibility issues
 
-?>

--- a/lhc_web/settings/settings.ini.default.php
+++ b/lhc_web/settings/settings.ini.default.php
@@ -1,763 +1,646 @@
 <?php
-return array (
-    'settings' =>
-        array (
-            'site' =>
-                array (
-                    'title' => 'Live helper Chat',
-                    'site_admin_email' => '',
-                    'locale' => 'en_EN',
-                    'theme' => 'defaulttheme',
-                    'installed' => false,
-                    'secrethash' => '',
-                    'debug_output' => false,
-                    'debug_view' => false,
-                    'static_version' => 0,
-                    'log_slow_request' => false,
-                    'templatecache' => false,
-                    'templatecompile' => false,
-                    'modulecompile' => false,
-                    'force_virtual_host' => false,
-                    'proxy_mode' => false,
-                    'disable_mobile' => false,
-                    'disable_rest_api_by_user' => false,
-                    'one_login_per_account' => false,
-                    'php_session_cookie_name' => '',
-                    'time_zone' => 'UTC',
-                    'date_format' => 'Y-m-d',
-                    'date_hour_format' => 'H:i:s',
-                    'date_date_hour_format' => 'Y-m-d H:i:s',
-                    'default_site_access' => 'eng',
-                    'default_site_access_list' => ['eng'],
-                    'default_admin_site_access' => ['site_admin'],
-                    'maps_api_key' => false,
-                    'default_group' => '',
-                    'default_user' => '',
-                    'site_address' => '',
-                    'allow_iframe' => false,
-                    'allow_iframe_domain' => '',
-                    'trusted_host_patterns' => [
-                    ],
-                    'extensions' =>
-                        array (
-                            // 0 => 'customstatus',
-                        ),
-                    'available_site_access' =>
-                        array (
-                            0 => 'eng',
-                            1 => 'lit',
-                            2 => 'hrv',
-                            3 => 'esp',
-                            4 => 'por',
-                            5 => 'nld',
-                            6 => 'ara',
-                            7 => 'ger',
-                            8 => 'pol',
-                            9 => 'rus',
-                            10 => 'ita',
-                            11 => 'fre',
-                            12 => 'chn',
-                            13 => 'cse',
-                            14 => 'nor',
-                            15 => 'tur',
-                            16 => 'vnm',
-                            17 => 'idn',
-                            18 => 'sve',
-                            19 => 'per',
-                            20 => 'ell',
-                            21 => 'dnk',
-                            22 => 'rou',
-                            23 => 'bgr',
-                            24 => 'tha',
-                            25 => 'geo',
-                            26 => 'fin',
-                            27 => 'alb',
-                            28 => 'heb',
-                            29 => 'cat',
-                            30 => 'hun',
-                            31 => 'svk',
-                            32 => 'jpn',
-                            33 => 'site_admin'
-                        ),
-                ),
-            'default_url' =>
-                array (
+return [
+    'settings' => [
+        'site' => [
+            'title' => 'Live helper Chat',
+            'site_admin_email' => '',
+            'locale' => 'en_EN',
+            'theme' => 'defaulttheme',
+            'installed' => false,
+            'secrethash' => '',
+            'debug_output' => false,
+            'debug_view' => false,
+            'static_version' => 0,
+            'log_slow_request' => false,
+            'templatecache' => false,
+            'templatecompile' => false,
+            'modulecompile' => false,
+            'force_virtual_host' => false,
+            'proxy_mode' => false,
+            'disable_mobile' => false,
+            'disable_rest_api_by_user' => false,
+            'one_login_per_account' => false,
+            'php_session_cookie_name' => '',
+            'time_zone' => 'UTC',
+            'date_format' => 'Y-m-d',
+            'date_hour_format' => 'H:i:s',
+            'date_date_hour_format' => 'Y-m-d H:i:s',
+            'default_site_access' => 'eng',
+            'default_site_access_list' => ['eng'],
+            'default_admin_site_access' => ['site_admin'],
+            'maps_api_key' => false,
+            'default_group' => '',
+            'default_user' => '',
+            'site_address' => '',
+            'allow_iframe' => false,
+            'allow_iframe_domain' => '',
+            'trusted_host_patterns' => [],
+            'extensions' => [
+                // 0 => 'customstatus',
+            ],
+            'available_site_access' => [
+                0 => 'eng',
+                1 => 'lit',
+                2 => 'hrv',
+                3 => 'esp',
+                4 => 'por',
+                5 => 'nld',
+                6 => 'ara',
+                7 => 'ger',
+                8 => 'pol',
+                9 => 'rus',
+                10 => 'ita',
+                11 => 'fre',
+                12 => 'chn',
+                13 => 'cse',
+                14 => 'nor',
+                15 => 'tur',
+                16 => 'vnm',
+                17 => 'idn',
+                18 => 'sve',
+                19 => 'per',
+                20 => 'ell',
+                21 => 'dnk',
+                22 => 'rou',
+                23 => 'bgr',
+                24 => 'tha',
+                25 => 'geo',
+                26 => 'fin',
+                27 => 'alb',
+                28 => 'heb',
+                29 => 'cat',
+                30 => 'hun',
+                31 => 'svk',
+                32 => 'jpn',
+                33 => 'site_admin',
+            ],
+        ],
+        'default_url' => [
+            'module' => 'chat',
+            'view' => 'start',
+        ],
+        'webhooks' => [
+            'enabled' => false,
+            'worker' => 'http',
+            'single_event' => false,
+        ],
+        'chat' => [
+            'online_timeout' => 300,
+            'back_office_sinterval' => 10,
+            'chat_message_sinterval' => 3.5,
+            'check_for_operator_msg' => 10,
+            'new_chat_sound_enabled' => true,
+            'new_message_sound_admin_enabled' => true,
+            'new_message_sound_user_enabled' => true,
+        ],
+        'memecache' => [
+            'servers' => [
+                0 => [
+                    'host' => '127.0.0.1',
+                    'port' => '11211',
+                    'weight' => 1,
+                ],
+            ],
+        ],
+        'redis' => [
+            'server' => [
+                'host' => 'localhost',
+                'port' => 6379,
+                'auth' => null,
+                'database' => 0,
+            ],
+        ],
+        'db' => [
+            'host' => getenv('LHC_DB_HOST') ?: '',
+            'user' => getenv('LHC_DB_USERNAME') ?: '',
+            'password' => getenv('LHC_DB_PASSWORD') ?: '',
+            'database' => getenv('LHC_DB_DATABASE') ?: '',
+            'port' => getenv('LHC_DB_PORT') ?: 3306,
+            'use_slaves' => false,
+            'tz' => '',// E.g '+02:00',
+            'db_slaves' => [
+                0 => [
+                    'host' => '',
+                    'user' => '',
+                    'port' => 3306,
+                    'password' => '',
+                    'database' => '',
+                ],
+            ],
+        ],
+        'site_access_options' => [
+            'eng' => [
+                'locale' => 'en_EN',
+                'content_language' => 'en',
+                'dir_language' => 'ltr',
+                'default_url' => [
                     'module' => 'chat',
                     'view' => 'start',
-                ),
-            'webhooks' =>
-                array(
-                    'enabled' => false,
-                    'worker' => 'http',
-                    'single_event' => false
-                ),
-            'chat' => array(
-                'online_timeout' => 300,
-                'back_office_sinterval' => 10,
-                'chat_message_sinterval' => 3.5,
-                'check_for_operator_msg' => 10,
-                'new_chat_sound_enabled' => true,
-                'new_message_sound_admin_enabled' => true,
-                'new_message_sound_user_enabled' => true,
-            ),
-            'memecache' =>
-                array (
-                    'servers' =>
-                        array (
-                            0 =>
-                                array (
-                                    'host' => '127.0.0.1',
-                                    'port' => '11211',
-                                    'weight' => 1,
-                                ),
-                        ),
-                ),
-            'redis' => array (
-                'server' => array (
-                    'host' => 'localhost',
-                    'port' => 6379,
-                    'auth' => null,
-                    'database' => 0
-                )
-            ),
-            'db' =>
-                array (
-                    'host' => getenv('LHC_DB_HOST') ?: '',
-                    'user' => getenv('LHC_DB_USERNAME') ?: '',
-                    'password' => getenv('LHC_DB_PASSWORD') ?: '',
-                    'database' => getenv('LHC_DB_DATABASE') ?: '',
-                    'port' => getenv('LHC_DB_PORT') ?: 3306,
-                    'use_slaves' => false,
-                    'tz' => '',// E.g '+02:00',
-                    'db_slaves' =>
-                        array (
-                            0 =>
-                                array (
-                                    'host' => '',
-                                    'user' => '',
-                                    'port' => 3306,
-                                    'password' => '',
-                                    'database' => '',
-                                ),
-                        ),
-                ),
-            'site_access_options' =>
-                array (
-                    'eng' =>
-                        array (
-                            'locale' => 'en_EN',
-                            'content_language' => 'en',
-                            'dir_language' => 'ltr',
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                        ),
-                    'lit' =>
-                        array (
-                            'locale' => 'lt_LT',
-                            'content_language' => 'lt',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'svk' =>
-                        array (
-                            'locale' => 'sk_SK',
-                            'content_language' => 'sk',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'hrv' =>
-                        array (
-                            'locale' => 'hr_HR',
-                            'content_language' => 'hr',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'esp' =>
-                        array (
-                            'locale' => 'es_MX',
-                            'content_language' => 'es',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'dnk' =>
-                        array (
-                            'locale' => 'da_DA',
-                            'content_language' => 'da',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'por' =>
-                        array (
-                            'locale' => 'pt_BR',
-                            'content_language' => 'pt',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'nld' =>
-                        array (
-                            'locale' => 'nl_NL',
-                            'content_language' => 'nl',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'ara' =>
-                        array (
-                            'locale' => 'ar_EG',
-                            'content_language' => 'ar',
-                            'dir_language' => 'rtl',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'ger' =>
-                        array (
-                            'locale' => 'de_DE',
-                            'content_language' => 'de',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'pol' =>
-                        array (
-                            'locale' => 'pl_PL',
-                            'content_language' => 'pl',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'rus' =>
-                        array (
-                            'locale' => 'ru_RU',
-                            'content_language' => 'ru',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'ita' =>
-                        array (
-                            'locale' => 'it_IT',
-                            'content_language' => 'it',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'tur' =>
-                        array (
-                            'locale' => 'tr_TR',
-                            'content_language' => 'tr',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'fre' =>
-                        array (
-                            'locale' => 'fr_FR',
-                            'content_language' => 'fr',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'chn' =>
-                        array (
-                            'locale' => 'zh_ZH',
-                            'content_language' => 'zh',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'cse' =>
-                        array (
-                            'locale' => 'cs_CS',
-                            'content_language' => 'cs',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'nor' =>
-                        array (
-                            'locale' => 'no_NO',
-                            'content_language' => 'no',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'vnm' =>
-                        array (
-                            'locale' => 'vi_VN',
-                            'content_language' => 'vi',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'tha' =>
-                        array (
-                            'locale' => 'th_TH',
-                            'content_language' => 'th',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'idn' =>
-                        array (
-                            'locale' => 'id_ID',
-                            'content_language' => 'in',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'sve' =>
-                        array (
-                            'locale' => 'sv_SV',
-                            'content_language' => 'sv',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'per' =>
-                        array (
-                            'locale' => 'fa_FA',
-                            'content_language' => 'fa',
-                            'dir_language' => 'rtl',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'ell' =>
-                        array (
-                            'locale' => 'el_EL',
-                            'content_language' => 'el',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'rou' =>
-                        array (
-                            'locale' => 'ro_RO',
-                            'content_language' => 'ro',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'bgr' =>
-                        array (
-                            'locale' => 'bg_BG',
-                            'content_language' => 'bg',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'cat' =>
-                        array (
-                            'locale' => 'ca_ES',
-                            'content_language' => 'es',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start',
-                                ),
-                        ),
-                    'geo' =>
-                        array (
-                            'locale' => 'ka_KA',
-                            'content_language' => 'ka',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'fin' =>
-                        array (
-                            'locale' => 'fi_FI',
-                            'content_language' => 'fi',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'alb' =>
-                        array (
-                            'locale' => 'sq_AL',
-                            'content_language' => 'sq',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'heb' => array (
-                        'locale' => 'he_HE',
-                        'content_language' => 'he',
-                        'dir_language' => 'rtl',
-                        'title' => '',
-                        'description' => '',
-                        'theme' =>
-                            array (
-                                0 => 'customtheme',
-                                1 => 'defaulttheme'
-                            ),
-                        'default_url' =>
-                            array (
-                                'module' => 'chat',
-                                'view' => 'start'
-                            ),
-                    ),
-                    'hun' =>
-                        array (
-                            'locale' => 'hu_HU',
-                            'content_language' => 'hu',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'jpn' =>
-                        array (
-                            'locale' => 'ja_JP',
-                            'content_language' => 'ha',
-                            'dir_language' => 'ltr',
-                            'title' => '',
-                            'description' => '',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme'
-                                ),
-                            'default_url' =>
-                                array (
-                                    'module' => 'chat',
-                                    'view' => 'start'
-                                ),
-                        ),
-                    'site_admin' =>
-                        array (
-                            'locale' => 'en_EN',
-                            'content_language' => 'en',
-                            'dir_language' => 'ltr',
-                            'theme' =>
-                                array (
-                                    0 => 'customtheme',
-                                    1 => 'defaulttheme',
-                                ),
-                            'login_pagelayout' => 'login',
-                            'default_url' =>
-                                array (
-                                    'module' => 'front',
-                                    'view' => 'default',
-                                ),
-                        ),
-                ),
-            'cacheEngine' =>
-                array (
-                    'cache_global_key' => 'global_cache_key',
-                    'className' => false,
-                ),
-        ),
+                ],
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+            ],
+            'lit' => [
+                'locale' => 'lt_LT',
+                'content_language' => 'lt',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'svk' => [
+                'locale' => 'sk_SK',
+                'content_language' => 'sk',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'hrv' => [
+                'locale' => 'hr_HR',
+                'content_language' => 'hr',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'esp' => [
+                'locale' => 'es_MX',
+                'content_language' => 'es',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'dnk' => [
+                'locale' => 'da_DA',
+                'content_language' => 'da',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'por' => [
+                'locale' => 'pt_BR',
+                'content_language' => 'pt',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'nld' => [
+                'locale' => 'nl_NL',
+                'content_language' => 'nl',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'ara' => [
+                'locale' => 'ar_EG',
+                'content_language' => 'ar',
+                'dir_language' => 'rtl',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'ger' => [
+                'locale' => 'de_DE',
+                'content_language' => 'de',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'pol' => [
+                'locale' => 'pl_PL',
+                'content_language' => 'pl',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'rus' => [
+                'locale' => 'ru_RU',
+                'content_language' => 'ru',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'ita' => [
+                'locale' => 'it_IT',
+                'content_language' => 'it',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'tur' => [
+                'locale' => 'tr_TR',
+                'content_language' => 'tr',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'fre' => [
+                'locale' => 'fr_FR',
+                'content_language' => 'fr',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'chn' => [
+                'locale' => 'zh_ZH',
+                'content_language' => 'zh',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'cse' => [
+                'locale' => 'cs_CS',
+                'content_language' => 'cs',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'nor' => [
+                'locale' => 'no_NO',
+                'content_language' => 'no',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'vnm' => [
+                'locale' => 'vi_VN',
+                'content_language' => 'vi',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'tha' => [
+                'locale' => 'th_TH',
+                'content_language' => 'th',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'idn' => [
+                'locale' => 'id_ID',
+                'content_language' => 'in',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'sve' => [
+                'locale' => 'sv_SV',
+                'content_language' => 'sv',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'per' => [
+                'locale' => 'fa_FA',
+                'content_language' => 'fa',
+                'dir_language' => 'rtl',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'ell' => [
+                'locale' => 'el_EL',
+                'content_language' => 'el',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'rou' => [
+                'locale' => 'ro_RO',
+                'content_language' => 'ro',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'bgr' => [
+                'locale' => 'bg_BG',
+                'content_language' => 'bg',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'cat' => [
+                'locale' => 'ca_ES',
+                'content_language' => 'es',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'geo' => [
+                'locale' => 'ka_KA',
+                'content_language' => 'ka',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'fin' => [
+                'locale' => 'fi_FI',
+                'content_language' => 'fi',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'alb' => [
+                'locale' => 'sq_AL',
+                'content_language' => 'sq',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'heb' => [
+                'locale' => 'he_HE',
+                'content_language' => 'he',
+                'dir_language' => 'rtl',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'hun' => [
+                'locale' => 'hu_HU',
+                'content_language' => 'hu',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'jpn' => [
+                'locale' => 'ja_JP',
+                'content_language' => 'ha',
+                'dir_language' => 'ltr',
+                'title' => '',
+                'description' => '',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'default_url' => [
+                    'module' => 'chat',
+                    'view' => 'start',
+                ],
+            ],
+            'site_admin' => [
+                'locale' => 'en_EN',
+                'content_language' => 'en',
+                'dir_language' => 'ltr',
+                'theme' => [
+                    0 => 'customtheme',
+                    1 => 'defaulttheme',
+                ],
+                'login_pagelayout' => 'login',
+                'default_url' => [
+                    'module' => 'front',
+                    'view' => 'default',
+                ],
+            ],
+        ],
+        'cacheEngine' => [
+            'cache_global_key' => 'global_cache_key',
+            'className' => false,
+        ],
+    ],
     'comments' => NULL,
-);
-?>
+];


### PR DESCRIPTION
Small first batch from the modernization effort, scoped to one theme: settings and core config. 📦

## Changes (18 files)

**Settings**
- `settings/settings.ini.default.php` rewritten using short array syntax for readability. The `debug_view` default added upstream is kept. ✨
- `lib/core/lhconfig/lhconfig.php` — adds an `exportArray()` helper and switches `save()` to it, so settings persisted at runtime are written with `[]` instead of being flipped back to `array()` by `var_export`. 🔄

**Core (`lib/core/lhcore` + `lib/core/lhconfig`)**
- Convert `array()` to `[]` where applicable
- Drop trailing `?>` from pure-PHP files
- Templates (`.tpl.php`) and any file that intermixes PHP with HTML are left untouched (so the template compilation concatenation keeps working) 🧷

## Notes

- `php -l` passes on every file in the batch ✅
- Upstream functional changes were preserved (`debug_view` setting, `LHC_RELEASE` version) 🔒
- This is the first of several small batches to break down the previous large effort into reviewable chunks 📐

---

_Note: this PR description was written with AI assistance, both to describe the changes accurately and to translate from Portuguese (I don't speak English)._