### PR TITLE
Allow REST file API for single attachment with caption

### DIFF
--- a/lhc_web/design/defaulttheme/tpl/lhgenericbot/form_rest_api.tpl.php
+++ b/lhc_web/design/defaulttheme/tpl/lhgenericbot/form_rest_api.tpl.php
@@ -379,6 +379,10 @@
                             <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/restapi','Convert to multipart/form-data if one of those API is used. Post the file using multipart/form-data in the usual way that files are uploaded via the browser.');?> E.g mp3_m4a,tgs,file_api,image_api,video_api</label>
                             <input type="text" class="form-control form-control-sm" ng-model="param.suburl_file_convert" placeholder="mp3_m4a,tgs,file_api,image_api,video_api" value="" />
                         </div>
+                        <div class="form-group">
+                            <label><?php echo erTranslationClassLhTranslation::getInstance()->getTranslation('genericbot/restapi','Do not use file API with message text for these file extensions');?> E.g tgs,webp</label>
+                            <input type="text" class="form-control form-control-sm" ng-model="param.suburl_file_skip_ext" placeholder="tgs,webp" value="" />
+                        </div>
 
                     </div>
 

--- a/lhc_web/lib/core/lhgenericbot/actionTypes/lhgenericbotactionrestapi.php
+++ b/lhc_web/lib/core/lhgenericbot/actionTypes/lhgenericbotactionrestapi.php
@@ -634,12 +634,21 @@ class erLhcoreClassGenericBotActionRestapi
         $file_mime = null;
 
         $file_api = false;
+        $canSendSingleFileWithText = false;
+
+        if (isset($methodSettings['body_raw_file']) && $methodSettings['body_raw_file'] != '' && count($files) == 1 && trim($msg_text_cleaned) != '' && strpos($methodSettings['body_raw_file'], '{{msg_clean}}') !== false) {
+            $captionUnsupportedExtensions = array();
+            if (isset($methodSettings['suburl_file_skip_ext']) && $methodSettings['suburl_file_skip_ext'] != '') {
+                $captionUnsupportedExtensions = explode(',',str_replace(' ','',strtolower($methodSettings['suburl_file_skip_ext'])));
+            }
+            $canSendSingleFileWithText = !in_array(strtolower($files[0]->extension), $captionUnsupportedExtensions);
+        }
 
         // We want files as attachements.
         if (isset($methodSettings['switch_form_data']) && $methodSettings['switch_form_data'] === true && count($files) == 1 && trim($msg_text_cleaned) == '') {
             $msg_text = '';
         // Switch to file API if it's only one file send
-        } else if (isset($methodSettings['body_raw_file']) && $methodSettings['body_raw_file'] != '' && count($files) == 1 && trim($msg_text_cleaned) == '') {
+        } else if (isset($methodSettings['body_raw_file']) && $methodSettings['body_raw_file'] != '' && count($files) == 1 && (trim($msg_text_cleaned) == '' || $canSendSingleFileWithText === true)) {
             foreach ($files as $mediaFile) {
 
                 $file_api = false;


### PR DESCRIPTION
Allow REST file API to handle a single attachment with text/caption instead of sending rendered attachment HTML through the normal text body.\n\nThis keeps file uploads working when the message contains a caption and preserves the existing behavior for plain text and multi-file messages.\n\nRelated Telegram extension PR: LiveHelperChat/telegram#73