### PR TITLE
Keep message field focused after starting chat

### DIFF
--- a/lhc_web/design/defaulttheme/widget/react-app/src/components/ChatIntroStatus.js
+++ b/lhc_web/design/defaulttheme/widget/react-app/src/components/ChatIntroStatus.js
@@ -13,6 +13,10 @@ class ChatIntroStatus extends PureComponent {
         if (elm) {
             elm.scrollTop = elm.scrollHeight + 1000;
         }
+
+        if (this.props.textMessageRef && this.props.textMessageRef.current) {
+            this.props.textMessageRef.current.focus();
+        }
     }
 
     render() {
@@ -34,7 +38,7 @@ class ChatIntroStatus extends PureComponent {
                 </div>
                 <div className="disable-select d-flex flex-column justify-content-end align-items-stretch" id="send-button-wrapper">
                     <div className="user-chatwidget-buttons pe-1" id="ChatSendButtonContainer">
-                        <i className="material-icons text-muted-light settings me-0">&#xf113;</i>
+                        <i className="material-icons text-muted settings me-0">&#xf113;</i>
                     </div>
                 </div>
             </div>}

--- a/lhc_web/design/defaulttheme/widget/react-app/src/components/OnlineChat.js
+++ b/lhc_web/design/defaulttheme/widget/react-app/src/components/OnlineChat.js
@@ -260,8 +260,16 @@ class OnlineChat extends Component {
 
         // We want to focus only if widget is open
         var elm = document.getElementById('CSChatMessage');
-        if (elm !== null && ((this.props.chatwidget.get('shown') === true && this.props.chatwidget.get('mode') == 'widget') || this.props.chatwidget.get('mode') == 'popup')) {
+        const shouldFocusMessage = elm !== null && ((this.props.chatwidget.get('shown') === true && this.props.chatwidget.get('mode') == 'widget') || this.props.chatwidget.get('mode') == 'popup');
+        if (shouldFocusMessage === true) {
             elm.focus();
+        }
+
+        if (helperFunctions.getSessionStorage('_start_chat_message_focused') !== null) {
+            helperFunctions.removeSessionStorage('_start_chat_message_focused');
+            if (shouldFocusMessage === true) {
+                this.focusMessage();
+            }
         }
     }
 

--- a/lhc_web/design/defaulttheme/widget/react-app/src/components/StartChat.js
+++ b/lhc_web/design/defaulttheme/widget/react-app/src/components/StartChat.js
@@ -150,6 +150,9 @@ class StartChat extends Component {
         var elm = document.getElementById('CSChatMessage');
         if (elm !== null) {
             elm.focus();
+            if (document.activeElement === elm && helperFunctions.hasSessionStorage === true) {
+                helperFunctions.setSessionStorage('_start_chat_message_focused', 1);
+            }
             this.props.setHideMessageField(false);
         }
 


### PR DESCRIPTION
This improves the first-message UX in the React widget.

Before this change, starting a chat can visually look like the message textarea loses focus while the widget transitions from `StartChat` to `OnlineChat`. `StartChat` already focuses `#CSChatMessage` before submitting, but the component switch can still briefly interrupt the focused input.

The change stores a short-lived flag when the start-chat message field was focused and restores focus once `OnlineChat` has mounted, using the same widget/popup visibility condition that already guards the existing focus logic.

Tested with:
- `npm ci`
- `npm run build`