### PR TITLE
Fix incoming webhook file extension detection

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
+++ b/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
@@ -2432,6 +2432,7 @@ class erLhcoreClassChatWebhookIncoming {
             // File extension
             $partsExtension = explode('.',strtok($url, '?'));
             $file_extension = array_pop($partsExtension);
+            $upload_name_extension = strtolower(pathinfo($upload_name, PATHINFO_EXTENSION));
 
             if (isset($overrideAttributes['mime_type']) && !empty($overrideAttributes['mime_type']) && ($file_extension_mime = self::getExtensionByMime($overrideAttributes['mime_type'])) !== false) {
                 $file_extension = $file_extension_mime;
@@ -2442,7 +2443,11 @@ class erLhcoreClassChatWebhookIncoming {
 
             // We want to validate is extension valid one from our defined one
             if (self::getExtensionByMime($file_extension, true) === false) {
-                $file_extension = 'bin';
+                if ($upload_name_extension !== '' && self::getExtensionByMime($upload_name_extension, true) !== false) {
+                    $file_extension = $upload_name_extension;
+                } else {
+                    $file_extension = 'bin';
+                }
             }
 
         } else {
@@ -2488,6 +2493,12 @@ class erLhcoreClassChatWebhookIncoming {
                 $extension = self::getExtensionByMime($mimeType);
                 if ($extension !== false) {
                     $fileUpload->extension = $extension;
+                    $mimeTypeByExtension = self::getExtensionByMime($extension, true);
+                    if ($mimeTypeByExtension !== null) {
+                        $mimeType = $mimeTypeByExtension;
+                    }
+                } elseif (($mimeTypeByExtension = self::getExtensionByMime($fileUpload->extension, true)) !== null) {
+                    $mimeType = $mimeTypeByExtension;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Use the provided upload filename extension when the remote file URL has no valid extension.
- Normalize the stored MIME type from the resolved extension using the existing LHC extension/MIME map, so download validation remains consistent.

## Why
Some integrations expose media through generic endpoints such as /ru/getfile while also providing the real filename, for example NISSAN.rar. In that case LHC can derive an invalid extension from the URL and later reject the file during download because extension and MIME do not match.

## Testing
- php -l lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
- Verified that an affected production file downloads as attachment filename 8610-NISSAN.rar.
