### PR TITLE
Fix RAR extension detection for incoming webhook files

### DIFF
--- a/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
+++ b/lhc_web/lib/core/lhchat/lhchatwebhookincomming.php
@@ -2593,6 +2593,10 @@ class erLhcoreClassChatWebhookIncoming {
             'sql' => 'application/octet-stream'
         );
 
+        if ($getMime == false && $mimeType == 'application/vnd.rar') {
+            return 'rar';
+        }
+
         if ($getMime == false) {
             return array_search($mimeType,$mime_types);
         } else {


### PR DESCRIPTION
Some providers send RAR archives as `application/vnd.rar`. The existing extension detection did not map this MIME type, so the uploaded file could fall back to `.bin`.

This PR only extends the MIME-to-extension mapping.