### PR TITLE
Change widget theme custom CSS fields from TEXT to MEDIUMTEXT to avoid CSS truncation

### DIFF
--- a/lhc_web/doc/update_db/structure.json
+++ b/lhc_web/doc/update_db/structure.json
@@ -1,12730 +1,12798 @@
 {
-  "tables": {
-    "lh_brand": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_mail_continuous_event": [
-      {
-        "field": "message_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_performance": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_notification_op_subscriber": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_sent_copy": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_brand_member": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_chat_participant": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "frt",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "aart",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mart",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_bot_condition": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_delete_item": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_delete_filter": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "delete_policy",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_msg_open": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_pending_import": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_msg_protection": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "rule_type",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "has_dep",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "dep_ids",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "languages",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_mailing_list_recipient": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_recipient": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "attr_str_1",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "mailbox",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_2",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_3",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_4",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_5",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_6",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_mailing_list": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_mailing_campaign_recipient": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "message_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conversation_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "opened_at",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mailbox",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_4",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_5",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_6",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_mailing_campaign": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "owner_logic",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "owner_user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_canned_msg_replace": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "active_from",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_to",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "repetitiveness",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "days_activity",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "time_zone",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_personal_mailbox_group": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_chat_action": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_userdep_alias": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "job_title",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_userdep_disabled": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "only_priority",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_departament_group_user_disabled": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "only_priority",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_saved_search": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "passive",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "status",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "sharer_user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "description",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_saved_report": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "recurring_options",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "send_log",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_canned_msg_use": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_auto_responder": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "siteaccess",
-        "type": "varchar(3)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_message",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bot_configuration",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "disabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "only_proactive",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ignore_pa_chat",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_hold_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_hold_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_hold_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_hold_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_hold_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_hold_message_1",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_hold",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "timeout_hold_message_2",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "timeout_hold_message_3",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "timeout_hold_message_4",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "timeout_hold_message_5",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_message_2",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_message_3",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_message_4",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_message_5",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_reply_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_reply_message_1",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_reply_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_reply_message_2",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_reply_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_reply_message_3",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_reply_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_reply_message_4",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "wait_timeout_reply_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "timeout_reply_message_5",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "repeat_number",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "1",
-        "extra": ""
-      },
-      {
-        "field": "position",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "survey_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "survey_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "timeout_message",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "languages",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_auto_responder_chat": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "auto_responder_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pending_send_status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_timeout_send",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "active_send_status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_survey": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "feedback_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_1_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_1_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_1_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_1_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_2_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_2_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_2_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_2_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_3_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_3_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_3_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_3_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_4_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_4_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_4_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_4_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_5_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "max_stars_5_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_5_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_5_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_1",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_1_items",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_1_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_1_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_1_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_2",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_2_items",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_2_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_2_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_2_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_3",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_3_items",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_3_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_3_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_3_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_4",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_4_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_4_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_4_items",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_4_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_5",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_5_items",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_options_5_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_5_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_5_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_1",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_1_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_1_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_1_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_2",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_2_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_2_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_2_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_3",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_3_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_3_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_3_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_4",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_4_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_4_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_4_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_5",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_5_pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_5_enabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_5_req",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_product_departament": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "product_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "departament_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_proactive_chat_variables": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "store_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "filter_val",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_proactive_chat_event": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "vid_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ev_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ts",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "val",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_proactive_chat_invitation_event": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "invitation_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "event_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "min_number",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "during_seconds",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_proactive_chat_campaign": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_chat_alert_icon": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_stats": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_proactive_chat_campaign_conv": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "variation_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conv_int_expires",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conv_int_time",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conv_event",
-        "type": "varchar(20)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "unique_id",
-        "type": "varchar(20)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lh_incoming_webhook": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "log_incoming",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "log_failed_parse",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "scope",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "icon",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "icon_color",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_chat_incoming": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_external_id",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_chat_paid": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "hash",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_group_object": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "object_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "group_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_subject": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "color",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "internal",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "archive",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pinned",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "widgets",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "internal_type",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_subject_dep": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "subject_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_subject_chat": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "subject_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_users_session": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "token",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "device_type",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "device_token",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "created_on",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "updated_on",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "expires_on",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "notifications_status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "1",
-        "extra": ""
-      },
-      {
-        "field": "error",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "last_error",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_users_online_session": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "duration",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "lactivity",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "offline_reason_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "updated_by_user_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "online_by_user_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_notification_subscriber": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_rest_api_key": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "api_key",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ip_restrictions",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_rest_api_key_remote": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "api_key",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "username",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "host",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "active",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "position",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_admin_theme": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "static_content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "static_js_content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "css_attributes",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "static_css_content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "header_content",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "header_css",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_product": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "departament_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "disabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_canned_msg_tag_link": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "tag_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "canned_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_canned_msg_tag": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "tag",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_chat_online_user_footprint_update": [
-      {
-        "field": "online_user_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_survey_item": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "survey_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_stars_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_stars_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_4",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_options_5",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_plain_1",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_2",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_3",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_4",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "question_plain_5",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ftime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_browse_offer_invitation": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "siteaccess",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "time_on_site",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "callback_content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "lhc_iframe_content",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "custom_iframe_url",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "executed_times",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "url",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "has_url",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "is_wildcard",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "referrer",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "priority",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "hash",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "width",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "height",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "unit",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_email_template": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "from_name",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "from_name_ac",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "use_chat_locale",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "only_recipient",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "from_email",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "from_email_ac",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_mail_as_sender",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "content",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "translations",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "subject",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bcc_recipients",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "subject_ac",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "reply_to",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "reply_to_ac",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "recipient",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_form": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "recipient",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "name_attr",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "intro_attr",
-        "type": "varchar(400)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "xls_columns",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "pagelayout",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "post_content",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "form_type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_form_collected": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "form_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ctime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ip",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "custom_fields",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "attr_int_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "attr_int_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "attr_int_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_proactive_chat_invitation": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "active_from",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_to",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "repetitiveness",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "days_activity",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "url_present",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "siteaccess",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "time_on_site",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "parent_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "bot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inject_only_html",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "campaign_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "disabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "trigger_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "bot_offline",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pageviews",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "message",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "message_returning",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "executed_times",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "show_on_mobile",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay_init",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "show_instant",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "autoresponder_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dynamic_invitation",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "iddle_for",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "event_type",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hide_after_ntimes",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_ids",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "message_returning_nick",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "referrer",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "show_random_operator",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "operator_name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "position",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "event_invitation",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "tag",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "requires_email",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "requires_username",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "requires_phone",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "design_data",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_widget_theme": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "support_joined",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "alias",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "support_closed",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bot_status_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "pending_join",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "pending_join_queue",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "noonline_operators",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "noonline_operators_offline",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name_company",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "onl_bcolor",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bor_bcolor",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": "e3e3e3",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "text_color",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "popup_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "popup_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "close_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "close_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "restore_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "restore_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "minimize_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "minimize_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "offline_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "offline_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "logo_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "logo_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "copyright_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "copyright_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "widget_copyright_url",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "show_copyright",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 1,
-        "extra": ""
-      },
-      {
-        "field": "modern_look",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "hide_op_ts",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "hide_ts",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "hide_close",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "show_need_help_delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "show_status_delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "hide_popup",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "header_height",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "show_need_help",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "1",
-        "extra": ""
-      },
-      {
-        "field": "widget_response_width",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "show_need_help_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "24",
-        "extra": ""
-      },
-      {
-        "field": "header_padding",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "widget_border_width",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "need_help_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "header_background",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "widget_border_color",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bot_configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "notification_configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_tcolor",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_bcolor",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_border",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_close_bg",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_hover_bg",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_close_hover_bg",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "custom_status_css",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "custom_container_css",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "custom_widget_css",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "custom_popup_css",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_header",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "need_help_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "offline_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "intro_operator_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_image",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_image_path",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "explain_text",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "show_voting",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "1",
-        "extra": ""
-      },
-      {
-        "field": "department_title",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "department_select",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_visitor_background",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_visitor_title_color",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_visitor_text_color",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_operator_background",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_operator_title_color",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "buble_operator_text_color",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "modified",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_show_leave_form",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "enable_widget_embed_override",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_pright",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_pbottom",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_popheight",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_popwidth",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_survey",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "widget_position",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_canned_msg": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "msg",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "fallback_msg",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "html_snippet",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "updated_at",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "disabled",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "activate_responder",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "created_at",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_from",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_to",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "delete_on_exp",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "repetitiveness",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "days_activity",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "additional_data",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "languages",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "unique_id",
-        "type": "varchar(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci",
-        "post_query": "UPDATE `lh_canned_msg` SET `unique_id` = `id`;"
-      },
-      {
-        "field": "explain",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "position",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "department_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "auto_send",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_cobrowse": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "mtime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "finished",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "w",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wh",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "x",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "y",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "url",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "initialize",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "modifications",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_chat": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "nick",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_locale",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_locale_to",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "iwh_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "theme_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "invitation_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pnd_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "anonymized",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "cls_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "cls_us",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "usaccept",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "gbot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "lsync",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "auto_responder_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "status_sub",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "status_sub_arg",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "uagent",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "status_sub_sub",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "device_type",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_op_msg_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "sender_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "has_unread_op_messages",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "unread_op_messages_informed",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "unanswered_chat",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_uid",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "product_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hash",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "referrer",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "session_referrer",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_variables",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "remarks",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ip",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_tz_identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_status",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "user_closed_ts",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "support_informed",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "unread_messages_informed",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "reinform_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "email",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "country_code",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "country_name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_typing",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_typing_txt",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_typing",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "operator_typing_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "phone",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "has_unread_messages",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_user_msg_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "fbst",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_msg_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "additional_data",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "lat",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "lon",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "city",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operation",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operation_admin",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "mail_send",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "screenshot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wait_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_duration",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "tslasign",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_initiator",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_timeout_ts",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_timeout_ac",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_if_na",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "na_cb_executed",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "nc_cb_executed",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "frt",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "aart",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mart",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_chat_accept": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hash",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ctime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "wused",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_chat_archive_range": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "range_from",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "range_to",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "year_month",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "older_than",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "first_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_mail_archive_range": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_chat_blocked_user": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "ip",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "datets",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "btype",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "expires",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "nick",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_group_work": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "group_work_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_chat_config": [
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "value",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "explain",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "hidden",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_chat_file": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "meta_msg",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "width",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "height",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "upload_name",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "size",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "file_path",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "extension",
-        "type": "varchar(255)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "date",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "persistent",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "tmp",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_chat_online_user": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "vid",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ip",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "visitor_tz",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "current_page",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "page_title",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "notes",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "referrer",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "device_type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conversion_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_time",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "last_visit_prev",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "user_active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "invitation_seen_count",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_check_time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "invitation_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_visit",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "first_visit",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "total_visits",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pages_count",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "tt_pages_count",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "invitation_count",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_agent",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_country_code",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "user_country_name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_message",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_user_proactive",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operator_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "message_seen",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "message_seen_ts",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "lat",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "lon",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "city",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "reopen_chat",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "time_on_site",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "tt_time_on_site",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "requires_email",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "requires_username",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "requires_phone",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "screenshot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operation",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_attr_system",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operation_chat",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_attr",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_chat_online_user_footprint": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "online_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "page",
-        "type": "varchar(2083)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "vtime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_chatbox": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_departament_group_user": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "dep_group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "read_only",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "exc_indv_autoasign",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "only_priority",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "assign_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_min_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_max_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_speech_user_language": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_departament_group_member": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_abstract_chat_variable": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "persistent",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inv",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "try_decrypt",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "case_insensitive",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "change_message",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "old_js_id",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "content_field",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_rest_api": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_generic_bot_rest_api_cache": [
-      {
-        "field": "hash",
-        "type": "varchar(32)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_abstract_chat_column": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "icon_mode",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "has_popup",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_window_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "popup_content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "sort_column",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "sort_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_list_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mail_list_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mail_enabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_chat_priority": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "sort_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "dest_dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "skip_bot",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "role_destination",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "present_role_is",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lh_group_chat": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_group_msg": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_group_chat_member": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "last_msg_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_chat_voice_video": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_canned_msg_dep": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_content_chunk": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "content",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "in_active",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_content_chunk_dep": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_offline_reason": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "description",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "icon",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "pos",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_abstract_auto_responder_dep": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_proactive_chat_invitation_dep": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_abstract_proactive_chat_invitation_one_time": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "invitation_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "vid_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_departament_limit_group_member": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_limit_group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_departament_group": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "achats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "inachats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_op",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_op_h",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "inopchats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "acopchats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pchats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "bchats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_h",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_departament_limit_group": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "pending_max",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_departament": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "email",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "xmpp_recipients",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "xmpp_group_recipients",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_offline",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "archive",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pending_max",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_load",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_op",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_op_h",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_load_h",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "inop_chats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "acop_chats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "bot_chats_counter",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "inactive_chats_cnt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "assign_same_language",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_ac_dep_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_ac_dep_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pending_group_max",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "exclude_inactive_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay_before_assign",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay_before_assign_mail",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "sort_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "visible_if_online",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ignore_op_status",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "department_transfer_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_timeout",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "disabled",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hidden",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delay_lm",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_active_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_active_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_timeout_seconds",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_timeout_seconds_mail",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(2083)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "alias",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "mod_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "mod_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "tud_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "tud_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "wed_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "wed_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "thd_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "thd_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "frd_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "frd_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "sad_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "sad_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "sud_start_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "sud_end_hour",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": "-1",
-        "extra": ""
-      },
-      {
-        "field": "nc_cb_execute",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "na_cb_execute",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inform_unread",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "active_balancing",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "active_mail_balancing",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inform_close",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inform_unread_delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inform_options",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "online_hours_active",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inform_delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "active_chats_counter",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "pending_chats_counter",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "inform_close_all",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": ""
-      },
-      {
-        "field": "inform_close_all_email",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": 0,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "product_configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bot_configuration",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_departament_custom_work_hours": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "date_from",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "date_to",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "start_hour",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "end_hour",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "repetitiveness",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_faq": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "question",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "answer",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "url",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "email",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "has_url",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "is_wildcard",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_forgotpasswordhash": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hash",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "created",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_group": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "disabled",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "required",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_grouprole": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "role_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_groupuser": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_msg": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "msg",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "meta_msg",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "del_st",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "name_support",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_question": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "question",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "location",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "active",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "is_voting",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_intro",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "revote",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_question_answer": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "ip",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "question_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "answer",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "ctime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_question_option": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "question_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "option_name",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "priority",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_exception": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_exception_message": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_tr_group": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "nick",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "bot_lang",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filepath",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filename",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "use_translation_service",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_tr_item": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "auto_translate",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_bot": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "nick",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "short_name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "avatar",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_1",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_2",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attr_str_3",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filepath",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filename",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_generic_bot_pending_event": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_chat_event": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "counter",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_group": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "is_collapsed",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_canned_msg_subject": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_response_template_subject": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_response_template_dep": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_chat_workflow": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "trigger_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_trigger_template": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_trigger": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "bot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "default",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pos",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "default_unknown",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "default_always",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "default_unknown_btn",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "in_progress",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "as_argument",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_payload": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_webhook": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "delay",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "bot_id_alt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "trigger_id_alt",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "status",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lh_users_login": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_trigger_event_template": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lh_generic_bot_trigger_event": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "bot_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "on_start_type",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "skip",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pattern_exc",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pattern",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "configuration",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_audits": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_departament_availability": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "ymdhi",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ymd",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "time",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hourminute",
-        "type": "int(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_question_option_answer": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "question_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "option_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ctime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "ip",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_role": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_speech_chat_language": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "language_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dialect",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_speech_language": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "siteaccess",
-        "type": "varchar(3)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_chat_start_settings": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "data",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "dep_ids",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "department_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_chat_event_track": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "data",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "department_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_speech_language_dialect": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "language_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "lang_name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "lang_code",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "short_code",
-        "type": "varchar(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_rolefunction": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "role_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "module",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "function",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "limitation",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_transfer": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "chat_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_scope",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "ctime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "from_dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "transfer_to_user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_command": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "enabled_display",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "position",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "1000",
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "fields",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "shortcut_1",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "shortcut_2",
-        "type": "varchar(10)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "sub_command",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "info_msg",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_userdep": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "exclude_autoasign",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "exclude_autoasign_mails",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "only_priority",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "exc_indv_autoasign",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "ro",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "last_activity",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "lastd_activity",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "hide_online_ts",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "hide_online",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "last_accepted",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "last_accepted_mail",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pending_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "active_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pending_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "inactive_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "type",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "dep_group_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "always_on",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "assign_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_max_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "chat_min_priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_users": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "username",
-        "type": "varchar(80)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "password",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "avatar",
-        "type": "varchar(150)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "session_id",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "operation_admin",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "email",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "time_zone",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "surname",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "chat_nickname",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filepath",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "filename",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "job_title",
-        "type": "varchar(100)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "xmpp_username",
-        "type": "varchar(200)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "skype",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "departments_ids",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "disabled",
-        "type": "tinyint(4)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "force_logout",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "offline_reason_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "llogin",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "rec_per_req",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "hide_online",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "auto_accept",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "exclude_autoasign",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "exclude_autoasign_mails",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "max_active_chats",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "max_active_mails",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "all_departments",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "invisible_mode",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "inactive_mode",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "cache_version",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "attr_int_1",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_2",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "attr_int_3",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "pswd_updated",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "always_on",
-        "type": "tinyint(1)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lh_users_remember": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "mtime",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ],
-    "lh_generic_bot_repeat_restrict": [
-      {
-        "field": "id",
-        "type": "bigint(20)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_users_setting": [
-      {
-        "field": "id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "user_id",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "MUL",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "value",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lh_users_setting_option": [
-      {
-        "field": "identifier",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "class",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "attribute",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_oauth_ms": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_conversation": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "conv_duration",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "body",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "opened_at",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "priority_asc",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "follow_up_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "mail_variables",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "has_attachment",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "pending_sync",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "undelivered",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "lang",
-        "type": "varchar(5)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "phone",
-        "type": "varchar(16)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "from_address_clean",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_file": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "meta_msg",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "width",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "height",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_remarks": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_msg": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "conversation_id_old",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conv_duration",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "is_external",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "auto_submitted",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "conv_user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "priority",
-        "type": "int(11)",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "opened_at",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "message_hash",
-        "type": "varchar(40)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      },
-      {
-        "field": "has_attachment",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "undelivered",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "rfc822_body",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "delivery_status",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "lang",
-        "type": "varchar(5)",
-        "null": "NO",
-        "key": "",
-        "default": "",
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_msg_subject": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_mailbox": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "import_since",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "dep_id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "auth_method",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "import_priority",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "reopen_reset",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "delete_on_archive",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "delete_policy",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "reopen_timeout",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "4",
-        "extra": ""
-      },
-      {
-        "field": "last_process_time",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "delete_mode",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "no_pswd_smtp",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "create_a_copy",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "user_id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "assign_parent_user",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "failed",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      },
-      {
-        "field": "uuid_status",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "mail_smtp",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "name_smtp",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "username_smtp",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "password_smtp",
-        "type": "varchar(250)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      },
-      {
-        "field": "workflow_options",
-        "type": "longtext",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci"
-      }
-    ],
-    "lhc_mailconv_response_template": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "template_plain",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "unique_id",
-        "type": "varchar(20)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": "",
-        "collation": "utf8mb4_unicode_ci",
-        "post_query": "UPDATE `lhc_mailconv_response_template` SET `unique_id` = `id`;"
-      },
-      {
-        "field": "disabled",
-        "type": "tinyint(1) unsigned",
-        "null": "NO",
-        "key": "",
-        "default": "0",
-        "extra": ""
-      }
-    ],
-    "lhc_mailconv_msg_internal": [
-      {
-        "field": "id",
-        "type": "bigint(20) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      }
-    ],
-    "lhc_mailconv_match_rule": [
-      {
-        "field": "id",
-        "type": "int(11) unsigned",
-        "null": "NO",
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment"
-      },
-      {
-        "field": "options",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "mailbox_id",
-        "type": "text",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      },
-      {
-        "field": "name",
-        "type": "varchar(50)",
-        "null": "NO",
-        "key": "",
-        "default": null,
-        "extra": ""
-      }
-    ]
-  },
-  "tables_data": {
-    "lh_users_setting_option": [
-      {
-        "identifier": "chat_message",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "enable_active_list",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "enable_close_list",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "enable_pending_list",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "enable_unread_list",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "new_chat_sound",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "new_user_bn",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "new_user_sound",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "oupdate_timeout",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "ouser_timeout",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "ocountry",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "otime_on_site",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "o_department",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "omax_rows",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "ogroup_by",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "omap_depid",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "omap_mtimeout",
-        "class": "",
-        "attribute": ""
-      },
-      {
-        "identifier": "dwo",
-        "class": "",
-        "attribute": ""
-      }
-    ],
-    "lh_chat_config": [
-      {
-        "identifier": "dashboard_order",
-        "value": "[[\"online_operators\",\"departments_stats\",\"online_visitors\"],[\"pending_chats\",\"unread_chats\",\"transfered_chats\"],[\"active_chats\",\"closed_chats\"]]",
-        "type": "0",
-        "explain": "Home page dashboard widgets order",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_iframe_sharing",
-        "value": "1",
-        "type": "0",
-        "explain": "Disable iframes in sharing mode",
-        "hidden": "0"
-      },
-      {
-        "identifier": "remember_username",
-        "value": "1",
-        "type": "0",
-        "explain": "Should we remember username for the next time visitor starts a chat?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "remember_phone_email",
-        "value": "1",
-        "type": "0",
-        "explain": "Should we remember E-Mail, Phone for the next time visitor starts a chat?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "inform_unread_message",
-        "value": "0",
-        "type": "0",
-        "explain": "Inform visitor if they have unread messages",
-        "hidden": "0"
-      },
-      {
-        "identifier": "transfer_configuration",
-        "value": "0",
-        "type": "0",
-        "explain": "Transfer configuration",
-        "hidden": "1"
-      },
-      {
-        "identifier": "accept_chat_link_timeout",
-        "value": "300",
-        "type": "0",
-        "explain": "How many seconds chat accept link is valid. Set 0 to force login all the time manually.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "open_closed_chat_timeout",
-        "value": "1800",
-        "type": "0",
-        "explain": "How many seconds customer has to open already closed chat.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "hide_right_column_frontpage",
-        "value": "0",
-        "type": "0",
-        "explain": "Hide right column in frontpage",
-        "hidden": "0"
-      },
-      {
-        "identifier": "online_if",
-        "value": "0",
-        "type": "0",
-        "explain": "",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_mouse_activity",
-        "value": "0",
-        "type": "0",
-        "explain": "Should mouse movement be tracked as activity measure, if not checked only basic events would be tracked",
-        "hidden": "0"
-      },
-      {
-        "identifier": "accept_tos_link",
-        "value": "#",
-        "type": "0",
-        "explain": "Change to your site Terms of Service",
-        "hidden": "0"
-      },
-      {
-        "identifier": "speech_data",
-        "value": "a:3:{i:0;b:0;s:8:\"language\";i:7;s:7:\"dialect\";s:5:\"en-US\";}",
-        "type": "1",
-        "explain": "Change to your site Terms of Service",
-        "hidden": "1"
-      },
-      {
-        "identifier": "front_tabs",
-        "value": "dashboard,online_users,online_map,pending_chats,active_chats,unread_chats,closed_chats,online_operators",
-        "type": "0",
-        "explain": "Home page tabs order",
-        "hidden": "0"
-      },
-      {
-        "identifier": "preload_iframes",
-        "value": "0",
-        "type": "0",
-        "explain": "Preload widget. It will avoid loading delay after clicking widget",
-        "hidden": "0"
-      },
-      {
-        "identifier": "min_phone_length",
-        "value": "8",
-        "type": "0",
-        "explain": "Minimum phone number length",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_auto_allow",
-        "value": "0",
-        "type": "0",
-        "explain": "Do not ask permission for users to see their screen",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_nodejs_enabled",
-        "value": "0",
-        "type": "0",
-        "explain": "NodeJs support enabled",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_nodejs_secure",
-        "value": "0",
-        "type": "0",
-        "explain": "Connect to NodeJs in https mode",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_nodejs_path",
-        "value": "",
-        "type": "0",
-        "explain": "socket.io path, optional",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_js_execution",
-        "value": "1",
-        "type": "0",
-        "explain": "Disable JS execution in Co-Browsing operator window",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_nodejs_socket_host",
-        "value": "",
-        "type": "0",
-        "explain": "Host where NodeJs is running",
-        "hidden": "0"
-      },
-      {
-        "identifier": "sharing_nodejs_sllocation",
-        "value": "https://cdn.socket.io/socket.io-1.1.0.js",
-        "type": "0",
-        "explain": "Location of SocketIO JS library",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_is_online",
-        "value": "0",
-        "type": "0",
-        "explain": "Track is user still on site, chat status checks also has to be enabled",
-        "hidden": "0"
-      },
-      {
-        "identifier": "reverse_pending",
-        "value": "0",
-        "type": "0",
-        "explain": "Make default pending chats order from old to new",
-        "hidden": "0"
-      },
-      {
-        "identifier": "allow_reopen_closed",
-        "value": "1",
-        "type": "0",
-        "explain": "Allow user to reopen closed chats?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_activity",
-        "value": "0",
-        "type": "0",
-        "explain": "Track users activity on site?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "product_enabled_module",
-        "value": "0",
-        "type": "0",
-        "explain": "Product module is enabled",
-        "hidden": "1"
-      },
-      {
-        "identifier": "application_name",
-        "value": "a:6:{s:3:\"eng\";s:31:\"Live Helper Chat - live support\";s:3:\"lit\";s:26:\"Live Helper Chat - pagalba\";s:3:\"hrv\";s:0:\"\";s:3:\"esp\";s:0:\"\";s:3:\"por\";s:0:\"\";s:10:\"site_admin\";s:31:\"Live Helper Chat - live support\";}",
-        "type": "1",
-        "explain": "Support application name, visible in browser title.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_timeout",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatic chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_timeout_pending",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatic pending chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_timeout_active",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatic active chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_timeout_bot",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatic bot chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
-        "hidden": "0"
-      },
-      {
-        "identifier": "automatically_reopen_chat",
-        "value": "1",
-        "type": "0",
-        "explain": "Automatically reopen chat on widget open",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autopurge_timeout",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatic chats purging. 0 - disabled, n > 0 time in minutes before chat is automatically deleted",
-        "hidden": "0"
-      },
-      {
-        "identifier": "cduration_timeout_user",
-        "value": "4",
-        "type": "0",
-        "explain": "How long operator can wait for message from visitor before time between messages are ignored. Values in minutes.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "cduration_timeout_operator",
-        "value": "10",
-        "type": "0",
-        "explain": "How long visitor can wait for message from operator before time between messages are ignored. Values in minutes.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "assign_workflow_timeout",
-        "value": "0",
-        "type": "0",
-        "explain": "Chats waiting in pending queue more than n seconds should be auto-assigned first. Time in seconds",
-        "hidden": "0"
-      },
-      {
-        "identifier": "del_on_close_no_msg",
-        "value": "0",
-        "type": "0",
-        "explain": "Delete chat on close if there are no messages from the visitor",
-        "hidden": "0"
-      },
-      {
-        "identifier": "hide_button_dropdown",
-        "value": "0",
-        "type": "0",
-        "explain": "Hide close button in dropdown",
-        "hidden": "0"
-      },
-      {
-        "identifier": "on_close_exit_chat",
-        "value": "0",
-        "type": "0",
-        "explain": "On chat close exit chat",
-        "hidden": "0"
-      },
-      {
-        "identifier": "bbc_button_visible",
-        "value": "1",
-        "type": "0",
-        "explain": "Show BB Code button",
-        "hidden": "0"
-      },
-      {
-        "identifier": "activity_timeout",
-        "value": "5",
-        "type": "0",
-        "explain": "How long operator should go offline automatically because of inactivity. Value in minutes",
-        "hidden": "0"
-      },
-      {
-        "identifier": "valid_domains",
-        "value": "",
-        "type": "0",
-        "explain": "Domains where script can be embedded. E.g example.com, google.com",
-        "hidden": "0"
-      },
-      {
-        "identifier": "activity_track_all",
-        "value": "0",
-        "type": "0",
-        "explain": "Track all logged operators activity and ignore their individual settings.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "chatbox_data",
-        "value": "a:6:{i:0;b:0;s:20:\"chatbox_auto_enabled\";i:0;s:19:\"chatbox_secret_hash\";s:9:\"9e2e125yq\";s:20:\"chatbox_default_name\";s:7:\"Chatbox\";s:17:\"chatbox_msg_limit\";i:50;s:22:\"chatbox_default_opname\";s:7:\"Manager\";}",
-        "type": "0",
-        "explain": "Chatbox configuration",
-        "hidden": "1"
-      },
-      {
-        "identifier": "customer_company_name",
-        "value": "Live Helper Chat",
-        "type": "0",
-        "explain": "Your company name - visible in bottom left corner",
-        "hidden": "0"
-      },
-      {
-        "identifier": "paidchat_data",
-        "value": "",
-        "type": "0",
-        "explain": "Paid chat configuration",
-        "hidden": "1"
-      },
-      {
-        "identifier": "customer_site_url",
-        "value": "http:\/\/livehelperchat.com",
-        "type": "0",
-        "explain": "Your site URL address",
-        "hidden": "0"
-      },
-      {
-        "identifier": "default_theme_id",
-        "value": "0",
-        "type": "0",
-        "explain": "Default theme ID.",
-        "hidden": "1"
-      },
-      {
-        "identifier": "disable_html5_storage",
-        "value": "1",
-        "type": "0",
-        "explain": "Disable HMTL5 storage, check it if your site is switching between http and https",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_popup_restore",
-        "value": "0",
-        "type": "0",
-        "explain": "Disable option in widget to open new window. Restore icon will be hidden",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_print",
-        "value": "0",
-        "type": "0",
-        "explain": "Disable chat print",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_txt_dwnld",
-        "value": "0",
-        "type": "0",
-        "explain": "Disable chat download",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_send",
-        "value": "0",
-        "type": "0",
-        "explain": "Disable chat transcript send",
-        "hidden": "0"
-      },
-      {
-        "identifier": "explicit_http_mode",
-        "value": "",
-        "type": "0",
-        "explain": "Please enter explicit http mode. Either http: or https:, do not forget : at the end.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "mobile_options",
-        "value": "a:2:{s:13:\"notifications\";i:0;s:7:\"fcm_key\";s:152:\"AAAAiF8DeNk:APA91bFVHu2ybhBUTtlEtQrUEPpM2fb-5ovgo0FVNm4XxK3cYJtSwRcd-pqcBot_422yDOzHyw2p9ZFplkHrmNXjm8f5f-OIzfalGmpsypeXvnPxhU6Db1B2Z1Acc-TamHUn2F4xBJkP\";}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "export_hash",
-        "value": "qlg55biu",
-        "type": "0",
-        "explain": "Chats export secret hash",
-        "hidden": "0"
-      },
-      {
-        "identifier": "faq_email_required",
-        "value": "0",
-        "type": "0",
-        "explain": "Is visitor e-mail required for FAQ",
-        "hidden": "0"
-      },
-      {
-        "identifier": "file_configuration",
-        "value": "a:7:{i:0;b:0;s:5:\"ft_op\";s:43:\"gif|jpe?g|png|zip|rar|xls|doc|docx|xlsx|pdf\";s:5:\"ft_us\";s:26:\"gif|jpe?g|png|doc|docx|pdf\";s:6:\"fs_max\";i:2048;s:18:\"active_user_upload\";b:0;s:16:\"active_op_upload\";b:1;s:19:\"active_admin_upload\";b:1;}",
-        "type": "0",
-        "explain": "Files configuration item",
-        "hidden": "1"
-      },
-      {
-        "identifier": "geo_data",
-        "value": "",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "geo_location_data",
-        "value": "a:3:{s:4:\"zoom\";i:4;s:3:\"lat\";s:7:\"49.8211\";s:3:\"lng\";s:7:\"11.7835\";}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "autologin_data",
-        "value": "a:3:{i:0;b:0;s:11:\"secret_hash\";s:16:\"please_change_me\";s:7:\"enabled\";i:0;}",
-        "type": "0",
-        "explain": "Autologin configuration data",
-        "hidden": "1"
-      },
-      {
-        "identifier": "password_data",
-        "value": "",
-        "type": "0",
-        "explain": "Password requirements",
-        "hidden": "1"
-      },
-      {
-        "identifier": "hide_disabled_department",
-        "value": "1",
-        "type": "0",
-        "explain": "Hide disabled department widget",
-        "hidden": "0"
-      },
-      {
-        "identifier": "ignorable_ip",
-        "value": "",
-        "type": "0",
-        "explain": "Which ip should be ignored in online users list, separate by comma",
-        "hidden": "0"
-      },
-      {
-        "identifier": "vwait_to_long",
-        "value": "120",
-        "type": "0",
-        "explain": "How long we should wait before we inform operator about unanswered chat.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "banned_ip_range",
-        "value": "",
-        "type": "0",
-        "explain": "Which ip should not be allowed to chat",
-        "hidden": "0"
-      },
-      {
-        "identifier": "unban_ip_range",
-        "value": "",
-        "type": "0",
-        "explain": "Which ip should not be allowed to be blocked",
-        "hidden": "0"
-      },
-      {
-        "identifier": "update_ip",
-        "value": "127.0.0.1",
-        "type": "0",
-        "explain": "Which ip should be allowed to update DB by executing http request, separate by comma?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_if_offline",
-        "value": "0",
-        "type": "0",
-        "explain": "Track online visitors even if there is no online operators",
-        "hidden": "0"
-      },
-      {
-        "identifier": "ignore_user_status",
-        "value": "0",
-        "type": "0",
-        "explain": "Ignore users online statuses and use departments online hours",
-        "hidden": "0"
-      },
-      {
-        "identifier": "list_online_operators",
-        "value": "0",
-        "type": "0",
-        "explain": "List online operators.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "list_unread",
-        "value": "0",
-        "type": "0",
-        "explain": "List unread chats, disabled for high performance",
-        "hidden": "0"
-      },
-      {
-        "identifier": "list_closed",
-        "value": "0",
-        "type": "0",
-        "explain": "List closed chats, disabled for high performance",
-        "hidden": "0"
-      },
-      {
-        "identifier": "disable_live_autoassign",
-        "value": "0",
-        "type": "0",
-        "explain": "Disable live auto assign",
-        "hidden": "0"
-      },
-      {
-        "identifier": "default_admin_theme_id",
-        "value": "0",
-        "type": "0",
-        "explain": "Default admin theme ID",
-        "hidden": "1"
-      },
-      {
-        "identifier": "max_message_length",
-        "value": "500",
-        "type": "0",
-        "explain": "Maximum message length in characters",
-        "hidden": "0"
-      },
-      {
-        "identifier": "message_seen_timeout",
-        "value": "24",
-        "type": "0",
-        "explain": "Proactive message timeout in hours. After how many hours proactive chat mesasge should be shown again.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "need_help_tip",
-        "value": "1",
-        "type": "0",
-        "explain": "Show need help tooltip?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "enable_status_cache",
-        "value": "0",
-        "type": "0",
-        "explain": "Enable status check cache using Redis. PHPResque extension is required.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "need_help_tip_timeout",
-        "value": "24",
-        "type": "0",
-        "explain": "Need help tooltip timeout, after how many hours show again tooltip?",
-        "hidden": "0"
-      },
-      {
-        "identifier": "pro_active_invite",
-        "value": "1",
-        "type": "0",
-        "explain": "Is pro active chat invitation active. Online users tracking also has to be enabled",
-        "hidden": "0"
-      },
-      {
-        "identifier": "pro_active_limitation",
-        "value": "-1",
-        "type": "0",
-        "explain": "Pro active chats invitations limitation based on pending chats, (-1) do not limit, (0,1,n+1) number of pending chats can be for invitation to be shown.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "pro_active_show_if_offline",
-        "value": "0",
-        "type": "0",
-        "explain": "Should invitation logic be executed if there is no online operators",
-        "hidden": "0"
-      },
-      {
-        "identifier": "notice_message",
-        "value": "",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "reopen_as_new",
-        "value": "1",
-        "type": "0",
-        "explain": "Reopen closed chat as new? Otherwise it will be reopened as active.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "reopen_chat_enabled",
-        "value": "1",
-        "type": "0",
-        "explain": "Reopen chat functionality enabled",
-        "hidden": "0"
-      },
-      {
-        "identifier": "run_departments_workflow",
-        "value": "0",
-        "type": "0",
-        "explain": "Should cronjob run departments transfer workflow, even if user leaves a chat",
-        "hidden": "0"
-      },
-      {
-        "identifier": "run_unaswered_chat_workflow",
-        "value": "0",
-        "type": "0",
-        "explain": "Should cronjob run unanswered chats workflow and execute unaswered chats callback, 0 - no, any other number bigger than 0 is a minits how long chat have to be not accepted before executing callback.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "session_captcha",
-        "value": "0",
-        "type": "0",
-        "explain": "Use session captcha. LHC have to be installed on the same domain or subdomain.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "smtp_data",
-        "value": "a:5:{s:4:\"host\";s:0:\"\";s:4:\"port\";s:2:\"25\";s:8:\"use_smtp\";i:0;s:8:\"username\";s:0:\"\";s:8:\"password\";s:0:\"\";}",
-        "type": "0",
-        "explain": "SMTP configuration",
-        "hidden": "1"
-      },
-      {
-        "identifier": "audit_configuration",
-        "value": "a:7:{s:8:\"days_log\";i:90;s:11:\"log_objects\";a:0:{}s:6:\"log_js\";i:0;s:9:\"log_block\";i:0;s:11:\"log_routing\";i:0;s:9:\"log_files\";i:0;s:8:\"log_user\";i:0;}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "recaptcha_data",
-        "value": "",
-        "type": "0",
-        "explain": "Re-captcha configuration",
-        "hidden": "1"
-      },
-      {
-        "identifier": "sound_invitation",
-        "value": "1",
-        "type": "0",
-        "explain": "Play sound on invitation to chat.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "departament_availability",
-        "value": "364",
-        "type": "0",
-        "explain": "How long department availability statistic should be kept? (days)",
-        "hidden": "0"
-      },
-      {
-        "identifier": "uonline_sessions",
-        "value": "364",
-        "type": "0",
-        "explain": "How long keep operators online sessions data? (days)",
-        "hidden": "0"
-      },
-      {
-        "identifier": "start_chat_data",
-        "value": "a:23:{i:0;b:0;s:21:\"name_visible_in_popup\";b:1;s:27:\"name_visible_in_page_widget\";b:1;s:19:\"name_require_option\";s:8:\"required\";s:22:\"email_visible_in_popup\";b:0;s:28:\"email_visible_in_page_widget\";b:0;s:20:\"email_require_option\";s:8:\"required\";s:24:\"message_visible_in_popup\";b:1;s:30:\"message_visible_in_page_widget\";b:1;s:22:\"message_require_option\";s:8:\"required\";s:22:\"phone_visible_in_popup\";b:0;s:28:\"phone_visible_in_page_widget\";b:0;s:20:\"phone_require_option\";s:8:\"required\";s:21:\"force_leave_a_message\";b:0;s:29:\"offline_name_visible_in_popup\";b:1;s:35:\"offline_name_visible_in_page_widget\";b:1;s:27:\"offline_name_require_option\";s:8:\"required\";s:30:\"offline_phone_visible_in_popup\";b:0;s:36:\"offline_phone_visible_in_page_widget\";b:0;s:28:\"offline_phone_require_option\";s:8:\"required\";s:32:\"offline_message_visible_in_popup\";b:1;s:38:\"offline_message_visible_in_page_widget\";b:1;s:30:\"offline_message_require_option\";s:8:\"required\";}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "sync_sound_settings",
-        "value": "a:16:{i:0;b:0;s:12:\"repeat_sound\";i:1;s:18:\"repeat_sound_delay\";i:5;s:10:\"show_alert\";b:0;s:22:\"new_chat_sound_enabled\";b:1;s:31:\"new_message_sound_admin_enabled\";b:1;s:30:\"new_message_sound_user_enabled\";b:1;s:14:\"online_timeout\";d:300;s:22:\"check_for_operator_msg\";d:10;s:21:\"back_office_sinterval\";d:10;s:22:\"chat_message_sinterval\";d:3.5;s:20:\"long_polling_enabled\";b:0;s:30:\"polling_chat_message_sinterval\";d:1.5;s:29:\"polling_back_office_sinterval\";d:5;s:18:\"connection_timeout\";i:30;s:28:\"browser_notification_message\";b:0;}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      },
-      {
-        "identifier": "tracked_users_cleanup",
-        "value": "160",
-        "type": "0",
-        "explain": "How many days keep records of online users.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "tracked_footprint_cleanup",
-        "value": "90",
-        "type": "0",
-        "explain": "How many days keep records of users footprint.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "cleanup_cronjob",
-        "value": "0",
-        "type": "0",
-        "explain": "Cleanup should be done only using cronjob.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_domain",
-        "value": "",
-        "type": "0",
-        "explain": "Set your domain to enable user tracking across different domain subdomains.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_footprint",
-        "value": "0",
-        "type": "0",
-        "explain": "Track users footprint. For this also online visitors tracking should be enabled",
-        "hidden": "0"
-      },
-      {
-        "identifier": "footprint_background",
-        "value": "0",
-        "type": "0",
-        "explain": "Footprint updates should be processed in the background. Make sure you are running workflow background cronjob.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "mheight",
-        "value": "",
-        "type": "0",
-        "explain": "Messages box height",
-        "hidden": "0"
-      },
-      {
-        "identifier": "mheight_op",
-        "value": "200",
-        "type": "0",
-        "explain": "Messages box height for operator",
-        "hidden": "0"
-      },
-      {
-        "identifier": "listd_op",
-        "value": "10",
-        "type": "0",
-        "explain": "Default number of online operators to show",
-        "hidden": "0"
-      },
-      {
-        "identifier": "product_show_departament",
-        "value": "0",
-        "type": "0",
-        "explain": "Enable products show by departments",
-        "hidden": "1"
-      },
-      {
-        "identifier": "suggest_leave_msg",
-        "value": "1",
-        "type": "0",
-        "explain": "Suggest user to leave a message then user chooses offline department",
-        "hidden": "0"
-      },
-      {
-        "identifier": "no_wildcard_cookie",
-        "value": "0",
-        "type": "0",
-        "explain": "Cookie should be valid only for domain where Javascript is embedded (excludes subdomains)",
-        "hidden": "0"
-      },
-      {
-        "identifier": "checkstatus_timeout",
-        "value": "0",
-        "type": "0",
-        "explain": "Interval between chat status checks in seconds, 0 disabled.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_abandon_pending",
-        "value": "0,0",
-        "type": "0",
-        "explain": "Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>,<status chat>.",
-        "hidden": "0"
-      },
-      {
-        "identifier": "autoclose_activity_timeout",
-        "value": "0",
-        "type": "0",
-        "explain": "Automatically close active chat if from last visitor/operator message passed. 0 - disabled, n > 0 time in minutes. Optional second argument: ,1 - close only when visitor sent the last message, ,2 - close only when operator sent the last message",
-        "hidden": "0"
-      },
-      {
-        "identifier": "do_no_track_ip",
-        "value": "0",
-        "type": "0",
-        "explain": "Do not track visitors IP",
-        "hidden": "0"
-      },
-      {
-        "identifier": "ignore_typing",
-        "value": "0",
-        "type": "0",
-        "explain": "Do not store what visitor is typing",
-        "hidden": "0"
-      },
-      {
-        "identifier": "encrypt_msg_after",
-        "value": "0",
-        "type": "0",
-        "explain": "After how many days anonymize messages",
-        "hidden": "0"
-      },
-      {
-        "identifier": "encrypt_msg_op",
-        "value": "0",
-        "type": "0",
-        "explain": "Anonymize also operators messages",
-        "hidden": "0"
-      },
-      {
-        "identifier": "track_online_visitors",
-        "value": "1",
-        "type": "0",
-        "explain": "Enable online site visitors tracking",
-        "hidden": "0"
-      },
-      {
-        "identifier": "use_secure_cookie",
-        "value": "0",
-        "type": "0",
-        "explain": "Use secure cookie, check this if you want to force SSL all the time",
-        "hidden": "0"
-      },
-      {
-        "identifier": "translation_data",
-        "value": "a:6:{i:0;b:0;s:19:\"translation_handler\";s:4:\"bing\";s:19:\"enable_translations\";b:0;s:14:\"bing_client_id\";s:0:\"\";s:18:\"bing_client_secret\";s:0:\"\";s:14:\"google_api_key\";s:0:\"\";}",
-        "type": "0",
-        "explain": "Translation data",
-        "hidden": "1"
-      },
-      {
-        "identifier": "voting_days_limit",
-        "value": "7",
-        "type": "0",
-        "explain": "How many days voting widget should not be expanded after last show",
-        "hidden": "0"
-      },
-      {
-        "identifier": "guardrails_enabled",
-        "value": "0",
-        "type": "0",
-        "explain": "Enable guardrails for operators and visitors",
-        "hidden": "1"
-      },
-      {
-        "identifier": "show_language_switcher",
-        "value": "0",
-        "type": "0",
-        "explain": "Show users option to switch language at widget",
-        "hidden": "0"
-      },
-      {
-        "identifier": "show_languages",
-        "value": "eng,lit,hrv,esp,por,nld,ara,ger,pol,rus,ita,fre,chn,cse,nor,tur,vnm,idn,sve,per,ell,dnk,rou,bgr,tha,geo,fin,alb",
-        "type": "0",
-        "explain": "Between what languages user should be able to switch",
-        "hidden": "0"
-      },
-      {
-        "identifier": "xmp_data",
-        "value": "a:14:{i:0;b:0;s:4:\"host\";s:15:\"talk.google.com\";s:6:\"server\";s:9:\"gmail.com\";s:8:\"resource\";s:6:\"xmpphp\";s:4:\"port\";s:4:\"5222\";s:7:\"use_xmp\";i:0;s:8:\"username\";s:0:\"\";s:8:\"password\";s:0:\"\";s:11:\"xmp_message\";s:78:\"New chat request [{chat_id}]\r\n{messages}\r\nClick to accept a chat\r\n{url_accept}\";s:10:\"recipients\";s:0:\"\";s:20:\"xmp_accepted_message\";s:69:\"{user_name} has accepted a chat [{chat_id}]\r\n{messages}\r\n{url_accept}\";s:16:\"use_standard_xmp\";i:0;s:15:\"test_recipients\";s:0:\"\";s:21:\"test_group_recipients\";s:0:\"\";}",
-        "type": "0",
-        "explain": "XMP data",
-        "hidden": "1"
-      },
-      {
-        "identifier": "geoadjustment_data",
-        "value": "a:8:{i:0;b:0;s:18:\"use_geo_adjustment\";b:0;s:13:\"available_for\";s:0:\"\";s:15:\"other_countries\";s:6:\"custom\";s:8:\"hide_for\";s:0:\"\";s:12:\"other_status\";s:7:\"offline\";s:11:\"rest_status\";s:6:\"hidden\";s:12:\"apply_widget\";i:0;}",
-        "type": "0",
-        "explain": "Geo adjustment settings",
-        "hidden": "1"
-      },
-      {
-        "identifier": "bbcode_options",
-        "value": "a:2:{s:3:\"div\";a:0:{}s:3:\"dio\";a:0:{}}",
-        "type": "0",
-        "explain": "",
-        "hidden": "1"
-      }
-    ],
-    "lh_speech_language_dialect": [
-      {
-        "id": "1",
-        "language_id": "1",
-        "lang_name": "Afrikaans",
-        "lang_code": "af-ZA"
-      },
-      {
-        "id": "2",
-        "language_id": "2",
-        "lang_name": "Bahasa Indonesia",
-        "lang_code": "id-ID"
-      },
-      {
-        "id": "3",
-        "language_id": "3",
-        "lang_name": "Bahasa Melayu",
-        "lang_code": "ms-MY"
-      },
-      {
-        "id": "4",
-        "language_id": "4",
-        "lang_name": "Catal\u00e0",
-        "lang_code": "ca-ES"
-      },
-      {
-        "id": "5",
-        "language_id": "5",
-        "lang_name": "\u010ce\u0161tina",
-        "lang_code": "cs-CZ"
-      },
-      {
-        "id": "6",
-        "language_id": "6",
-        "lang_name": "Deutsch",
-        "lang_code": "de-DE"
-      },
-      {
-        "id": "7",
-        "language_id": "7",
-        "lang_name": "Australia",
-        "lang_code": "en-AU"
-      },
-      {
-        "id": "8",
-        "language_id": "7",
-        "lang_name": "Canada",
-        "lang_code": "en-CA"
-      },
-      {
-        "id": "9",
-        "language_id": "7",
-        "lang_name": "India",
-        "lang_code": "en-IN"
-      },
-      {
-        "id": "10",
-        "language_id": "7",
-        "lang_name": "New Zealand",
-        "lang_code": "en-NZ"
-      },
-      {
-        "id": "11",
-        "language_id": "7",
-        "lang_name": "South Africa",
-        "lang_code": "en-ZA"
-      },
-      {
-        "id": "12",
-        "language_id": "7",
-        "lang_name": "United Kingdom",
-        "lang_code": "en-GB"
-      },
-      {
-        "id": "13",
-        "language_id": "7",
-        "lang_name": "United States",
-        "lang_code": "en-US"
-      },
-      {
-        "id": "14",
-        "language_id": "8",
-        "lang_name": "Argentina",
-        "lang_code": "es-AR"
-      },
-      {
-        "id": "15",
-        "language_id": "8",
-        "lang_name": "Bolivia",
-        "lang_code": "es-BO"
-      },
-      {
-        "id": "16",
-        "language_id": "8",
-        "lang_name": "Chile",
-        "lang_code": "es-CL"
-      },
-      {
-        "id": "17",
-        "language_id": "8",
-        "lang_name": "Colombia",
-        "lang_code": "es-CO"
-      },
-      {
-        "id": "18",
-        "language_id": "8",
-        "lang_name": "Costa Rica",
-        "lang_code": "es-CR"
-      },
-      {
-        "id": "19",
-        "language_id": "8",
-        "lang_name": "Ecuador",
-        "lang_code": "es-EC"
-      },
-      {
-        "id": "20",
-        "language_id": "8",
-        "lang_name": "El Salvador",
-        "lang_code": "es-SV"
-      },
-      {
-        "id": "21",
-        "language_id": "8",
-        "lang_name": "Espa\u00f1a",
-        "lang_code": "es-ES"
-      },
-      {
-        "id": "22",
-        "language_id": "8",
-        "lang_name": "Estados Unidos",
-        "lang_code": "es-US"
-      },
-      {
-        "id": "23",
-        "language_id": "8",
-        "lang_name": "Guatemala",
-        "lang_code": "es-GT"
-      },
-      {
-        "id": "24",
-        "language_id": "8",
-        "lang_name": "Honduras",
-        "lang_code": "es-HN"
-      },
-      {
-        "id": "25",
-        "language_id": "8",
-        "lang_name": "M\u00e9xico",
-        "lang_code": "es-MX"
-      },
-      {
-        "id": "26",
-        "language_id": "8",
-        "lang_name": "Nicaragua",
-        "lang_code": "es-NI"
-      },
-      {
-        "id": "27",
-        "language_id": "8",
-        "lang_name": "Panam\u00e1",
-        "lang_code": "es-PA"
-      },
-      {
-        "id": "28",
-        "language_id": "8",
-        "lang_name": "Paraguay",
-        "lang_code": "es-PY"
-      },
-      {
-        "id": "29",
-        "language_id": "8",
-        "lang_name": "Per\u00fa",
-        "lang_code": "es-PE"
-      },
-      {
-        "id": "30",
-        "language_id": "8",
-        "lang_name": "Puerto Rico",
-        "lang_code": "es-PR"
-      },
-      {
-        "id": "31",
-        "language_id": "8",
-        "lang_name": "Rep\u00fablica Dominicana",
-        "lang_code": "es-DO"
-      },
-      {
-        "id": "32",
-        "language_id": "8",
-        "lang_name": "Uruguay",
-        "lang_code": "es-UY"
-      },
-      {
-        "id": "33",
-        "language_id": "8",
-        "lang_name": "Venezuela",
-        "lang_code": "es-VE"
-      },
-      {
-        "id": "34",
-        "language_id": "9",
-        "lang_name": "Euskara",
-        "lang_code": "eu-ES"
-      },
-      {
-        "id": "35",
-        "language_id": "10",
-        "lang_name": "Fran\u00e7ais",
-        "lang_code": "fr-FR"
-      },
-      {
-        "id": "36",
-        "language_id": "11",
-        "lang_name": "Galego",
-        "lang_code": "gl-ES"
-      },
-      {
-        "id": "37",
-        "language_id": "12",
-        "lang_name": "Hrvatski",
-        "lang_code": "hr_HR"
-      },
-      {
-        "id": "38",
-        "language_id": "13",
-        "lang_name": "IsiZulu",
-        "lang_code": "zu-ZA"
-      },
-      {
-        "id": "39",
-        "language_id": "14",
-        "lang_name": "\u00cdslenska",
-        "lang_code": "is-IS"
-      },
-      {
-        "id": "40",
-        "language_id": "15",
-        "lang_name": "Italia",
-        "lang_code": "it-IT"
-      },
-      {
-        "id": "41",
-        "language_id": "15",
-        "lang_name": "Svizzera",
-        "lang_code": "it-CH"
-      },
-      {
-        "id": "42",
-        "language_id": "16",
-        "lang_name": "Magyar",
-        "lang_code": "hu-HU"
-      },
-      {
-        "id": "43",
-        "language_id": "17",
-        "lang_name": "Nederlands",
-        "lang_code": "nl-NL"
-      },
-      {
-        "id": "44",
-        "language_id": "18",
-        "lang_name": "Norsk bokm\u00e5l",
-        "lang_code": "nb-NO"
-      },
-      {
-        "id": "45",
-        "language_id": "19",
-        "lang_name": "Polski",
-        "lang_code": "pl-PL"
-      },
-      {
-        "id": "46",
-        "language_id": "20",
-        "lang_name": "Brasil",
-        "lang_code": "pt-BR"
-      },
-      {
-        "id": "47",
-        "language_id": "20",
-        "lang_name": "Portugal",
-        "lang_code": "pt-PT"
-      },
-      {
-        "id": "48",
-        "language_id": "21",
-        "lang_name": "Rom\u00e2n\u0103",
-        "lang_code": "ro-RO"
-      },
-      {
-        "id": "49",
-        "language_id": "22",
-        "lang_name": "Sloven\u010dina",
-        "lang_code": "sk-SK"
-      },
-      {
-        "id": "50",
-        "language_id": "23",
-        "lang_name": "Suomi",
-        "lang_code": "fi-FI"
-      },
-      {
-        "id": "51",
-        "language_id": "24",
-        "lang_name": "Svenska",
-        "lang_code": "sv-SE"
-      },
-      {
-        "id": "52",
-        "language_id": "25",
-        "lang_name": "T\u00fcrk\u00e7e",
-        "lang_code": "tr-TR"
-      },
-      {
-        "id": "53",
-        "language_id": "26",
-        "lang_name": "\u0431\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
-        "lang_code": "bg-BG"
-      },
-      {
-        "id": "54",
-        "language_id": "27",
-        "lang_name": "P\u0443\u0441\u0441\u043a\u0438\u0439",
-        "lang_code": "ru-RU"
-      },
-      {
-        "id": "55",
-        "language_id": "28",
-        "lang_name": "\u0421\u0440\u043f\u0441\u043a\u0438",
-        "lang_code": "sr-RS"
-      },
-      {
-        "id": "56",
-        "language_id": "29",
-        "lang_name": "\ud55c\uad6d\uc5b4",
-        "lang_code": "ko-KR"
-      },
-      {
-        "id": "57",
-        "language_id": "30",
-        "lang_name": "\u666e\u901a\u8bdd (\u4e2d\u56fd\u5927\u9646)",
-        "lang_code": "cmn-Hans-CN"
-      },
-      {
-        "id": "58",
-        "language_id": "30",
-        "lang_name": "\u666e\u901a\u8bdd (\u9999\u6e2f)",
-        "lang_code": "cmn-Hans-HK"
-      },
-      {
-        "id": "59",
-        "language_id": "30",
-        "lang_name": "\u4e2d\u6587 (\u53f0\u7063)",
-        "lang_code": "cmn-Hant-TW"
-      },
-      {
-        "id": "60",
-        "language_id": "30",
-        "lang_name": "\u7cb5\u8a9e (\u9999\u6e2f)",
-        "lang_code": "yue-Hant-HK"
-      },
-      {
-        "id": "61",
-        "language_id": "31",
-        "lang_name": "\u65e5\u672c\u8a9e",
-        "lang_code": "ja-JP"
-      },
-      {
-        "id": "62",
-        "language_id": "32",
-        "lang_name": "Lingua lat\u012bna",
-        "lang_code": "la"
-      }
-    ],
-    "lh_speech_language": [
-      {
-        "id": "1",
-        "name": "Afrikaans"
-      },
-      {
-        "id": "2",
-        "name": "Bahasa Indonesia"
-      },
-      {
-        "id": "3",
-        "name": "Bahasa Melayu"
-      },
-      {
-        "id": "4",
-        "name": "Catal\u00e0"
-      },
-      {
-        "id": "5",
-        "name": "\u010ce\u0161tina"
-      },
-      {
-        "id": "6",
-        "name": "Deutsch"
-      },
-      {
-        "id": "7",
-        "name": "English"
-      },
-      {
-        "id": "8",
-        "name": "Espa\u00f1ol"
-      },
-      {
-        "id": "9",
-        "name": "Euskara"
-      },
-      {
-        "id": "10",
-        "name": "Fran\u00e7ais"
-      },
-      {
-        "id": "11",
-        "name": "Galego"
-      },
-      {
-        "id": "12",
-        "name": "Hrvatski"
-      },
-      {
-        "id": "13",
-        "name": "IsiZulu"
-      },
-      {
-        "id": "14",
-        "name": "\u00cdslenska"
-      },
-      {
-        "id": "15",
-        "name": "Italiano"
-      },
-      {
-        "id": "16",
-        "name": "Magyar"
-      },
-      {
-        "id": "17",
-        "name": "Nederlands"
-      },
-      {
-        "id": "18",
-        "name": "Norsk bokm\u00e5l"
-      },
-      {
-        "id": "19",
-        "name": "Polski"
-      },
-      {
-        "id": "20",
-        "name": "Portugu\u00eas"
-      },
-      {
-        "id": "21",
-        "name": "Rom\u00e2n\u0103"
-      },
-      {
-        "id": "22",
-        "name": "Sloven\u010dina"
-      },
-      {
-        "id": "23",
-        "name": "Suomi"
-      },
-      {
-        "id": "24",
-        "name": "Svenska"
-      },
-      {
-        "id": "25",
-        "name": "T\u00fcrk\u00e7e"
-      },
-      {
-        "id": "26",
-        "name": "\u0431\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438"
-      },
-      {
-        "id": "27",
-        "name": "P\u0443\u0441\u0441\u043a\u0438\u0439"
-      },
-      {
-        "id": "28",
-        "name": "\u0421\u0440\u043f\u0441\u043a\u0438"
-      },
-      {
-        "id": "29",
-        "name": "\ud55c\uad6d\uc5b4"
-      },
-      {
-        "id": "30",
-        "name": "\u4e2d\u6587"
-      },
-      {
-        "id": "31",
-        "name": "\u65e5\u672c\u8a9e"
-      },
-      {
-        "id": "32",
-        "name": "Lingua lat\u012bna"
-      }
-    ],
-    "lh_abstract_email_template": [
-      {
-        "id": "1",
-        "name": "Send mail to user",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Dear {user_chat_nick},\r\n\r\n{additional_message}\r\n\r\nLive Support response:\r\n{messages_content}\r\n\r\nSincerely,\r\nLive Support Team\r\n",
-        "subject": "{name_surname} has responded to your request",
-        "bcc_recipients": "",
-        "subject_ac": "1",
-        "reply_to": "",
-        "reply_to_ac": "1",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "2",
-        "name": "Support request from user",
-        "from_name": "",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nLink to chat if any:\r\n{prefillchat}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Support request from user",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "3",
-        "name": "User mail for himself",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Dear {user_chat_nick},\r\n\r\nTranscript:\r\n{messages_content}\r\n\r\nSincerely,\r\nLive Support Team\r\n",
-        "subject": "Chat transcript",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "4",
-        "name": "New chat request",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "New chat request",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "5",
-        "name": "Chat was closed",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\n{operator} has closed a chat\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Chat was closed",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "6",
-        "name": "New FAQ question",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nNew FAQ question\r\nEmail: {email}\r\n\r\nQuestion:\r\n{question}\r\n\r\nQuestion URL:\r\n{url_question}\r\n\r\nURL to answer a question:\r\n{url_request}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "New FAQ question",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "7",
-        "name": "New unread message",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "New chat request",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "8",
-        "name": "Filled form",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nUser has filled a form\r\nForm name - {form_name}\r\nUser IP - {ip}\r\nDownload filled data - {url_download}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Filled form - {form_name}",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "9",
-        "name": "Chat was accepted",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nOperator {user_name} has accepted a chat [{chat_id}]\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Chat was accepted [{chat_id}]",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "10",
-        "name": "Permission request",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nOperator {user} has requested these permissions\n\r\n{permissions}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Permission request from {user}",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "11",
-        "name": "You have unread messages",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nOperator {user} has requested these permissions\n\r\n{permissions}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Operator has answered to your request",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "12",
-        "name": "Visitor returned",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nVisitor information\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\nCreated:{created}\r\nUser left:{user_left}\r\nWaited:{waited}\r\nChat duration:{chat_duration}\r\n\r\nSee more information at\r\n{url_accept}\r\n\r\nLast chat:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nSincerely,\r\nLive Support Team",
-        "subject": "Visitor returned - {username}",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      },
-      {
-        "id": "13",
-        "name": "Report prepared",
-        "from_name": "Live Helper Chat",
-        "from_name_ac": "0",
-        "from_email": "",
-        "from_email_ac": "0",
-        "content": "Hello,\r\n\r\nReport prepared - {report_name}, {date_range}\r\n\r\n{report_description}\r\n\r\nView report at:\r\n{url_report}\r\nView directly: {url_report_direct}",
-        "subject": "Report prepared - {report_name}",
-        "bcc_recipients": "",
-        "subject_ac": "0",
-        "reply_to": "",
-        "reply_to_ac": "0",
-        "recipient": "",
-        "user_mail_as_sender": "0",
-        "translations": ""
-      }
-    ]
-  },
-  "tables_data_identifier": {
-    "lh_users_setting_option": "identifier",
-    "lh_chat_config": "identifier",
-    "lh_abstract_email_template": "id",
-    "lh_speech_language": "id",
-    "lh_speech_language_dialect": "id"
-  },
-  "tables_alter" : {
-    "lh_abstract_survey_item" : {
-      "stars" : {"sql" : "ALTER TABLE `lh_abstract_survey_item` CHANGE `stars` `max_stars_1` int(11) NOT NULL;", "new" : "max_stars_1"}
-    },
-    "lh_abstract_survey" : {
-      "max_stars" : {"sql" : "ALTER TABLE `lh_abstract_survey` CHANGE `max_stars` `max_stars_1` int(11) NOT NULL;", "new" : "max_stars_1"}
-    }
-  },
-  "tables_drop_column" : {
-    "lh_departament" : ["start_hour","end_hour","mod","tud","wed","thd","frd","sad","sud","closed_chats_counter"],
-    "lh_chat" : ["wait_timeout","wait_timeout_send","timeout_message","wait_timeout_repeat"],
-    "lh_abstract_proactive_chat_invitation" : ["wait_message","wait_timeout","timeout_message","repeat_number"],
-    "lh_chat_online_user" : ["show_on_mobile"],
-    "lh_users" : ["active_chats_counter","closed_chats_counter","pending_chats_counter"]
-  },
-  "tables_collation" : {
-    "lh_abstract_auto_responder" : "utf8mb4_unicode_ci",
-    "lh_abstract_auto_responder_chat" : "utf8mb4_unicode_ci",
-    "lh_abstract_browse_offer_invitation" : "utf8mb4_unicode_ci",
-    "lh_abstract_email_template" : "utf8mb4_unicode_ci",
-    "lh_abstract_form" : "utf8mb4_unicode_ci",
-    "lh_abstract_form_collected" : "utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_event" : "utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_invitation" : "utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_invitation_event" : "utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_variables" : "utf8mb4_unicode_ci",
-    "lh_abstract_product" : "utf8mb4_unicode_ci",
-    "lh_abstract_product_departament" : "utf8mb4_unicode_ci",
-    "lh_abstract_rest_api_key" : "utf8mb4_unicode_ci",
-    "lh_abstract_survey" : "utf8mb4_unicode_ci",
-    "lh_abstract_survey_item" : "utf8mb4_unicode_ci",
-    "lh_abstract_widget_theme" : "utf8mb4_unicode_ci",
-    "lh_admin_theme" : "utf8mb4_unicode_ci",
-    "lh_canned_msg" : "utf8mb4_unicode_ci",
-    "lh_canned_msg_tag" : "utf8mb4_unicode_ci",
-    "lh_canned_msg_tag_link" : "utf8mb4_unicode_ci",
-    "lh_chat" : "utf8mb4_unicode_ci",
-    "lh_chatbox" : "utf8mb4_unicode_ci",
-    "lh_chat_accept" : "utf8mb4_unicode_ci",
-    "lh_chat_archive_range" : "utf8mb4_unicode_ci",
-    "lh_chat_blocked_user" : "utf8mb4_unicode_ci",
-    "lh_chat_config" : "utf8mb4_unicode_ci",
-    "lh_chat_file" : "utf8mb4_unicode_ci",
-    "lh_chat_online_user" : "utf8mb4_unicode_ci",
-    "lh_chat_online_user_footprint" : "utf8mb4_unicode_ci",
-    "lh_chat_paid" : "utf8mb4_unicode_ci",
-    "lh_chat_start_settings" : "utf8mb4_unicode_ci",
-    "lh_cobrowse" : "utf8mb4_unicode_ci",
-    "lh_departament" : "utf8mb4_unicode_ci",
-    "lh_departament_custom_work_hours" : "utf8mb4_unicode_ci",
-    "lh_departament_group" : "utf8mb4_unicode_ci",
-    "lh_departament_group_member" : "utf8mb4_unicode_ci",
-    "lh_departament_group_user" : "utf8mb4_unicode_ci",
-    "lh_departament_limit_group" : "utf8mb4_unicode_ci",
-    "lh_departament_limit_group_member" : "utf8mb4_unicode_ci",
-    "lh_faq" : "utf8mb4_unicode_ci",
-    "lh_forgotpasswordhash" : "utf8mb4_unicode_ci",
-    "lh_group" : "utf8mb4_unicode_ci",
-    "lh_grouprole" : "utf8mb4_unicode_ci",
-    "lh_groupuser" : "utf8mb4_unicode_ci",
-    "lh_group_work" : "utf8mb4_unicode_ci",
-    "lh_msg" : "utf8mb4_unicode_ci",
-    "lh_question" : "utf8mb4_unicode_ci",
-    "lh_question_answer" : "utf8mb4_unicode_ci",
-    "lh_question_option" : "utf8mb4_unicode_ci",
-    "lh_question_option_answer" : "utf8mb4_unicode_ci",
-    "lh_role" : "utf8mb4_unicode_ci",
-    "lh_rolefunction" : "utf8mb4_unicode_ci",
-    "lh_speech_chat_language" : "utf8mb4_unicode_ci",
-    "lh_speech_language" : "utf8mb4_unicode_ci",
-    "lh_speech_language_dialect" : "utf8mb4_unicode_ci",
-    "lh_transfer" : "utf8mb4_unicode_ci",
-    "lh_userdep" : "utf8mb4_unicode_ci",
-    "lh_users" : "utf8mb4_unicode_ci",
-    "lh_users_online_session" : "utf8mb4_unicode_ci",
-    "lh_users_remember" : "utf8mb4_unicode_ci",
-    "lh_users_session" : "utf8mb4_unicode_ci",
-    "lh_users_setting" : "utf8mb4_unicode_ci",
-    "lh_users_setting_option" : "utf8mb4_unicode_ci",
-    "lh_abstract_offline_reason" : "utf8mb4_unicode_ci"
-  },
-  "tables_indexes" : {
-    "lh_users_online_session" : {
-      "new" : {
-        "lactivity" : "ALTER TABLE `lh_users_online_session` ADD INDEX `lactivity` (`lactivity`);",
-        "user_id_time" : "ALTER TABLE `lh_users_online_session` ADD KEY `user_id_time` (`user_id`, `time`);"
-    },
-      "old" : []
-    },
-    "lh_chat_incoming" : {
-      "new" : {"incoming_ext_id_uniq" : "ALTER TABLE `lh_chat_incoming` ADD UNIQUE `incoming_ext_id_uniq` (`incoming_id`, `chat_external_id`);"},
-      "old" : ["incoming_ext_id"]
-    },
-    "lh_notification_subscriber" : {
-      "new" : {"subscriber_hash" : "ALTER TABLE `lh_notification_subscriber` ADD INDEX `subscriber_hash` (`subscriber_hash`);"},
-      "old" : []
-    },
-    "lh_canned_msg_use" : {
-      "new" : {"chat_id" : "ALTER TABLE `lh_canned_msg_use` ADD INDEX `chat_id` (`chat_id`);"},
-      "old" : []
-    },
-    "lh_grouprole" : {
-      "new" : {"group_id_primary" : "ALTER TABLE `lh_grouprole` ADD INDEX `group_id_primary` (`group_id`);"},
-      "old" : []
-    },
-    "lh_users_session" : {
-      "new" : {
-        "device_token_device_type_v2" : "ALTER TABLE `lh_users_session` ADD INDEX `device_token_device_type_v2` (`device_token`(191),`device_type`);",
-        "error" : "ALTER TABLE `lh_users_session` ADD INDEX `error` (`error`);"
-      },
-      "old" : ["device_token_device_type"]
-    },
-    "lh_departament_group_member" : {
-      "new" : {
-        "dep_group_id_dep_id" : "DELETE t1 FROM `lh_departament_group_member` t1 INNER JOIN `lh_departament_group_member` t2 ON t1.`dep_group_id` = t2.`dep_group_id` AND t1.`dep_id` = t2.`dep_id` WHERE t1.id > t2.id; ALTER TABLE `lh_departament_group_member` ADD UNIQUE `dep_group_id_dep_id` (`dep_group_id`, `dep_id`);"
-      },
-      "old" : ["dep_group_id"]
-    },
-    "lh_chat_blocked_user" : {
-      "new" : {
-        "nick" : "ALTER TABLE `lh_chat_blocked_user` ADD INDEX `nick` (`nick`);",
-        "online_user_id" : "ALTER TABLE `lh_chat_blocked_user` ADD INDEX `online_user_id` (`online_user_id`);"
-      },
-      "old" : []
-    },
-    "lh_faq" : {
-      "new" : {"active_url_2" : "ALTER TABLE `lh_faq` ADD INDEX `active_url_2` (`active`,`url`(191));"},
-      "old" : ["active_url"]
-    },
-    "lh_userdep" : {
-      "new" : {
-        "user_id_type" : "ALTER TABLE `lh_userdep` ADD INDEX `user_id_type` (`user_id`, `type`);",
-        "online_op_widget_2" : "ALTER TABLE `lh_userdep` ADD INDEX `online_op_widget_2` (`dep_id`, `last_activity`, `user_id`);",
-        "online_op_widget_3" : "ALTER TABLE `lh_userdep` ADD INDEX `online_op_widget_3` (`user_id`, `active_chats`);"
-      },
-      "old" : ["user_id","online_op_widget"]
-    },
-    "lh_chat_online_user_footprint" : {
-      "new" : {"chat_id" : "ALTER TABLE `lh_chat_online_user_footprint` ADD INDEX `chat_id` (`chat_id`);"},
-      "old" : ["chat_id_vtime"]
-    },
-    "lh_chat_online_user" : {
-      "new" : {"first_visit" : "ALTER TABLE `lh_chat_online_user` ADD INDEX `first_visit` (`first_visit`);"},
-      "old" : []
-    },
-    "lh_group" : {
-      "new" : {"disabled" : "ALTER TABLE `lh_group` ADD INDEX `disabled` (`disabled`);"},
-      "old" : []
-    },
-    "lh_chat" : {
-      "new" : {
-        "nick" : "ALTER TABLE `lh_chat` ADD INDEX `nick` (`nick`);",
-        "time" : "ALTER TABLE `lh_chat` ADD INDEX `time` (`time`);",
-        "iwh_id" : "ALTER TABLE `lh_chat` ADD INDEX `iwh_id` (`iwh_id`);",
-        "theme_id" : "ALTER TABLE `lh_chat` ADD INDEX `theme_id` (`theme_id`);",
-        "email" : "ALTER TABLE `lh_chat` ADD INDEX `email` (`email`);",
-        "phone" : "ALTER TABLE `lh_chat` ADD INDEX `phone` (`phone`);",
-        "unanswered_chat" : "ALTER TABLE `lh_chat` ADD INDEX `unanswered_chat` (`unanswered_chat`);",
-        "product_id" : "ALTER TABLE `lh_chat` ADD INDEX `product_id` (`product_id`);",
-        "dep_id" : "ALTER TABLE `lh_chat` ADD INDEX `dep_id` (`dep_id`);",
-        "unread_operator" : "ALTER TABLE `lh_chat` ADD INDEX `unread_operator` (`has_unread_op_messages`, `unread_op_messages_informed`);",
-        "online_user_id" : "ALTER TABLE `lh_chat` ADD INDEX `online_user_id` (`online_user_id`);",
-        "user_id_sender_user_id" : "ALTER TABLE `lh_chat` ADD INDEX `user_id_sender_user_id` (`user_id`, `sender_user_id`);",
-        "sender_user_id" : "ALTER TABLE `lh_chat` ADD INDEX `sender_user_id` (`sender_user_id`);",
-        "anonymized" : "ALTER TABLE `lh_chat` ADD INDEX `anonymized` (`anonymized`);",
-        "has_unread_messages" : "ALTER TABLE `lh_chat` ADD INDEX `has_unread_messages` (`has_unread_messages`);",
-        "dep_id_status" : "ALTER TABLE `lh_chat` ADD INDEX `dep_id_status` (`dep_id`,`status`);",
-        "status" : "ALTER TABLE `lh_chat` ADD INDEX `status` (`status`);",
-        "status_user_id" : "ALTER TABLE `lh_chat` ADD INDEX `status_user_id` (`status`,`user_id`);"
-      },
-      "old" : ["user_id","status_dep_id_id","status_dep_id_priority_id","status_priority_id","has_unread_messages_dep_id_id"]
-    },
-    "lh_users" : {
-      "new" : {
-        "rec_per_req" : "ALTER TABLE `lh_users` ADD INDEX `rec_per_req` (`rec_per_req`);",
-        "disabled" : "ALTER TABLE `lh_users` ADD INDEX `disabled` (`disabled`);",
-        "username" : "ALTER TABLE `lh_users` ADD INDEX `username` (`username`);"
-      },
-      "old" : []
-    },
-    "lh_generic_bot_trigger" : {
-      "new" : {
-        "default_always" : "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `default_always` (`default_always`);",
-        "default_unknown_btn" : "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `default_unknown_btn` (`default_unknown_btn`);",
-        "in_progress" : "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `in_progress` (`in_progress`);"
-      },
-      "old" : []
-    },
-    "lh_cobrowse" : {
-      "new" : {"online_user_id" : "ALTER TABLE `lh_cobrowse` ADD INDEX `online_user_id` (`online_user_id`);"},
-      "old" : []
-    },
-    "lh_chat_file" : {
-      "new" : {"online_user_id" : "ALTER TABLE `lh_chat_file` ADD INDEX `online_user_id` (`online_user_id`)"},
-      "old" : []
-    },
-    "lh_speech_language_dialect" : {
-      "new" : {
-        "short_code" : "ALTER TABLE `lh_speech_language_dialect` ADD INDEX `short_code` (`short_code`);",
-        "lang_code" : "ALTER TABLE `lh_speech_language_dialect` ADD INDEX `lang_code` (`lang_code`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_chat_column" : {
-      "new" : {
-        "online_enabled" : "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `online_enabled` (`online_enabled`);",
-        "chat_enabled" : "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `chat_enabled` (`chat_enabled`);",
-        "chat_window_enabled" : "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `chat_window_enabled` (`chat_window_enabled`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_subject" : {
-      "new" : {
-        "internal" : "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal` (`internal`);",
-        "internal_type" : "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal_type` (`internal_type`);",
-        "archive" : "ALTER TABLE `lh_abstract_subject` ADD INDEX `archive` (`archive`);"
-      },
-      "old" : []
-    },
-    "lh_departament" : {
-      "new" : {
-        "alias" : "ALTER TABLE `lh_departament` ADD INDEX `alias` (`alias`);",
-        "attr_int_1" : "ALTER TABLE `lh_departament` ADD INDEX `attr_int_1` (`attr_int_1`);",
-        "attr_int_2" : "ALTER TABLE `lh_departament` ADD INDEX `attr_int_2` (`attr_int_2`);",
-        "attr_int_3" : "ALTER TABLE `lh_departament` ADD INDEX `attr_int_3` (`attr_int_3`);",
-        "sort_priority_name" : "ALTER TABLE `lh_departament` ADD INDEX `sort_priority_name` (`sort_priority`,`name`);",
-        "active_mod" : "ALTER TABLE `lh_departament` ADD INDEX `active_mod` (`online_hours_active`,`mod_start_hour`,`mod_end_hour`);",
-        "active_tud" : "ALTER TABLE `lh_departament` ADD INDEX `active_tud` (`online_hours_active`,`tud_start_hour`,`tud_end_hour`);",
-        "active_wed" : "ALTER TABLE `lh_departament` ADD INDEX `active_wed` (`online_hours_active`,`wed_start_hour`,`wed_end_hour`);",
-        "active_thd" : "ALTER TABLE `lh_departament` ADD INDEX `active_thd` (`online_hours_active`,`thd_start_hour`,`thd_end_hour`);",
-        "active_frd" : "ALTER TABLE `lh_departament` ADD INDEX `active_frd` (`online_hours_active`,`frd_start_hour`,`frd_end_hour`);",
-        "active_sad" : "ALTER TABLE `lh_departament` ADD INDEX `active_sad` (`online_hours_active`,`sad_start_hour`,`sad_end_hour`);",
-        "active_sud" : "ALTER TABLE `lh_departament` ADD INDEX `active_sud` (`online_hours_active`,`sud_start_hour`,`sud_end_hour`);",
-        "active_chats_counter" : "ALTER TABLE `lh_departament` ADD INDEX `active_chats_counter` (`active_chats_counter`);",
-        "pending_chats_counter" : "ALTER TABLE `lh_departament` ADD INDEX `pending_chats_counter` (`pending_chats_counter`);",
-        "bot_chats_counter" : "ALTER TABLE `lh_departament` ADD INDEX `bot_chats_counter` (`bot_chats_counter`);",
-        "archive" : "ALTER TABLE `lh_departament` ADD INDEX `archive` (`archive`);",
-        "identifier_2" : "ALTER TABLE `lh_departament` ADD INDEX `identifier_2` (`identifier`(191));",
-        "ignore_op_status" : "ALTER TABLE `lh_departament` ADD INDEX `ignore_op_status` (`ignore_op_status`);",
-        "dep_offline" : "ALTER TABLE `lh_departament` ADD INDEX `dep_offline` (`dep_offline`);"
-      },
-      "old" : ["oha_sh_eh","identifier"]
-    },
-    "lh_generic_bot_trigger_event" : {
-      "new" : {
-        "pattern_v2" : "ALTER TABLE `lh_generic_bot_trigger_event` ADD INDEX `pattern_v2` (`pattern`(191));",
-        "on_start_type" : "ALTER TABLE `lh_generic_bot_trigger_event` ADD INDEX `on_start_type` (`on_start_type`);"
-      },
-      "old" : ["pattern"]
-    },
-    "lh_canned_msg" : {
-      "new" : {
-        "attr_int_1" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_1` (`attr_int_1`);",
-        "attr_int_2" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_2` (`attr_int_2`);",
-        "attr_int_3" : "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_3` (`attr_int_3`);",
-        "disabled" : "ALTER TABLE `lh_canned_msg` ADD INDEX `disabled` (`disabled`);",
-        "unique_id" : "ALTER TABLE `lh_canned_msg` ADD INDEX `unique_id` (`unique_id`);",
-        "repetitiveness" : "ALTER TABLE `lh_canned_msg` ADD INDEX `repetitiveness` (`repetitiveness`);",
-        "position_title_v2" : "ALTER TABLE `lh_canned_msg` ADD INDEX `position_title_v2` (`position`, `title`(191));",
-        "delete_on_exp" : "ALTER TABLE `lh_canned_msg` ADD INDEX `delete_on_exp` (`delete_on_exp`);"
-      },
-      "old" : ["position_title"]
-    },
-    "lh_departament_custom_work_hours" : {
-      "new" : {
-        "repetitiveness" : "ALTER TABLE `lh_departament_custom_work_hours` ADD INDEX `repetitiveness` (`repetitiveness`);"
-      },
-      "old" : []
-    },
-    "lhc_mailconv_response_template" : {
-      "new" : {
-        "unique_id" : "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `unique_id` (`unique_id`);",
-        "disabled" : "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `disabled` (`disabled`);",
-        "dep_id" : "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `dep_id` (`dep_id`);"
-      },
-      "old" : []
-    },
-    "lh_msg" : {
-      "new" : {
-        "user_id" : "ALTER TABLE `lh_msg` ADD INDEX `user_id` (`user_id`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_form_collected" : {
-      "new" : {
-        "form_id_chat_id" : "ALTER TABLE `lh_abstract_form_collected` ADD INDEX `form_id_chat_id` (`form_id`, `chat_id`);",
-        "chat_id" : "ALTER TABLE `lh_abstract_form_collected` ADD INDEX `chat_id` (`chat_id`);"
-      },
-      "old" : ["form_id"]
-    },
-    "lh_abstract_survey_item" : {
-      "new" : {
-        "ftime" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `ftime` (`ftime`);",
-        "max_stars_1" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_1` (`max_stars_1`);",
-        "max_stars_2" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_2` (`max_stars_2`);",
-        "max_stars_3" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_3` (`max_stars_3`);",
-        "max_stars_4" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_4` (`max_stars_4`);",
-        "max_stars_5" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_5` (`max_stars_5`);",
-        "question_options_1" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_1` (`question_options_1`);",
-        "question_options_2" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_2` (`question_options_2`);",
-        "question_options_3" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_3` (`question_options_3`);",
-        "question_options_4" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_4` (`question_options_4`);",
-        "question_options_5" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_5` (`question_options_5`);",
-        "online_user_id" : "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `online_user_id` (`online_user_id`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_survey" : {
-      "new" : {
-        "identifier" : "ALTER TABLE `lh_abstract_survey` ADD INDEX `identifier` (`identifier`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_proactive_chat_invitation" : {
-      "new" : {
-        "tag" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `tag` (`tag`);",
-        "dynamic_invitation" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `dynamic_invitation` (`dynamic_invitation`);",
-        "show_on_mobile" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `show_on_mobile` (`show_on_mobile`)",
-        "parent_id" : "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `parent_id` (`parent_id`)"
-      },
-      "old" : []
-    },
-    "lh_abstract_proactive_chat_campaign_conv" : {
-      "new" : {
-        "ctime" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `ctime` (`ctime`);",
-        "invitation_id_variation_id" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `invitation_id_variation_id` (`invitation_id`, `variation_id`);",
-        "conv_event_vid_id" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `conv_event_vid_id` (`conv_event`, `vid_id`);",
-        "unique_id" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `unique_id` (`unique_id`);",
-        "conv_int_time" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `conv_int_time` (`conv_int_time`);",
-        "inv_vid" : "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `inv_vid` (`invitation_id`,`invitation_status`,`vid_id`);"
-      },
-      "old" : [
-        "invitation_id"
-      ]
-    },
-    "lh_group_chat" : {
-      "new" : {
-        "chat_id" : "ALTER TABLE `lh_group_chat` ADD INDEX `chat_id` (`chat_id`);"
-      },
-      "old" : []
-    },
-    "lh_group_chat_member" : {
-      "new" : {
-        "type" : "ALTER TABLE `lh_group_chat_member` ADD INDEX `type` (`type`);"
-      },
-      "old" : []
-    },
-    "lh_admin_theme" : {
-      "new" : {
-        "user_id" : "ALTER TABLE `lh_admin_theme` ADD INDEX `user_id` (`user_id`);"
-      },
-      "old" : []
-    },
-    "lh_transfer" : {
-      "new" : {
-        "chat_id_transfer" : "ALTER TABLE `lh_transfer` ADD INDEX `chat_id_transfer` (`chat_id`,`transfer_scope`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_auto_responder" : {
-      "new" : {
-        "disabled" : "ALTER TABLE `lh_abstract_auto_responder` ADD INDEX `disabled` (`disabled`);"
-      },
-      "old" : []
-    },
-    "lhc_mailconv_conversation" : {
-      "new" : {
-        "from_address" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `from_address` (`from_address`);",
-        "from_address_clean" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `from_address_clean` (`from_address_clean`);",
-        "mailbox_id" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `mailbox_id` (`mailbox_id`);",
-        "dep_id" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `dep_id` (`dep_id`);",
-        "status_priority" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_priority` (`status`, `priority`);",
-        "status_priority_asc" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_priority_asc` (`status`, `priority_asc`);",
-        "has_attachment" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `has_attachment` (`has_attachment`);",
-        "udate" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `udate` (`udate`);",
-        "user_id_status" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `user_id_status` (`user_id`, `status`);",
-        "status_dep_id" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_dep_id` (`status`, `dep_id`);",
-        "undelivered" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `undelivered` (`undelivered`);",
-        "lang" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `lang` (`lang`);",
-        "phone" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `phone` (`phone`);",
-        "mailbox_id_status_udate" : "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `mailbox_id_status_udate` (`mailbox_id`,`status`,`udate`);"
-      },
-      "old" : [
-        "status",
-        "user_id"
-      ]
-    },
-    "lhc_mailconv_msg" : {
-      "new" : {
-        "has_attachment" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `has_attachment` (`has_attachment`);",
-        "udate" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `udate` (`udate`);",
-        "dep_id" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `dep_id` (`dep_id`);",
-        "mailbox_id" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `mailbox_id` (`mailbox_id`);",
-        "conversation_id" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `conversation_id` (`conversation_id`);",
-        "conversation_id_old" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `conversation_id_old` (`conversation_id_old`);",
-        "lang" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `lang` (`lang`);",
-        "message_hash" : "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `message_hash` (`message_hash`);"
-      },
-      "old" : []
-    },
-    "lhc_mailconv_mailing_campaign_recipient" : {
-      "new" : {
-        "message_id" : "ALTER TABLE `lhc_mailconv_mailing_campaign_recipient` ADD INDEX `message_id` (`message_id`);"
-      },
-      "old" : []
-    },
-    "lh_abstract_msg_protection" : {
-        "new" : {
-          "enabled_type" : "ALTER TABLE `lh_abstract_msg_protection` ADD INDEX `enabled_type` (`enabled`,`rule_type`);"
-        },
-        "old" : [
-          "enabled"
+    "tables": {
+        "lh_brand": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_mail_continuous_event": [
+            {
+                "field": "message_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_performance": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_notification_op_subscriber": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_sent_copy": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_brand_member": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_chat_participant": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "frt",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "aart",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mart",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_bot_condition": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_delete_item": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_delete_filter": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "delete_policy",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_msg_open": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_pending_import": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_msg_protection": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "rule_type",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "has_dep",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "dep_ids",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "languages",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_mailing_list_recipient": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_recipient": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "attr_str_1",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "mailbox",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_2",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_3",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_4",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_5",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_6",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_mailing_list": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_mailing_campaign_recipient": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "message_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conversation_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "opened_at",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mailbox",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_4",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_5",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_6",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_mailing_campaign": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "owner_logic",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "owner_user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_canned_msg_replace": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "active_from",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_to",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "repetitiveness",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "days_activity",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "time_zone",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_personal_mailbox_group": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_chat_action": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_userdep_alias": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "job_title",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_userdep_disabled": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "only_priority",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_departament_group_user_disabled": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "only_priority",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_saved_search": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "passive",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "status",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "sharer_user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "description",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_saved_report": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "recurring_options",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "send_log",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_canned_msg_use": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_auto_responder": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "siteaccess",
+                "type": "varchar(3)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_message",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bot_configuration",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "disabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "only_proactive",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ignore_pa_chat",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_hold_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_hold_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_hold_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_hold_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_hold_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_hold_message_1",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_hold",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "timeout_hold_message_2",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "timeout_hold_message_3",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "timeout_hold_message_4",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "timeout_hold_message_5",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_message_2",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_message_3",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_message_4",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_message_5",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_reply_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_reply_message_1",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_reply_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_reply_message_2",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_reply_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_reply_message_3",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_reply_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_reply_message_4",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "wait_timeout_reply_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "timeout_reply_message_5",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "repeat_number",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "1",
+                "extra": ""
+            },
+            {
+                "field": "position",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "survey_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "survey_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "timeout_message",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "languages",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_auto_responder_chat": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "auto_responder_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pending_send_status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_timeout_send",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "active_send_status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_survey": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "feedback_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_1_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_1_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_1_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_1_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_2_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_2_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_2_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_2_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_3_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_3_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_3_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_3_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_4_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_4_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_4_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_4_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_5_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "max_stars_5_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_5_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_5_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_1",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_1_items",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_1_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_1_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_1_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_2",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_2_items",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_2_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_2_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_2_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_3",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_3_items",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_3_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_3_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_3_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_4",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_4_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_4_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_4_items",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_4_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_5",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_5_items",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_options_5_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_5_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_5_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_1",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_1_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_1_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_1_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_2",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_2_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_2_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_2_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_3",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_3_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_3_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_3_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_4",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_4_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_4_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_4_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_5",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_5_pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_5_enabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_5_req",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_product_departament": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "product_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "departament_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_proactive_chat_variables": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "store_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "filter_val",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_proactive_chat_event": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "vid_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ev_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ts",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "val",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_proactive_chat_invitation_event": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "invitation_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "event_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "min_number",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "during_seconds",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_proactive_chat_campaign": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_chat_alert_icon": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_stats": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_proactive_chat_campaign_conv": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "variation_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conv_int_expires",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conv_int_time",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conv_event",
+                "type": "varchar(20)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "unique_id",
+                "type": "varchar(20)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lh_incoming_webhook": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "log_incoming",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "log_failed_parse",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "scope",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "icon",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "icon_color",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_chat_incoming": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_external_id",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_chat_paid": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "hash",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_group_object": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "object_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "group_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_subject": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "color",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "internal",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "archive",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pinned",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "widgets",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "internal_type",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_subject_dep": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "subject_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_subject_chat": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "subject_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_users_session": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "token",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "device_type",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "device_token",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "created_on",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "updated_on",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "expires_on",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "notifications_status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "1",
+                "extra": ""
+            },
+            {
+                "field": "error",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "last_error",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_users_online_session": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "duration",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "lactivity",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "offline_reason_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "updated_by_user_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "online_by_user_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_notification_subscriber": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_rest_api_key": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "api_key",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ip_restrictions",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_rest_api_key_remote": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "api_key",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "username",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "host",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "active",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "position",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_admin_theme": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "static_content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "static_js_content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "css_attributes",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "static_css_content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "header_content",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "header_css",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_product": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "departament_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "disabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_canned_msg_tag_link": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "tag_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "canned_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_canned_msg_tag": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "tag",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_chat_online_user_footprint_update": [
+            {
+                "field": "online_user_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_survey_item": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "survey_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_stars_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_stars_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_4",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_options_5",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_plain_1",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_2",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_3",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_4",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "question_plain_5",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ftime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_browse_offer_invitation": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "siteaccess",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "time_on_site",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "callback_content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "lhc_iframe_content",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "custom_iframe_url",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "executed_times",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "url",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "has_url",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "is_wildcard",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "referrer",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "priority",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "hash",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "width",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "height",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "unit",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_email_template": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "from_name",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "from_name_ac",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "use_chat_locale",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "only_recipient",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "from_email",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "from_email_ac",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_mail_as_sender",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "content",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "translations",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "subject",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bcc_recipients",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "subject_ac",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "reply_to",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "reply_to_ac",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "recipient",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_form": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "recipient",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "name_attr",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "intro_attr",
+                "type": "varchar(400)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "xls_columns",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "pagelayout",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "post_content",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "form_type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_form_collected": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "form_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ctime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ip",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "custom_fields",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "attr_int_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "attr_int_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "attr_int_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_proactive_chat_invitation": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "active_from",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_to",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "repetitiveness",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "days_activity",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "url_present",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "siteaccess",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "time_on_site",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "parent_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "bot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inject_only_html",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "campaign_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "disabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "trigger_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "bot_offline",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pageviews",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "message",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "message_returning",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "executed_times",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "show_on_mobile",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay_init",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "show_instant",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "autoresponder_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dynamic_invitation",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "iddle_for",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "event_type",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hide_after_ntimes",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_ids",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "message_returning_nick",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "referrer",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "show_random_operator",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "operator_name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "position",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "event_invitation",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "tag",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "requires_email",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "requires_username",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "requires_phone",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "design_data",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_widget_theme": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "support_joined",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "alias",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "support_closed",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bot_status_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "pending_join",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "pending_join_queue",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "noonline_operators",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "noonline_operators_offline",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name_company",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "onl_bcolor",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bor_bcolor",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": "e3e3e3",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "text_color",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "popup_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "popup_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "close_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "close_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "restore_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "restore_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "minimize_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "minimize_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "offline_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "offline_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "logo_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "logo_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "copyright_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "copyright_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "widget_copyright_url",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "show_copyright",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 1,
+                "extra": ""
+            },
+            {
+                "field": "modern_look",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "hide_op_ts",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "hide_ts",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "hide_close",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "show_need_help_delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "show_status_delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "hide_popup",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "header_height",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "show_need_help",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "1",
+                "extra": ""
+            },
+            {
+                "field": "widget_response_width",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "show_need_help_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "24",
+                "extra": ""
+            },
+            {
+                "field": "header_padding",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "widget_border_width",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "need_help_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "header_background",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "widget_border_color",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bot_configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "notification_configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_tcolor",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_bcolor",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_border",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_close_bg",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_hover_bg",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_close_hover_bg",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "custom_status_css",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "custom_container_css",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "custom_widget_css",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "custom_popup_css",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_header",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "need_help_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "offline_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "intro_operator_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_image",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_image_path",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "explain_text",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "show_voting",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "1",
+                "extra": ""
+            },
+            {
+                "field": "department_title",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "department_select",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_visitor_background",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_visitor_title_color",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_visitor_text_color",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_operator_background",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_operator_title_color",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "buble_operator_text_color",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "modified",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_show_leave_form",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "enable_widget_embed_override",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_pright",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_pbottom",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_popheight",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_popwidth",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_survey",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "widget_position",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_canned_msg": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "msg",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "fallback_msg",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "html_snippet",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "updated_at",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "disabled",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "activate_responder",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "created_at",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_from",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_to",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "delete_on_exp",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "repetitiveness",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "days_activity",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "additional_data",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "languages",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "unique_id",
+                "type": "varchar(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci",
+                "post_query": "UPDATE `lh_canned_msg` SET `unique_id` = `id`;"
+            },
+            {
+                "field": "explain",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "position",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "department_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "auto_send",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_cobrowse": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "mtime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "finished",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "w",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wh",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "x",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "y",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "url",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "initialize",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "modifications",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_chat": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "nick",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_locale",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_locale_to",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "iwh_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "theme_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "invitation_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pnd_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "anonymized",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "cls_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "cls_us",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "usaccept",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "gbot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "lsync",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "auto_responder_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "status_sub",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "status_sub_arg",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "uagent",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "status_sub_sub",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "device_type",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_op_msg_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "sender_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "has_unread_op_messages",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "unread_op_messages_informed",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "unanswered_chat",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_uid",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "product_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hash",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "referrer",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "session_referrer",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_variables",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "remarks",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ip",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_tz_identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_status",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "user_closed_ts",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "support_informed",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "unread_messages_informed",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "reinform_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "email",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "country_code",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "country_name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_typing",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_typing_txt",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_typing",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "operator_typing_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "phone",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "has_unread_messages",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_user_msg_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "fbst",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_msg_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "additional_data",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "lat",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "lon",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "city",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operation",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operation_admin",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "mail_send",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "screenshot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wait_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_duration",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "tslasign",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_initiator",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_timeout_ts",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_timeout_ac",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_if_na",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "na_cb_executed",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "nc_cb_executed",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "frt",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "aart",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mart",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_chat_accept": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hash",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ctime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "wused",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_chat_archive_range": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "range_from",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "range_to",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "year_month",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "older_than",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "first_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_mail_archive_range": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_chat_blocked_user": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "ip",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "datets",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "btype",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "expires",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "nick",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_group_work": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "group_work_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_chat_config": [
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "value",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "explain",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "hidden",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_chat_file": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "meta_msg",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "width",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "height",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "upload_name",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "size",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "file_path",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "extension",
+                "type": "varchar(255)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "date",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "persistent",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "tmp",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_chat_online_user": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "vid",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ip",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "visitor_tz",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "current_page",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "page_title",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "notes",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "referrer",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "device_type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conversion_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_time",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "last_visit_prev",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "user_active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "invitation_seen_count",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_check_time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "invitation_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_visit",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "first_visit",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "total_visits",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pages_count",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "tt_pages_count",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "invitation_count",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_agent",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_country_code",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "user_country_name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_message",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_user_proactive",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operator_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "message_seen",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "message_seen_ts",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "lat",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "lon",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "city",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "reopen_chat",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "time_on_site",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "tt_time_on_site",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "requires_email",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "requires_username",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "requires_phone",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "screenshot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operation",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_attr_system",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operation_chat",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_attr",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_chat_online_user_footprint": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "online_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "page",
+                "type": "varchar(2083)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "vtime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_chatbox": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_departament_group_user": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "dep_group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "read_only",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "exc_indv_autoasign",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "only_priority",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "assign_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_min_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_max_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_speech_user_language": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_departament_group_member": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_abstract_chat_variable": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "persistent",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inv",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "try_decrypt",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "case_insensitive",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "change_message",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "old_js_id",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "content_field",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_rest_api": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_generic_bot_rest_api_cache": [
+            {
+                "field": "hash",
+                "type": "varchar(32)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_abstract_chat_column": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "icon_mode",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "has_popup",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_window_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "popup_content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "sort_column",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "sort_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_list_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mail_list_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mail_enabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_chat_priority": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "sort_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "dest_dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "skip_bot",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "role_destination",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "present_role_is",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lh_group_chat": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_group_msg": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_group_chat_member": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "last_msg_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_chat_voice_video": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_canned_msg_dep": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_content_chunk": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "content",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "in_active",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_content_chunk_dep": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_offline_reason": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "description",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "icon",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "pos",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_abstract_auto_responder_dep": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_proactive_chat_invitation_dep": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_abstract_proactive_chat_invitation_one_time": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "invitation_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "vid_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_departament_limit_group_member": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_limit_group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_departament_group": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "achats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "inachats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_op",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_op_h",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "inopchats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "acopchats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pchats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "bchats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_h",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_departament_limit_group": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "pending_max",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_departament": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "email",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "xmpp_recipients",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "xmpp_group_recipients",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_offline",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "archive",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pending_max",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_load",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_op",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_op_h",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_load_h",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "inop_chats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "acop_chats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "bot_chats_counter",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "inactive_chats_cnt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "assign_same_language",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_ac_dep_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_ac_dep_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pending_group_max",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "exclude_inactive_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay_before_assign",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay_before_assign_mail",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "sort_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "visible_if_online",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ignore_op_status",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "department_transfer_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_timeout",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "disabled",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hidden",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delay_lm",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_active_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_active_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_timeout_seconds",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_timeout_seconds_mail",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(2083)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "alias",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "mod_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "mod_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "tud_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "tud_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "wed_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "wed_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "thd_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "thd_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "frd_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "frd_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "sad_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "sad_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "sud_start_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "sud_end_hour",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": "-1",
+                "extra": ""
+            },
+            {
+                "field": "nc_cb_execute",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "na_cb_execute",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inform_unread",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "active_balancing",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "active_mail_balancing",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inform_close",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inform_unread_delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inform_options",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "online_hours_active",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inform_delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "active_chats_counter",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "pending_chats_counter",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "inform_close_all",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": ""
+            },
+            {
+                "field": "inform_close_all_email",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": 0,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "product_configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bot_configuration",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_departament_custom_work_hours": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "date_from",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "date_to",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "start_hour",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "end_hour",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "repetitiveness",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_faq": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "question",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "answer",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "url",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "email",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "has_url",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "is_wildcard",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_forgotpasswordhash": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hash",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "created",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_group": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "disabled",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "required",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_grouprole": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "role_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_groupuser": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_msg": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "msg",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "meta_msg",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "del_st",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "name_support",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_question": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "question",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "location",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "active",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "is_voting",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_intro",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "revote",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_question_answer": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "ip",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "question_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "answer",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "ctime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_question_option": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "question_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "option_name",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "priority",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_exception": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_exception_message": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_tr_group": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "nick",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "bot_lang",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filepath",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filename",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "use_translation_service",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_tr_item": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "auto_translate",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_bot": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "nick",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "short_name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "avatar",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_1",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_2",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attr_str_3",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filepath",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filename",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_generic_bot_pending_event": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_chat_event": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "counter",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_group": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "is_collapsed",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_canned_msg_subject": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_response_template_subject": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_response_template_dep": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_chat_workflow": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "trigger_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_trigger_template": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_trigger": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "bot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "default",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pos",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "default_unknown",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "default_always",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "default_unknown_btn",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "in_progress",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "as_argument",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_payload": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_webhook": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "delay",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "bot_id_alt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "trigger_id_alt",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "status",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lh_users_login": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_trigger_event_template": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lh_generic_bot_trigger_event": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "bot_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "on_start_type",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "skip",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pattern_exc",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pattern",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "configuration",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_audits": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_departament_availability": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "ymdhi",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ymd",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "time",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hourminute",
+                "type": "int(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_question_option_answer": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "question_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "option_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ctime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "ip",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_role": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_speech_chat_language": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "language_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dialect",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_speech_language": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "siteaccess",
+                "type": "varchar(3)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_chat_start_settings": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "data",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "dep_ids",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "department_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_chat_event_track": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "data",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "department_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_speech_language_dialect": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "language_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "lang_name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "lang_code",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "short_code",
+                "type": "varchar(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_rolefunction": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "role_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "module",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "function",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "limitation",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_transfer": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "chat_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_scope",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "ctime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "from_dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "transfer_to_user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_command": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "enabled_display",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "position",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "1000",
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "fields",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "shortcut_1",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "shortcut_2",
+                "type": "varchar(10)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "sub_command",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "info_msg",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_userdep": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "exclude_autoasign",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "exclude_autoasign_mails",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "only_priority",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "exc_indv_autoasign",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "ro",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "last_activity",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "lastd_activity",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "hide_online_ts",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "hide_online",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "last_accepted",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "last_accepted_mail",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pending_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "active_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pending_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "inactive_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "type",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "dep_group_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "always_on",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "assign_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_max_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "chat_min_priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_users": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "username",
+                "type": "varchar(80)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "password",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "avatar",
+                "type": "varchar(150)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "session_id",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "operation_admin",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "email",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "time_zone",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "surname",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "chat_nickname",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filepath",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "filename",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "job_title",
+                "type": "varchar(100)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "xmpp_username",
+                "type": "varchar(200)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "skype",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "departments_ids",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "disabled",
+                "type": "tinyint(4)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "force_logout",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "offline_reason_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "llogin",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "rec_per_req",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "hide_online",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "auto_accept",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "exclude_autoasign",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "exclude_autoasign_mails",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "max_active_chats",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "max_active_mails",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "all_departments",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "invisible_mode",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "inactive_mode",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "cache_version",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "attr_int_1",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_2",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "attr_int_3",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "pswd_updated",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "always_on",
+                "type": "tinyint(1)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lh_users_remember": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "mtime",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
+        ],
+        "lh_generic_bot_repeat_restrict": [
+            {
+                "field": "id",
+                "type": "bigint(20)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_users_setting": [
+            {
+                "field": "id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "user_id",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "MUL",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "value",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lh_users_setting_option": [
+            {
+                "field": "identifier",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "class",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "attribute",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_oauth_ms": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_conversation": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "conv_duration",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "body",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "opened_at",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "priority_asc",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "follow_up_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "mail_variables",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "has_attachment",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "pending_sync",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "undelivered",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "lang",
+                "type": "varchar(5)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "phone",
+                "type": "varchar(16)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "from_address_clean",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_file": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "meta_msg",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "width",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "height",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_remarks": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_msg": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "conversation_id_old",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conv_duration",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "is_external",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "auto_submitted",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "conv_user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "priority",
+                "type": "int(11)",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "opened_at",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "message_hash",
+                "type": "varchar(40)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            },
+            {
+                "field": "has_attachment",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "undelivered",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "rfc822_body",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "delivery_status",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "lang",
+                "type": "varchar(5)",
+                "null": "NO",
+                "key": "",
+                "default": "",
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_msg_subject": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_mailbox": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "import_since",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "dep_id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "auth_method",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "import_priority",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "reopen_reset",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "delete_on_archive",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "delete_policy",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "reopen_timeout",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "4",
+                "extra": ""
+            },
+            {
+                "field": "last_process_time",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "delete_mode",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "no_pswd_smtp",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "create_a_copy",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "user_id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "assign_parent_user",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "failed",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            },
+            {
+                "field": "uuid_status",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "mail_smtp",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "name_smtp",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "username_smtp",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "password_smtp",
+                "type": "varchar(250)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            },
+            {
+                "field": "workflow_options",
+                "type": "longtext",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci"
+            }
+        ],
+        "lhc_mailconv_response_template": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "template_plain",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "unique_id",
+                "type": "varchar(20)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": "",
+                "collation": "utf8mb4_unicode_ci",
+                "post_query": "UPDATE `lhc_mailconv_response_template` SET `unique_id` = `id`;"
+            },
+            {
+                "field": "disabled",
+                "type": "tinyint(1) unsigned",
+                "null": "NO",
+                "key": "",
+                "default": "0",
+                "extra": ""
+            }
+        ],
+        "lhc_mailconv_msg_internal": [
+            {
+                "field": "id",
+                "type": "bigint(20) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            }
+        ],
+        "lhc_mailconv_match_rule": [
+            {
+                "field": "id",
+                "type": "int(11) unsigned",
+                "null": "NO",
+                "key": "PRI",
+                "default": null,
+                "extra": "auto_increment"
+            },
+            {
+                "field": "options",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "mailbox_id",
+                "type": "text",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            },
+            {
+                "field": "name",
+                "type": "varchar(50)",
+                "null": "NO",
+                "key": "",
+                "default": null,
+                "extra": ""
+            }
         ]
     },
-    "lhc_mailconv_file" : {
-      "new" : {
-        "message_id" : "ALTER TABLE `lhc_mailconv_file` ADD INDEX `message_id` (`message_id`);",
-        "conversation_id" : "ALTER TABLE `lhc_mailconv_file` ADD INDEX `conversation_id` (`conversation_id`);"
-      },
-      "old" : []
+    "tables_data": {
+        "lh_users_setting_option": [
+            {
+                "identifier": "chat_message",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "enable_active_list",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "enable_close_list",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "enable_pending_list",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "enable_unread_list",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "new_chat_sound",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "new_user_bn",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "new_user_sound",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "oupdate_timeout",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "ouser_timeout",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "ocountry",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "otime_on_site",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "o_department",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "omax_rows",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "ogroup_by",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "omap_depid",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "omap_mtimeout",
+                "class": "",
+                "attribute": ""
+            },
+            {
+                "identifier": "dwo",
+                "class": "",
+                "attribute": ""
+            }
+        ],
+        "lh_chat_config": [
+            {
+                "identifier": "dashboard_order",
+                "value": "[[\"online_operators\",\"departments_stats\",\"online_visitors\"],[\"pending_chats\",\"unread_chats\",\"transfered_chats\"],[\"active_chats\",\"closed_chats\"]]",
+                "type": "0",
+                "explain": "Home page dashboard widgets order",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_iframe_sharing",
+                "value": "1",
+                "type": "0",
+                "explain": "Disable iframes in sharing mode",
+                "hidden": "0"
+            },
+            {
+                "identifier": "remember_username",
+                "value": "1",
+                "type": "0",
+                "explain": "Should we remember username for the next time visitor starts a chat?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "remember_phone_email",
+                "value": "1",
+                "type": "0",
+                "explain": "Should we remember E-Mail, Phone for the next time visitor starts a chat?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "inform_unread_message",
+                "value": "0",
+                "type": "0",
+                "explain": "Inform visitor if they have unread messages",
+                "hidden": "0"
+            },
+            {
+                "identifier": "transfer_configuration",
+                "value": "0",
+                "type": "0",
+                "explain": "Transfer configuration",
+                "hidden": "1"
+            },
+            {
+                "identifier": "accept_chat_link_timeout",
+                "value": "300",
+                "type": "0",
+                "explain": "How many seconds chat accept link is valid. Set 0 to force login all the time manually.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "open_closed_chat_timeout",
+                "value": "1800",
+                "type": "0",
+                "explain": "How many seconds customer has to open already closed chat.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "hide_right_column_frontpage",
+                "value": "0",
+                "type": "0",
+                "explain": "Hide right column in frontpage",
+                "hidden": "0"
+            },
+            {
+                "identifier": "online_if",
+                "value": "0",
+                "type": "0",
+                "explain": "",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_mouse_activity",
+                "value": "0",
+                "type": "0",
+                "explain": "Should mouse movement be tracked as activity measure, if not checked only basic events would be tracked",
+                "hidden": "0"
+            },
+            {
+                "identifier": "accept_tos_link",
+                "value": "#",
+                "type": "0",
+                "explain": "Change to your site Terms of Service",
+                "hidden": "0"
+            },
+            {
+                "identifier": "speech_data",
+                "value": "a:3:{i:0;b:0;s:8:\"language\";i:7;s:7:\"dialect\";s:5:\"en-US\";}",
+                "type": "1",
+                "explain": "Change to your site Terms of Service",
+                "hidden": "1"
+            },
+            {
+                "identifier": "front_tabs",
+                "value": "dashboard,online_users,online_map,pending_chats,active_chats,unread_chats,closed_chats,online_operators",
+                "type": "0",
+                "explain": "Home page tabs order",
+                "hidden": "0"
+            },
+            {
+                "identifier": "preload_iframes",
+                "value": "0",
+                "type": "0",
+                "explain": "Preload widget. It will avoid loading delay after clicking widget",
+                "hidden": "0"
+            },
+            {
+                "identifier": "min_phone_length",
+                "value": "8",
+                "type": "0",
+                "explain": "Minimum phone number length",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_auto_allow",
+                "value": "0",
+                "type": "0",
+                "explain": "Do not ask permission for users to see their screen",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_nodejs_enabled",
+                "value": "0",
+                "type": "0",
+                "explain": "NodeJs support enabled",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_nodejs_secure",
+                "value": "0",
+                "type": "0",
+                "explain": "Connect to NodeJs in https mode",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_nodejs_path",
+                "value": "",
+                "type": "0",
+                "explain": "socket.io path, optional",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_js_execution",
+                "value": "1",
+                "type": "0",
+                "explain": "Disable JS execution in Co-Browsing operator window",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_nodejs_socket_host",
+                "value": "",
+                "type": "0",
+                "explain": "Host where NodeJs is running",
+                "hidden": "0"
+            },
+            {
+                "identifier": "sharing_nodejs_sllocation",
+                "value": "https://cdn.socket.io/socket.io-1.1.0.js",
+                "type": "0",
+                "explain": "Location of SocketIO JS library",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_is_online",
+                "value": "0",
+                "type": "0",
+                "explain": "Track is user still on site, chat status checks also has to be enabled",
+                "hidden": "0"
+            },
+            {
+                "identifier": "reverse_pending",
+                "value": "0",
+                "type": "0",
+                "explain": "Make default pending chats order from old to new",
+                "hidden": "0"
+            },
+            {
+                "identifier": "allow_reopen_closed",
+                "value": "1",
+                "type": "0",
+                "explain": "Allow user to reopen closed chats?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_activity",
+                "value": "0",
+                "type": "0",
+                "explain": "Track users activity on site?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "product_enabled_module",
+                "value": "0",
+                "type": "0",
+                "explain": "Product module is enabled",
+                "hidden": "1"
+            },
+            {
+                "identifier": "application_name",
+                "value": "a:6:{s:3:\"eng\";s:31:\"Live Helper Chat - live support\";s:3:\"lit\";s:26:\"Live Helper Chat - pagalba\";s:3:\"hrv\";s:0:\"\";s:3:\"esp\";s:0:\"\";s:3:\"por\";s:0:\"\";s:10:\"site_admin\";s:31:\"Live Helper Chat - live support\";}",
+                "type": "1",
+                "explain": "Support application name, visible in browser title.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_timeout",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatic chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_timeout_pending",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatic pending chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_timeout_active",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatic active chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_timeout_bot",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatic bot chats closing. 0 - disabled, n > 0 time in minutes before chat is automatically closed",
+                "hidden": "0"
+            },
+            {
+                "identifier": "automatically_reopen_chat",
+                "value": "1",
+                "type": "0",
+                "explain": "Automatically reopen chat on widget open",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autopurge_timeout",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatic chats purging. 0 - disabled, n > 0 time in minutes before chat is automatically deleted",
+                "hidden": "0"
+            },
+            {
+                "identifier": "cduration_timeout_user",
+                "value": "4",
+                "type": "0",
+                "explain": "How long operator can wait for message from visitor before time between messages are ignored. Values in minutes.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "cduration_timeout_operator",
+                "value": "10",
+                "type": "0",
+                "explain": "How long visitor can wait for message from operator before time between messages are ignored. Values in minutes.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "assign_workflow_timeout",
+                "value": "0",
+                "type": "0",
+                "explain": "Chats waiting in pending queue more than n seconds should be auto-assigned first. Time in seconds",
+                "hidden": "0"
+            },
+            {
+                "identifier": "del_on_close_no_msg",
+                "value": "0",
+                "type": "0",
+                "explain": "Delete chat on close if there are no messages from the visitor",
+                "hidden": "0"
+            },
+            {
+                "identifier": "hide_button_dropdown",
+                "value": "0",
+                "type": "0",
+                "explain": "Hide close button in dropdown",
+                "hidden": "0"
+            },
+            {
+                "identifier": "on_close_exit_chat",
+                "value": "0",
+                "type": "0",
+                "explain": "On chat close exit chat",
+                "hidden": "0"
+            },
+            {
+                "identifier": "bbc_button_visible",
+                "value": "1",
+                "type": "0",
+                "explain": "Show BB Code button",
+                "hidden": "0"
+            },
+            {
+                "identifier": "activity_timeout",
+                "value": "5",
+                "type": "0",
+                "explain": "How long operator should go offline automatically because of inactivity. Value in minutes",
+                "hidden": "0"
+            },
+            {
+                "identifier": "valid_domains",
+                "value": "",
+                "type": "0",
+                "explain": "Domains where script can be embedded. E.g example.com, google.com",
+                "hidden": "0"
+            },
+            {
+                "identifier": "activity_track_all",
+                "value": "0",
+                "type": "0",
+                "explain": "Track all logged operators activity and ignore their individual settings.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "chatbox_data",
+                "value": "a:6:{i:0;b:0;s:20:\"chatbox_auto_enabled\";i:0;s:19:\"chatbox_secret_hash\";s:9:\"9e2e125yq\";s:20:\"chatbox_default_name\";s:7:\"Chatbox\";s:17:\"chatbox_msg_limit\";i:50;s:22:\"chatbox_default_opname\";s:7:\"Manager\";}",
+                "type": "0",
+                "explain": "Chatbox configuration",
+                "hidden": "1"
+            },
+            {
+                "identifier": "customer_company_name",
+                "value": "Live Helper Chat",
+                "type": "0",
+                "explain": "Your company name - visible in bottom left corner",
+                "hidden": "0"
+            },
+            {
+                "identifier": "paidchat_data",
+                "value": "",
+                "type": "0",
+                "explain": "Paid chat configuration",
+                "hidden": "1"
+            },
+            {
+                "identifier": "customer_site_url",
+                "value": "http://livehelperchat.com",
+                "type": "0",
+                "explain": "Your site URL address",
+                "hidden": "0"
+            },
+            {
+                "identifier": "default_theme_id",
+                "value": "0",
+                "type": "0",
+                "explain": "Default theme ID.",
+                "hidden": "1"
+            },
+            {
+                "identifier": "disable_html5_storage",
+                "value": "1",
+                "type": "0",
+                "explain": "Disable HMTL5 storage, check it if your site is switching between http and https",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_popup_restore",
+                "value": "0",
+                "type": "0",
+                "explain": "Disable option in widget to open new window. Restore icon will be hidden",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_print",
+                "value": "0",
+                "type": "0",
+                "explain": "Disable chat print",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_txt_dwnld",
+                "value": "0",
+                "type": "0",
+                "explain": "Disable chat download",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_send",
+                "value": "0",
+                "type": "0",
+                "explain": "Disable chat transcript send",
+                "hidden": "0"
+            },
+            {
+                "identifier": "explicit_http_mode",
+                "value": "",
+                "type": "0",
+                "explain": "Please enter explicit http mode. Either http: or https:, do not forget : at the end.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "mobile_options",
+                "value": "a:2:{s:13:\"notifications\";i:0;s:7:\"fcm_key\";s:152:\"AAAAiF8DeNk:APA91bFVHu2ybhBUTtlEtQrUEPpM2fb-5ovgo0FVNm4XxK3cYJtSwRcd-pqcBot_422yDOzHyw2p9ZFplkHrmNXjm8f5f-OIzfalGmpsypeXvnPxhU6Db1B2Z1Acc-TamHUn2F4xBJkP\";}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "export_hash",
+                "value": "qlg55biu",
+                "type": "0",
+                "explain": "Chats export secret hash",
+                "hidden": "0"
+            },
+            {
+                "identifier": "faq_email_required",
+                "value": "0",
+                "type": "0",
+                "explain": "Is visitor e-mail required for FAQ",
+                "hidden": "0"
+            },
+            {
+                "identifier": "file_configuration",
+                "value": "a:7:{i:0;b:0;s:5:\"ft_op\";s:43:\"gif|jpe?g|png|zip|rar|xls|doc|docx|xlsx|pdf\";s:5:\"ft_us\";s:26:\"gif|jpe?g|png|doc|docx|pdf\";s:6:\"fs_max\";i:2048;s:18:\"active_user_upload\";b:0;s:16:\"active_op_upload\";b:1;s:19:\"active_admin_upload\";b:1;}",
+                "type": "0",
+                "explain": "Files configuration item",
+                "hidden": "1"
+            },
+            {
+                "identifier": "geo_data",
+                "value": "",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "geo_location_data",
+                "value": "a:3:{s:4:\"zoom\";i:4;s:3:\"lat\";s:7:\"49.8211\";s:3:\"lng\";s:7:\"11.7835\";}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "autologin_data",
+                "value": "a:3:{i:0;b:0;s:11:\"secret_hash\";s:16:\"please_change_me\";s:7:\"enabled\";i:0;}",
+                "type": "0",
+                "explain": "Autologin configuration data",
+                "hidden": "1"
+            },
+            {
+                "identifier": "password_data",
+                "value": "",
+                "type": "0",
+                "explain": "Password requirements",
+                "hidden": "1"
+            },
+            {
+                "identifier": "hide_disabled_department",
+                "value": "1",
+                "type": "0",
+                "explain": "Hide disabled department widget",
+                "hidden": "0"
+            },
+            {
+                "identifier": "ignorable_ip",
+                "value": "",
+                "type": "0",
+                "explain": "Which ip should be ignored in online users list, separate by comma",
+                "hidden": "0"
+            },
+            {
+                "identifier": "vwait_to_long",
+                "value": "120",
+                "type": "0",
+                "explain": "How long we should wait before we inform operator about unanswered chat.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "banned_ip_range",
+                "value": "",
+                "type": "0",
+                "explain": "Which ip should not be allowed to chat",
+                "hidden": "0"
+            },
+            {
+                "identifier": "unban_ip_range",
+                "value": "",
+                "type": "0",
+                "explain": "Which ip should not be allowed to be blocked",
+                "hidden": "0"
+            },
+            {
+                "identifier": "update_ip",
+                "value": "127.0.0.1",
+                "type": "0",
+                "explain": "Which ip should be allowed to update DB by executing http request, separate by comma?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_if_offline",
+                "value": "0",
+                "type": "0",
+                "explain": "Track online visitors even if there is no online operators",
+                "hidden": "0"
+            },
+            {
+                "identifier": "ignore_user_status",
+                "value": "0",
+                "type": "0",
+                "explain": "Ignore users online statuses and use departments online hours",
+                "hidden": "0"
+            },
+            {
+                "identifier": "list_online_operators",
+                "value": "0",
+                "type": "0",
+                "explain": "List online operators.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "list_unread",
+                "value": "0",
+                "type": "0",
+                "explain": "List unread chats, disabled for high performance",
+                "hidden": "0"
+            },
+            {
+                "identifier": "list_closed",
+                "value": "0",
+                "type": "0",
+                "explain": "List closed chats, disabled for high performance",
+                "hidden": "0"
+            },
+            {
+                "identifier": "disable_live_autoassign",
+                "value": "0",
+                "type": "0",
+                "explain": "Disable live auto assign",
+                "hidden": "0"
+            },
+            {
+                "identifier": "default_admin_theme_id",
+                "value": "0",
+                "type": "0",
+                "explain": "Default admin theme ID",
+                "hidden": "1"
+            },
+            {
+                "identifier": "max_message_length",
+                "value": "500",
+                "type": "0",
+                "explain": "Maximum message length in characters",
+                "hidden": "0"
+            },
+            {
+                "identifier": "message_seen_timeout",
+                "value": "24",
+                "type": "0",
+                "explain": "Proactive message timeout in hours. After how many hours proactive chat mesasge should be shown again.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "need_help_tip",
+                "value": "1",
+                "type": "0",
+                "explain": "Show need help tooltip?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "enable_status_cache",
+                "value": "0",
+                "type": "0",
+                "explain": "Enable status check cache using Redis. PHPResque extension is required.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "need_help_tip_timeout",
+                "value": "24",
+                "type": "0",
+                "explain": "Need help tooltip timeout, after how many hours show again tooltip?",
+                "hidden": "0"
+            },
+            {
+                "identifier": "pro_active_invite",
+                "value": "1",
+                "type": "0",
+                "explain": "Is pro active chat invitation active. Online users tracking also has to be enabled",
+                "hidden": "0"
+            },
+            {
+                "identifier": "pro_active_limitation",
+                "value": "-1",
+                "type": "0",
+                "explain": "Pro active chats invitations limitation based on pending chats, (-1) do not limit, (0,1,n+1) number of pending chats can be for invitation to be shown.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "pro_active_show_if_offline",
+                "value": "0",
+                "type": "0",
+                "explain": "Should invitation logic be executed if there is no online operators",
+                "hidden": "0"
+            },
+            {
+                "identifier": "notice_message",
+                "value": "",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "reopen_as_new",
+                "value": "1",
+                "type": "0",
+                "explain": "Reopen closed chat as new? Otherwise it will be reopened as active.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "reopen_chat_enabled",
+                "value": "1",
+                "type": "0",
+                "explain": "Reopen chat functionality enabled",
+                "hidden": "0"
+            },
+            {
+                "identifier": "run_departments_workflow",
+                "value": "0",
+                "type": "0",
+                "explain": "Should cronjob run departments transfer workflow, even if user leaves a chat",
+                "hidden": "0"
+            },
+            {
+                "identifier": "run_unaswered_chat_workflow",
+                "value": "0",
+                "type": "0",
+                "explain": "Should cronjob run unanswered chats workflow and execute unaswered chats callback, 0 - no, any other number bigger than 0 is a minits how long chat have to be not accepted before executing callback.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "session_captcha",
+                "value": "0",
+                "type": "0",
+                "explain": "Use session captcha. LHC have to be installed on the same domain or subdomain.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "smtp_data",
+                "value": "a:5:{s:4:\"host\";s:0:\"\";s:4:\"port\";s:2:\"25\";s:8:\"use_smtp\";i:0;s:8:\"username\";s:0:\"\";s:8:\"password\";s:0:\"\";}",
+                "type": "0",
+                "explain": "SMTP configuration",
+                "hidden": "1"
+            },
+            {
+                "identifier": "audit_configuration",
+                "value": "a:7:{s:8:\"days_log\";i:90;s:11:\"log_objects\";a:0:{}s:6:\"log_js\";i:0;s:9:\"log_block\";i:0;s:11:\"log_routing\";i:0;s:9:\"log_files\";i:0;s:8:\"log_user\";i:0;}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "recaptcha_data",
+                "value": "",
+                "type": "0",
+                "explain": "Re-captcha configuration",
+                "hidden": "1"
+            },
+            {
+                "identifier": "sound_invitation",
+                "value": "1",
+                "type": "0",
+                "explain": "Play sound on invitation to chat.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "departament_availability",
+                "value": "364",
+                "type": "0",
+                "explain": "How long department availability statistic should be kept? (days)",
+                "hidden": "0"
+            },
+            {
+                "identifier": "uonline_sessions",
+                "value": "364",
+                "type": "0",
+                "explain": "How long keep operators online sessions data? (days)",
+                "hidden": "0"
+            },
+            {
+                "identifier": "start_chat_data",
+                "value": "a:23:{i:0;b:0;s:21:\"name_visible_in_popup\";b:1;s:27:\"name_visible_in_page_widget\";b:1;s:19:\"name_require_option\";s:8:\"required\";s:22:\"email_visible_in_popup\";b:0;s:28:\"email_visible_in_page_widget\";b:0;s:20:\"email_require_option\";s:8:\"required\";s:24:\"message_visible_in_popup\";b:1;s:30:\"message_visible_in_page_widget\";b:1;s:22:\"message_require_option\";s:8:\"required\";s:22:\"phone_visible_in_popup\";b:0;s:28:\"phone_visible_in_page_widget\";b:0;s:20:\"phone_require_option\";s:8:\"required\";s:21:\"force_leave_a_message\";b:0;s:29:\"offline_name_visible_in_popup\";b:1;s:35:\"offline_name_visible_in_page_widget\";b:1;s:27:\"offline_name_require_option\";s:8:\"required\";s:30:\"offline_phone_visible_in_popup\";b:0;s:36:\"offline_phone_visible_in_page_widget\";b:0;s:28:\"offline_phone_require_option\";s:8:\"required\";s:32:\"offline_message_visible_in_popup\";b:1;s:38:\"offline_message_visible_in_page_widget\";b:1;s:30:\"offline_message_require_option\";s:8:\"required\";}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "sync_sound_settings",
+                "value": "a:16:{i:0;b:0;s:12:\"repeat_sound\";i:1;s:18:\"repeat_sound_delay\";i:5;s:10:\"show_alert\";b:0;s:22:\"new_chat_sound_enabled\";b:1;s:31:\"new_message_sound_admin_enabled\";b:1;s:30:\"new_message_sound_user_enabled\";b:1;s:14:\"online_timeout\";d:300;s:22:\"check_for_operator_msg\";d:10;s:21:\"back_office_sinterval\";d:10;s:22:\"chat_message_sinterval\";d:3.5;s:20:\"long_polling_enabled\";b:0;s:30:\"polling_chat_message_sinterval\";d:1.5;s:29:\"polling_back_office_sinterval\";d:5;s:18:\"connection_timeout\";i:30;s:28:\"browser_notification_message\";b:0;}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            },
+            {
+                "identifier": "tracked_users_cleanup",
+                "value": "160",
+                "type": "0",
+                "explain": "How many days keep records of online users.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "tracked_footprint_cleanup",
+                "value": "90",
+                "type": "0",
+                "explain": "How many days keep records of users footprint.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "cleanup_cronjob",
+                "value": "0",
+                "type": "0",
+                "explain": "Cleanup should be done only using cronjob.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_domain",
+                "value": "",
+                "type": "0",
+                "explain": "Set your domain to enable user tracking across different domain subdomains.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_footprint",
+                "value": "0",
+                "type": "0",
+                "explain": "Track users footprint. For this also online visitors tracking should be enabled",
+                "hidden": "0"
+            },
+            {
+                "identifier": "footprint_background",
+                "value": "0",
+                "type": "0",
+                "explain": "Footprint updates should be processed in the background. Make sure you are running workflow background cronjob.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "mheight",
+                "value": "",
+                "type": "0",
+                "explain": "Messages box height",
+                "hidden": "0"
+            },
+            {
+                "identifier": "mheight_op",
+                "value": "200",
+                "type": "0",
+                "explain": "Messages box height for operator",
+                "hidden": "0"
+            },
+            {
+                "identifier": "listd_op",
+                "value": "10",
+                "type": "0",
+                "explain": "Default number of online operators to show",
+                "hidden": "0"
+            },
+            {
+                "identifier": "product_show_departament",
+                "value": "0",
+                "type": "0",
+                "explain": "Enable products show by departments",
+                "hidden": "1"
+            },
+            {
+                "identifier": "suggest_leave_msg",
+                "value": "1",
+                "type": "0",
+                "explain": "Suggest user to leave a message then user chooses offline department",
+                "hidden": "0"
+            },
+            {
+                "identifier": "no_wildcard_cookie",
+                "value": "0",
+                "type": "0",
+                "explain": "Cookie should be valid only for domain where Javascript is embedded (excludes subdomains)",
+                "hidden": "0"
+            },
+            {
+                "identifier": "checkstatus_timeout",
+                "value": "0",
+                "type": "0",
+                "explain": "Interval between chat status checks in seconds, 0 disabled.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_abandon_pending",
+                "value": "0,0",
+                "type": "0",
+                "explain": "Automatically close pending chats where visitor has left a chat. Timeout in minutes, last activity by visitor <desktop timeout>,<mobile timeout>,<status chat>.",
+                "hidden": "0"
+            },
+            {
+                "identifier": "autoclose_activity_timeout",
+                "value": "0",
+                "type": "0",
+                "explain": "Automatically close active chat if from last visitor/operator message passed. 0 - disabled, n > 0 time in minutes. Optional second argument: ,1 - close only when visitor sent the last message, ,2 - close only when operator sent the last message",
+                "hidden": "0"
+            },
+            {
+                "identifier": "do_no_track_ip",
+                "value": "0",
+                "type": "0",
+                "explain": "Do not track visitors IP",
+                "hidden": "0"
+            },
+            {
+                "identifier": "ignore_typing",
+                "value": "0",
+                "type": "0",
+                "explain": "Do not store what visitor is typing",
+                "hidden": "0"
+            },
+            {
+                "identifier": "encrypt_msg_after",
+                "value": "0",
+                "type": "0",
+                "explain": "After how many days anonymize messages",
+                "hidden": "0"
+            },
+            {
+                "identifier": "encrypt_msg_op",
+                "value": "0",
+                "type": "0",
+                "explain": "Anonymize also operators messages",
+                "hidden": "0"
+            },
+            {
+                "identifier": "track_online_visitors",
+                "value": "1",
+                "type": "0",
+                "explain": "Enable online site visitors tracking",
+                "hidden": "0"
+            },
+            {
+                "identifier": "use_secure_cookie",
+                "value": "0",
+                "type": "0",
+                "explain": "Use secure cookie, check this if you want to force SSL all the time",
+                "hidden": "0"
+            },
+            {
+                "identifier": "translation_data",
+                "value": "a:6:{i:0;b:0;s:19:\"translation_handler\";s:4:\"bing\";s:19:\"enable_translations\";b:0;s:14:\"bing_client_id\";s:0:\"\";s:18:\"bing_client_secret\";s:0:\"\";s:14:\"google_api_key\";s:0:\"\";}",
+                "type": "0",
+                "explain": "Translation data",
+                "hidden": "1"
+            },
+            {
+                "identifier": "voting_days_limit",
+                "value": "7",
+                "type": "0",
+                "explain": "How many days voting widget should not be expanded after last show",
+                "hidden": "0"
+            },
+            {
+                "identifier": "guardrails_enabled",
+                "value": "0",
+                "type": "0",
+                "explain": "Enable guardrails for operators and visitors",
+                "hidden": "1"
+            },
+            {
+                "identifier": "show_language_switcher",
+                "value": "0",
+                "type": "0",
+                "explain": "Show users option to switch language at widget",
+                "hidden": "0"
+            },
+            {
+                "identifier": "show_languages",
+                "value": "eng,lit,hrv,esp,por,nld,ara,ger,pol,rus,ita,fre,chn,cse,nor,tur,vnm,idn,sve,per,ell,dnk,rou,bgr,tha,geo,fin,alb",
+                "type": "0",
+                "explain": "Between what languages user should be able to switch",
+                "hidden": "0"
+            },
+            {
+                "identifier": "xmp_data",
+                "value": "a:14:{i:0;b:0;s:4:\"host\";s:15:\"talk.google.com\";s:6:\"server\";s:9:\"gmail.com\";s:8:\"resource\";s:6:\"xmpphp\";s:4:\"port\";s:4:\"5222\";s:7:\"use_xmp\";i:0;s:8:\"username\";s:0:\"\";s:8:\"password\";s:0:\"\";s:11:\"xmp_message\";s:78:\"New chat request [{chat_id}]\r\n{messages}\r\nClick to accept a chat\r\n{url_accept}\";s:10:\"recipients\";s:0:\"\";s:20:\"xmp_accepted_message\";s:69:\"{user_name} has accepted a chat [{chat_id}]\r\n{messages}\r\n{url_accept}\";s:16:\"use_standard_xmp\";i:0;s:15:\"test_recipients\";s:0:\"\";s:21:\"test_group_recipients\";s:0:\"\";}",
+                "type": "0",
+                "explain": "XMP data",
+                "hidden": "1"
+            },
+            {
+                "identifier": "geoadjustment_data",
+                "value": "a:8:{i:0;b:0;s:18:\"use_geo_adjustment\";b:0;s:13:\"available_for\";s:0:\"\";s:15:\"other_countries\";s:6:\"custom\";s:8:\"hide_for\";s:0:\"\";s:12:\"other_status\";s:7:\"offline\";s:11:\"rest_status\";s:6:\"hidden\";s:12:\"apply_widget\";i:0;}",
+                "type": "0",
+                "explain": "Geo adjustment settings",
+                "hidden": "1"
+            },
+            {
+                "identifier": "bbcode_options",
+                "value": "a:2:{s:3:\"div\";a:0:{}s:3:\"dio\";a:0:{}}",
+                "type": "0",
+                "explain": "",
+                "hidden": "1"
+            }
+        ],
+        "lh_speech_language_dialect": [
+            {
+                "id": "1",
+                "language_id": "1",
+                "lang_name": "Afrikaans",
+                "lang_code": "af-ZA"
+            },
+            {
+                "id": "2",
+                "language_id": "2",
+                "lang_name": "Bahasa Indonesia",
+                "lang_code": "id-ID"
+            },
+            {
+                "id": "3",
+                "language_id": "3",
+                "lang_name": "Bahasa Melayu",
+                "lang_code": "ms-MY"
+            },
+            {
+                "id": "4",
+                "language_id": "4",
+                "lang_name": "Català",
+                "lang_code": "ca-ES"
+            },
+            {
+                "id": "5",
+                "language_id": "5",
+                "lang_name": "Čeština",
+                "lang_code": "cs-CZ"
+            },
+            {
+                "id": "6",
+                "language_id": "6",
+                "lang_name": "Deutsch",
+                "lang_code": "de-DE"
+            },
+            {
+                "id": "7",
+                "language_id": "7",
+                "lang_name": "Australia",
+                "lang_code": "en-AU"
+            },
+            {
+                "id": "8",
+                "language_id": "7",
+                "lang_name": "Canada",
+                "lang_code": "en-CA"
+            },
+            {
+                "id": "9",
+                "language_id": "7",
+                "lang_name": "India",
+                "lang_code": "en-IN"
+            },
+            {
+                "id": "10",
+                "language_id": "7",
+                "lang_name": "New Zealand",
+                "lang_code": "en-NZ"
+            },
+            {
+                "id": "11",
+                "language_id": "7",
+                "lang_name": "South Africa",
+                "lang_code": "en-ZA"
+            },
+            {
+                "id": "12",
+                "language_id": "7",
+                "lang_name": "United Kingdom",
+                "lang_code": "en-GB"
+            },
+            {
+                "id": "13",
+                "language_id": "7",
+                "lang_name": "United States",
+                "lang_code": "en-US"
+            },
+            {
+                "id": "14",
+                "language_id": "8",
+                "lang_name": "Argentina",
+                "lang_code": "es-AR"
+            },
+            {
+                "id": "15",
+                "language_id": "8",
+                "lang_name": "Bolivia",
+                "lang_code": "es-BO"
+            },
+            {
+                "id": "16",
+                "language_id": "8",
+                "lang_name": "Chile",
+                "lang_code": "es-CL"
+            },
+            {
+                "id": "17",
+                "language_id": "8",
+                "lang_name": "Colombia",
+                "lang_code": "es-CO"
+            },
+            {
+                "id": "18",
+                "language_id": "8",
+                "lang_name": "Costa Rica",
+                "lang_code": "es-CR"
+            },
+            {
+                "id": "19",
+                "language_id": "8",
+                "lang_name": "Ecuador",
+                "lang_code": "es-EC"
+            },
+            {
+                "id": "20",
+                "language_id": "8",
+                "lang_name": "El Salvador",
+                "lang_code": "es-SV"
+            },
+            {
+                "id": "21",
+                "language_id": "8",
+                "lang_name": "España",
+                "lang_code": "es-ES"
+            },
+            {
+                "id": "22",
+                "language_id": "8",
+                "lang_name": "Estados Unidos",
+                "lang_code": "es-US"
+            },
+            {
+                "id": "23",
+                "language_id": "8",
+                "lang_name": "Guatemala",
+                "lang_code": "es-GT"
+            },
+            {
+                "id": "24",
+                "language_id": "8",
+                "lang_name": "Honduras",
+                "lang_code": "es-HN"
+            },
+            {
+                "id": "25",
+                "language_id": "8",
+                "lang_name": "México",
+                "lang_code": "es-MX"
+            },
+            {
+                "id": "26",
+                "language_id": "8",
+                "lang_name": "Nicaragua",
+                "lang_code": "es-NI"
+            },
+            {
+                "id": "27",
+                "language_id": "8",
+                "lang_name": "Panamá",
+                "lang_code": "es-PA"
+            },
+            {
+                "id": "28",
+                "language_id": "8",
+                "lang_name": "Paraguay",
+                "lang_code": "es-PY"
+            },
+            {
+                "id": "29",
+                "language_id": "8",
+                "lang_name": "Perú",
+                "lang_code": "es-PE"
+            },
+            {
+                "id": "30",
+                "language_id": "8",
+                "lang_name": "Puerto Rico",
+                "lang_code": "es-PR"
+            },
+            {
+                "id": "31",
+                "language_id": "8",
+                "lang_name": "República Dominicana",
+                "lang_code": "es-DO"
+            },
+            {
+                "id": "32",
+                "language_id": "8",
+                "lang_name": "Uruguay",
+                "lang_code": "es-UY"
+            },
+            {
+                "id": "33",
+                "language_id": "8",
+                "lang_name": "Venezuela",
+                "lang_code": "es-VE"
+            },
+            {
+                "id": "34",
+                "language_id": "9",
+                "lang_name": "Euskara",
+                "lang_code": "eu-ES"
+            },
+            {
+                "id": "35",
+                "language_id": "10",
+                "lang_name": "Français",
+                "lang_code": "fr-FR"
+            },
+            {
+                "id": "36",
+                "language_id": "11",
+                "lang_name": "Galego",
+                "lang_code": "gl-ES"
+            },
+            {
+                "id": "37",
+                "language_id": "12",
+                "lang_name": "Hrvatski",
+                "lang_code": "hr_HR"
+            },
+            {
+                "id": "38",
+                "language_id": "13",
+                "lang_name": "IsiZulu",
+                "lang_code": "zu-ZA"
+            },
+            {
+                "id": "39",
+                "language_id": "14",
+                "lang_name": "Íslenska",
+                "lang_code": "is-IS"
+            },
+            {
+                "id": "40",
+                "language_id": "15",
+                "lang_name": "Italia",
+                "lang_code": "it-IT"
+            },
+            {
+                "id": "41",
+                "language_id": "15",
+                "lang_name": "Svizzera",
+                "lang_code": "it-CH"
+            },
+            {
+                "id": "42",
+                "language_id": "16",
+                "lang_name": "Magyar",
+                "lang_code": "hu-HU"
+            },
+            {
+                "id": "43",
+                "language_id": "17",
+                "lang_name": "Nederlands",
+                "lang_code": "nl-NL"
+            },
+            {
+                "id": "44",
+                "language_id": "18",
+                "lang_name": "Norsk bokmål",
+                "lang_code": "nb-NO"
+            },
+            {
+                "id": "45",
+                "language_id": "19",
+                "lang_name": "Polski",
+                "lang_code": "pl-PL"
+            },
+            {
+                "id": "46",
+                "language_id": "20",
+                "lang_name": "Brasil",
+                "lang_code": "pt-BR"
+            },
+            {
+                "id": "47",
+                "language_id": "20",
+                "lang_name": "Portugal",
+                "lang_code": "pt-PT"
+            },
+            {
+                "id": "48",
+                "language_id": "21",
+                "lang_name": "Română",
+                "lang_code": "ro-RO"
+            },
+            {
+                "id": "49",
+                "language_id": "22",
+                "lang_name": "Slovenčina",
+                "lang_code": "sk-SK"
+            },
+            {
+                "id": "50",
+                "language_id": "23",
+                "lang_name": "Suomi",
+                "lang_code": "fi-FI"
+            },
+            {
+                "id": "51",
+                "language_id": "24",
+                "lang_name": "Svenska",
+                "lang_code": "sv-SE"
+            },
+            {
+                "id": "52",
+                "language_id": "25",
+                "lang_name": "Türkçe",
+                "lang_code": "tr-TR"
+            },
+            {
+                "id": "53",
+                "language_id": "26",
+                "lang_name": "български",
+                "lang_code": "bg-BG"
+            },
+            {
+                "id": "54",
+                "language_id": "27",
+                "lang_name": "Pусский",
+                "lang_code": "ru-RU"
+            },
+            {
+                "id": "55",
+                "language_id": "28",
+                "lang_name": "Српски",
+                "lang_code": "sr-RS"
+            },
+            {
+                "id": "56",
+                "language_id": "29",
+                "lang_name": "한국어",
+                "lang_code": "ko-KR"
+            },
+            {
+                "id": "57",
+                "language_id": "30",
+                "lang_name": "普通话 (中国大陆)",
+                "lang_code": "cmn-Hans-CN"
+            },
+            {
+                "id": "58",
+                "language_id": "30",
+                "lang_name": "普通话 (香港)",
+                "lang_code": "cmn-Hans-HK"
+            },
+            {
+                "id": "59",
+                "language_id": "30",
+                "lang_name": "中文 (台灣)",
+                "lang_code": "cmn-Hant-TW"
+            },
+            {
+                "id": "60",
+                "language_id": "30",
+                "lang_name": "粵語 (香港)",
+                "lang_code": "yue-Hant-HK"
+            },
+            {
+                "id": "61",
+                "language_id": "31",
+                "lang_name": "日本語",
+                "lang_code": "ja-JP"
+            },
+            {
+                "id": "62",
+                "language_id": "32",
+                "lang_name": "Lingua latīna",
+                "lang_code": "la"
+            }
+        ],
+        "lh_speech_language": [
+            {
+                "id": "1",
+                "name": "Afrikaans"
+            },
+            {
+                "id": "2",
+                "name": "Bahasa Indonesia"
+            },
+            {
+                "id": "3",
+                "name": "Bahasa Melayu"
+            },
+            {
+                "id": "4",
+                "name": "Català"
+            },
+            {
+                "id": "5",
+                "name": "Čeština"
+            },
+            {
+                "id": "6",
+                "name": "Deutsch"
+            },
+            {
+                "id": "7",
+                "name": "English"
+            },
+            {
+                "id": "8",
+                "name": "Español"
+            },
+            {
+                "id": "9",
+                "name": "Euskara"
+            },
+            {
+                "id": "10",
+                "name": "Français"
+            },
+            {
+                "id": "11",
+                "name": "Galego"
+            },
+            {
+                "id": "12",
+                "name": "Hrvatski"
+            },
+            {
+                "id": "13",
+                "name": "IsiZulu"
+            },
+            {
+                "id": "14",
+                "name": "Íslenska"
+            },
+            {
+                "id": "15",
+                "name": "Italiano"
+            },
+            {
+                "id": "16",
+                "name": "Magyar"
+            },
+            {
+                "id": "17",
+                "name": "Nederlands"
+            },
+            {
+                "id": "18",
+                "name": "Norsk bokmål"
+            },
+            {
+                "id": "19",
+                "name": "Polski"
+            },
+            {
+                "id": "20",
+                "name": "Português"
+            },
+            {
+                "id": "21",
+                "name": "Română"
+            },
+            {
+                "id": "22",
+                "name": "Slovenčina"
+            },
+            {
+                "id": "23",
+                "name": "Suomi"
+            },
+            {
+                "id": "24",
+                "name": "Svenska"
+            },
+            {
+                "id": "25",
+                "name": "Türkçe"
+            },
+            {
+                "id": "26",
+                "name": "български"
+            },
+            {
+                "id": "27",
+                "name": "Pусский"
+            },
+            {
+                "id": "28",
+                "name": "Српски"
+            },
+            {
+                "id": "29",
+                "name": "한국어"
+            },
+            {
+                "id": "30",
+                "name": "中文"
+            },
+            {
+                "id": "31",
+                "name": "日本語"
+            },
+            {
+                "id": "32",
+                "name": "Lingua latīna"
+            }
+        ],
+        "lh_abstract_email_template": [
+            {
+                "id": "1",
+                "name": "Send mail to user",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Dear {user_chat_nick},\r\n\r\n{additional_message}\r\n\r\nLive Support response:\r\n{messages_content}\r\n\r\nSincerely,\r\nLive Support Team\r\n",
+                "subject": "{name_surname} has responded to your request",
+                "bcc_recipients": "",
+                "subject_ac": "1",
+                "reply_to": "",
+                "reply_to_ac": "1",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "2",
+                "name": "Support request from user",
+                "from_name": "",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nLink to chat if any:\r\n{prefillchat}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Support request from user",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "3",
+                "name": "User mail for himself",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Dear {user_chat_nick},\r\n\r\nTranscript:\r\n{messages_content}\r\n\r\nSincerely,\r\nLive Support Team\r\n",
+                "subject": "Chat transcript",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "4",
+                "name": "New chat request",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "New chat request",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "5",
+                "name": "Chat was closed",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\n{operator} has closed a chat\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Chat was closed",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "6",
+                "name": "New FAQ question",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nNew FAQ question\r\nEmail: {email}\r\n\r\nQuestion:\r\n{question}\r\n\r\nQuestion URL:\r\n{url_question}\r\n\r\nURL to answer a question:\r\n{url_request}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "New FAQ question",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "7",
+                "name": "New unread message",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "New chat request",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "8",
+                "name": "Filled form",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nUser has filled a form\r\nForm name - {form_name}\r\nUser IP - {ip}\r\nDownload filled data - {url_download}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Filled form - {form_name}",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "9",
+                "name": "Chat was accepted",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nOperator {user_name} has accepted a chat [{chat_id}]\r\n\r\nUser request data:\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\n\r\nMessage:\r\n{message}\r\n\r\nURL of page from which user has send request:\r\n{url_request}\r\n\r\nClick to accept chat automatically\r\n{url_accept}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Chat was accepted [{chat_id}]",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "10",
+                "name": "Permission request",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nOperator {user} has requested these permissions\n\r\n{permissions}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Permission request from {user}",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "11",
+                "name": "You have unread messages",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nOperator {user} has requested these permissions\n\r\n{permissions}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Operator has answered to your request",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "12",
+                "name": "Visitor returned",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nVisitor information\r\nName: {name}\r\nEmail: {email}\r\nPhone: {phone}\r\nDepartment: {department}\r\nCountry: {country}\r\nCity: {city}\r\nIP: {ip}\r\nCreated:{created}\r\nUser left:{user_left}\r\nWaited:{waited}\r\nChat duration:{chat_duration}\r\n\r\nSee more information at\r\n{url_accept}\r\n\r\nLast chat:\r\n{message}\r\n\r\nAdditional data, if any:\r\n{additional_data}\r\n\r\nSincerely,\r\nLive Support Team",
+                "subject": "Visitor returned - {username}",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            },
+            {
+                "id": "13",
+                "name": "Report prepared",
+                "from_name": "Live Helper Chat",
+                "from_name_ac": "0",
+                "from_email": "",
+                "from_email_ac": "0",
+                "content": "Hello,\r\n\r\nReport prepared - {report_name}, {date_range}\r\n\r\n{report_description}\r\n\r\nView report at:\r\n{url_report}\r\nView directly: {url_report_direct}",
+                "subject": "Report prepared - {report_name}",
+                "bcc_recipients": "",
+                "subject_ac": "0",
+                "reply_to": "",
+                "reply_to_ac": "0",
+                "recipient": "",
+                "user_mail_as_sender": "0",
+                "translations": ""
+            }
+        ]
     },
-    "lhc_mailconv_match_rule" : {
-      "new": {
-        "active_priority": "ALTER TABLE `lhc_mailconv_match_rule` ADD INDEX `active_priority` (`active`, `priority`);"
-      },
-      "old": [
-      ]
+    "tables_data_identifier": {
+        "lh_users_setting_option": "identifier",
+        "lh_chat_config": "identifier",
+        "lh_abstract_email_template": "id",
+        "lh_speech_language": "id",
+        "lh_speech_language_dialect": "id"
     },
-    "lhc_mailconv_recipient" : {
-      "new": {
-        "email": "ALTER TABLE `lhc_mailconv_recipient` ADD INDEX `email` (`email`);"
-      },
-      "old": [
-      ]
+    "tables_alter": {
+        "lh_abstract_survey_item": {
+            "stars": {
+                "sql": "ALTER TABLE `lh_abstract_survey_item` CHANGE `stars` `max_stars_1` int(11) NOT NULL;",
+                "new": "max_stars_1"
+            }
+        },
+        "lh_abstract_survey": {
+            "max_stars": {
+                "sql": "ALTER TABLE `lh_abstract_survey` CHANGE `max_stars` `max_stars_1` int(11) NOT NULL;",
+                "new": "max_stars_1"
+            }
+        }
     },
-    "lhc_mailconv_mailing_campaign_recipient" : {
-      "new": {
-        "campaign_id_email": "ALTER TABLE `lhc_mailconv_mailing_campaign_recipient` ADD INDEX `campaign_id_email` (`campaign_id`, `email`);"
-      },
-      "old": [
-      ]
+    "tables_drop_column": {
+        "lh_departament": [
+            "start_hour",
+            "end_hour",
+            "mod",
+            "tud",
+            "wed",
+            "thd",
+            "frd",
+            "sad",
+            "sud",
+            "closed_chats_counter"
+        ],
+        "lh_chat": [
+            "wait_timeout",
+            "wait_timeout_send",
+            "timeout_message",
+            "wait_timeout_repeat"
+        ],
+        "lh_abstract_proactive_chat_invitation": [
+            "wait_message",
+            "wait_timeout",
+            "timeout_message",
+            "repeat_number"
+        ],
+        "lh_chat_online_user": [
+            "show_on_mobile"
+        ],
+        "lh_users": [
+            "active_chats_counter",
+            "closed_chats_counter",
+            "pending_chats_counter"
+        ]
     },
-    "lh_abstract_widget_theme" : {
-      "new" : {
-        "alias" : "ALTER TABLE `lh_abstract_widget_theme` ADD INDEX `alias` (`alias`);"
-      },
-      "old" : []
+    "tables_collation": {
+        "lh_abstract_auto_responder": "utf8mb4_unicode_ci",
+        "lh_abstract_auto_responder_chat": "utf8mb4_unicode_ci",
+        "lh_abstract_browse_offer_invitation": "utf8mb4_unicode_ci",
+        "lh_abstract_email_template": "utf8mb4_unicode_ci",
+        "lh_abstract_form": "utf8mb4_unicode_ci",
+        "lh_abstract_form_collected": "utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_event": "utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_invitation": "utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_invitation_event": "utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_variables": "utf8mb4_unicode_ci",
+        "lh_abstract_product": "utf8mb4_unicode_ci",
+        "lh_abstract_product_departament": "utf8mb4_unicode_ci",
+        "lh_abstract_rest_api_key": "utf8mb4_unicode_ci",
+        "lh_abstract_survey": "utf8mb4_unicode_ci",
+        "lh_abstract_survey_item": "utf8mb4_unicode_ci",
+        "lh_abstract_widget_theme": "utf8mb4_unicode_ci",
+        "lh_admin_theme": "utf8mb4_unicode_ci",
+        "lh_canned_msg": "utf8mb4_unicode_ci",
+        "lh_canned_msg_tag": "utf8mb4_unicode_ci",
+        "lh_canned_msg_tag_link": "utf8mb4_unicode_ci",
+        "lh_chat": "utf8mb4_unicode_ci",
+        "lh_chatbox": "utf8mb4_unicode_ci",
+        "lh_chat_accept": "utf8mb4_unicode_ci",
+        "lh_chat_archive_range": "utf8mb4_unicode_ci",
+        "lh_chat_blocked_user": "utf8mb4_unicode_ci",
+        "lh_chat_config": "utf8mb4_unicode_ci",
+        "lh_chat_file": "utf8mb4_unicode_ci",
+        "lh_chat_online_user": "utf8mb4_unicode_ci",
+        "lh_chat_online_user_footprint": "utf8mb4_unicode_ci",
+        "lh_chat_paid": "utf8mb4_unicode_ci",
+        "lh_chat_start_settings": "utf8mb4_unicode_ci",
+        "lh_cobrowse": "utf8mb4_unicode_ci",
+        "lh_departament": "utf8mb4_unicode_ci",
+        "lh_departament_custom_work_hours": "utf8mb4_unicode_ci",
+        "lh_departament_group": "utf8mb4_unicode_ci",
+        "lh_departament_group_member": "utf8mb4_unicode_ci",
+        "lh_departament_group_user": "utf8mb4_unicode_ci",
+        "lh_departament_limit_group": "utf8mb4_unicode_ci",
+        "lh_departament_limit_group_member": "utf8mb4_unicode_ci",
+        "lh_faq": "utf8mb4_unicode_ci",
+        "lh_forgotpasswordhash": "utf8mb4_unicode_ci",
+        "lh_group": "utf8mb4_unicode_ci",
+        "lh_grouprole": "utf8mb4_unicode_ci",
+        "lh_groupuser": "utf8mb4_unicode_ci",
+        "lh_group_work": "utf8mb4_unicode_ci",
+        "lh_msg": "utf8mb4_unicode_ci",
+        "lh_question": "utf8mb4_unicode_ci",
+        "lh_question_answer": "utf8mb4_unicode_ci",
+        "lh_question_option": "utf8mb4_unicode_ci",
+        "lh_question_option_answer": "utf8mb4_unicode_ci",
+        "lh_role": "utf8mb4_unicode_ci",
+        "lh_rolefunction": "utf8mb4_unicode_ci",
+        "lh_speech_chat_language": "utf8mb4_unicode_ci",
+        "lh_speech_language": "utf8mb4_unicode_ci",
+        "lh_speech_language_dialect": "utf8mb4_unicode_ci",
+        "lh_transfer": "utf8mb4_unicode_ci",
+        "lh_userdep": "utf8mb4_unicode_ci",
+        "lh_users": "utf8mb4_unicode_ci",
+        "lh_users_online_session": "utf8mb4_unicode_ci",
+        "lh_users_remember": "utf8mb4_unicode_ci",
+        "lh_users_session": "utf8mb4_unicode_ci",
+        "lh_users_setting": "utf8mb4_unicode_ci",
+        "lh_users_setting_option": "utf8mb4_unicode_ci",
+        "lh_abstract_offline_reason": "utf8mb4_unicode_ci"
     },
-    "lh_abstract_saved_search" : {
-      "new" : {
-        "user_id_status" : "ALTER TABLE `lh_abstract_saved_search` ADD INDEX `user_id_status` (`user_id`,`status`);"
-      },
-      "old" : [
-        "user_id"
-      ]
+    "tables_indexes": {
+        "lh_users_online_session": {
+            "new": {
+                "lactivity": "ALTER TABLE `lh_users_online_session` ADD INDEX `lactivity` (`lactivity`);",
+                "user_id_time": "ALTER TABLE `lh_users_online_session` ADD KEY `user_id_time` (`user_id`, `time`);"
+            },
+            "old": []
+        },
+        "lh_chat_incoming": {
+            "new": {
+                "incoming_ext_id_uniq": "ALTER TABLE `lh_chat_incoming` ADD UNIQUE `incoming_ext_id_uniq` (`incoming_id`, `chat_external_id`);"
+            },
+            "old": [
+                "incoming_ext_id"
+            ]
+        },
+        "lh_notification_subscriber": {
+            "new": {
+                "subscriber_hash": "ALTER TABLE `lh_notification_subscriber` ADD INDEX `subscriber_hash` (`subscriber_hash`);"
+            },
+            "old": []
+        },
+        "lh_canned_msg_use": {
+            "new": {
+                "chat_id": "ALTER TABLE `lh_canned_msg_use` ADD INDEX `chat_id` (`chat_id`);"
+            },
+            "old": []
+        },
+        "lh_grouprole": {
+            "new": {
+                "group_id_primary": "ALTER TABLE `lh_grouprole` ADD INDEX `group_id_primary` (`group_id`);"
+            },
+            "old": []
+        },
+        "lh_users_session": {
+            "new": {
+                "device_token_device_type_v2": "ALTER TABLE `lh_users_session` ADD INDEX `device_token_device_type_v2` (`device_token`(191),`device_type`);",
+                "error": "ALTER TABLE `lh_users_session` ADD INDEX `error` (`error`);"
+            },
+            "old": [
+                "device_token_device_type"
+            ]
+        },
+        "lh_departament_group_member": {
+            "new": {
+                "dep_group_id_dep_id": "DELETE t1 FROM `lh_departament_group_member` t1 INNER JOIN `lh_departament_group_member` t2 ON t1.`dep_group_id` = t2.`dep_group_id` AND t1.`dep_id` = t2.`dep_id` WHERE t1.id > t2.id; ALTER TABLE `lh_departament_group_member` ADD UNIQUE `dep_group_id_dep_id` (`dep_group_id`, `dep_id`);"
+            },
+            "old": [
+                "dep_group_id"
+            ]
+        },
+        "lh_chat_blocked_user": {
+            "new": {
+                "nick": "ALTER TABLE `lh_chat_blocked_user` ADD INDEX `nick` (`nick`);",
+                "online_user_id": "ALTER TABLE `lh_chat_blocked_user` ADD INDEX `online_user_id` (`online_user_id`);"
+            },
+            "old": []
+        },
+        "lh_faq": {
+            "new": {
+                "active_url_2": "ALTER TABLE `lh_faq` ADD INDEX `active_url_2` (`active`,`url`(191));"
+            },
+            "old": [
+                "active_url"
+            ]
+        },
+        "lh_userdep": {
+            "new": {
+                "user_id_type": "ALTER TABLE `lh_userdep` ADD INDEX `user_id_type` (`user_id`, `type`);",
+                "online_op_widget_2": "ALTER TABLE `lh_userdep` ADD INDEX `online_op_widget_2` (`dep_id`, `last_activity`, `user_id`);",
+                "online_op_widget_3": "ALTER TABLE `lh_userdep` ADD INDEX `online_op_widget_3` (`user_id`, `active_chats`);"
+            },
+            "old": [
+                "user_id",
+                "online_op_widget"
+            ]
+        },
+        "lh_chat_online_user_footprint": {
+            "new": {
+                "chat_id": "ALTER TABLE `lh_chat_online_user_footprint` ADD INDEX `chat_id` (`chat_id`);"
+            },
+            "old": [
+                "chat_id_vtime"
+            ]
+        },
+        "lh_chat_online_user": {
+            "new": {
+                "first_visit": "ALTER TABLE `lh_chat_online_user` ADD INDEX `first_visit` (`first_visit`);"
+            },
+            "old": []
+        },
+        "lh_group": {
+            "new": {
+                "disabled": "ALTER TABLE `lh_group` ADD INDEX `disabled` (`disabled`);"
+            },
+            "old": []
+        },
+        "lh_chat": {
+            "new": {
+                "nick": "ALTER TABLE `lh_chat` ADD INDEX `nick` (`nick`);",
+                "time": "ALTER TABLE `lh_chat` ADD INDEX `time` (`time`);",
+                "iwh_id": "ALTER TABLE `lh_chat` ADD INDEX `iwh_id` (`iwh_id`);",
+                "theme_id": "ALTER TABLE `lh_chat` ADD INDEX `theme_id` (`theme_id`);",
+                "email": "ALTER TABLE `lh_chat` ADD INDEX `email` (`email`);",
+                "phone": "ALTER TABLE `lh_chat` ADD INDEX `phone` (`phone`);",
+                "unanswered_chat": "ALTER TABLE `lh_chat` ADD INDEX `unanswered_chat` (`unanswered_chat`);",
+                "product_id": "ALTER TABLE `lh_chat` ADD INDEX `product_id` (`product_id`);",
+                "dep_id": "ALTER TABLE `lh_chat` ADD INDEX `dep_id` (`dep_id`);",
+                "unread_operator": "ALTER TABLE `lh_chat` ADD INDEX `unread_operator` (`has_unread_op_messages`, `unread_op_messages_informed`);",
+                "online_user_id": "ALTER TABLE `lh_chat` ADD INDEX `online_user_id` (`online_user_id`);",
+                "user_id_sender_user_id": "ALTER TABLE `lh_chat` ADD INDEX `user_id_sender_user_id` (`user_id`, `sender_user_id`);",
+                "sender_user_id": "ALTER TABLE `lh_chat` ADD INDEX `sender_user_id` (`sender_user_id`);",
+                "anonymized": "ALTER TABLE `lh_chat` ADD INDEX `anonymized` (`anonymized`);",
+                "has_unread_messages": "ALTER TABLE `lh_chat` ADD INDEX `has_unread_messages` (`has_unread_messages`);",
+                "dep_id_status": "ALTER TABLE `lh_chat` ADD INDEX `dep_id_status` (`dep_id`,`status`);",
+                "status": "ALTER TABLE `lh_chat` ADD INDEX `status` (`status`);",
+                "status_user_id": "ALTER TABLE `lh_chat` ADD INDEX `status_user_id` (`status`,`user_id`);"
+            },
+            "old": [
+                "user_id",
+                "status_dep_id_id",
+                "status_dep_id_priority_id",
+                "status_priority_id",
+                "has_unread_messages_dep_id_id"
+            ]
+        },
+        "lh_users": {
+            "new": {
+                "rec_per_req": "ALTER TABLE `lh_users` ADD INDEX `rec_per_req` (`rec_per_req`);",
+                "disabled": "ALTER TABLE `lh_users` ADD INDEX `disabled` (`disabled`);",
+                "username": "ALTER TABLE `lh_users` ADD INDEX `username` (`username`);"
+            },
+            "old": []
+        },
+        "lh_generic_bot_trigger": {
+            "new": {
+                "default_always": "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `default_always` (`default_always`);",
+                "default_unknown_btn": "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `default_unknown_btn` (`default_unknown_btn`);",
+                "in_progress": "ALTER TABLE `lh_generic_bot_trigger` ADD INDEX `in_progress` (`in_progress`);"
+            },
+            "old": []
+        },
+        "lh_cobrowse": {
+            "new": {
+                "online_user_id": "ALTER TABLE `lh_cobrowse` ADD INDEX `online_user_id` (`online_user_id`);"
+            },
+            "old": []
+        },
+        "lh_chat_file": {
+            "new": {
+                "online_user_id": "ALTER TABLE `lh_chat_file` ADD INDEX `online_user_id` (`online_user_id`)"
+            },
+            "old": []
+        },
+        "lh_speech_language_dialect": {
+            "new": {
+                "short_code": "ALTER TABLE `lh_speech_language_dialect` ADD INDEX `short_code` (`short_code`);",
+                "lang_code": "ALTER TABLE `lh_speech_language_dialect` ADD INDEX `lang_code` (`lang_code`);"
+            },
+            "old": []
+        },
+        "lh_abstract_chat_column": {
+            "new": {
+                "online_enabled": "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `online_enabled` (`online_enabled`);",
+                "chat_enabled": "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `chat_enabled` (`chat_enabled`);",
+                "chat_window_enabled": "ALTER TABLE `lh_abstract_chat_column` ADD INDEX `chat_window_enabled` (`chat_window_enabled`);"
+            },
+            "old": []
+        },
+        "lh_abstract_subject": {
+            "new": {
+                "internal": "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal` (`internal`);",
+                "internal_type": "ALTER TABLE `lh_abstract_subject` ADD INDEX `internal_type` (`internal_type`);",
+                "archive": "ALTER TABLE `lh_abstract_subject` ADD INDEX `archive` (`archive`);"
+            },
+            "old": []
+        },
+        "lh_departament": {
+            "new": {
+                "alias": "ALTER TABLE `lh_departament` ADD INDEX `alias` (`alias`);",
+                "attr_int_1": "ALTER TABLE `lh_departament` ADD INDEX `attr_int_1` (`attr_int_1`);",
+                "attr_int_2": "ALTER TABLE `lh_departament` ADD INDEX `attr_int_2` (`attr_int_2`);",
+                "attr_int_3": "ALTER TABLE `lh_departament` ADD INDEX `attr_int_3` (`attr_int_3`);",
+                "sort_priority_name": "ALTER TABLE `lh_departament` ADD INDEX `sort_priority_name` (`sort_priority`,`name`);",
+                "active_mod": "ALTER TABLE `lh_departament` ADD INDEX `active_mod` (`online_hours_active`,`mod_start_hour`,`mod_end_hour`);",
+                "active_tud": "ALTER TABLE `lh_departament` ADD INDEX `active_tud` (`online_hours_active`,`tud_start_hour`,`tud_end_hour`);",
+                "active_wed": "ALTER TABLE `lh_departament` ADD INDEX `active_wed` (`online_hours_active`,`wed_start_hour`,`wed_end_hour`);",
+                "active_thd": "ALTER TABLE `lh_departament` ADD INDEX `active_thd` (`online_hours_active`,`thd_start_hour`,`thd_end_hour`);",
+                "active_frd": "ALTER TABLE `lh_departament` ADD INDEX `active_frd` (`online_hours_active`,`frd_start_hour`,`frd_end_hour`);",
+                "active_sad": "ALTER TABLE `lh_departament` ADD INDEX `active_sad` (`online_hours_active`,`sad_start_hour`,`sad_end_hour`);",
+                "active_sud": "ALTER TABLE `lh_departament` ADD INDEX `active_sud` (`online_hours_active`,`sud_start_hour`,`sud_end_hour`);",
+                "active_chats_counter": "ALTER TABLE `lh_departament` ADD INDEX `active_chats_counter` (`active_chats_counter`);",
+                "pending_chats_counter": "ALTER TABLE `lh_departament` ADD INDEX `pending_chats_counter` (`pending_chats_counter`);",
+                "bot_chats_counter": "ALTER TABLE `lh_departament` ADD INDEX `bot_chats_counter` (`bot_chats_counter`);",
+                "archive": "ALTER TABLE `lh_departament` ADD INDEX `archive` (`archive`);",
+                "identifier_2": "ALTER TABLE `lh_departament` ADD INDEX `identifier_2` (`identifier`(191));",
+                "ignore_op_status": "ALTER TABLE `lh_departament` ADD INDEX `ignore_op_status` (`ignore_op_status`);",
+                "dep_offline": "ALTER TABLE `lh_departament` ADD INDEX `dep_offline` (`dep_offline`);"
+            },
+            "old": [
+                "oha_sh_eh",
+                "identifier"
+            ]
+        },
+        "lh_generic_bot_trigger_event": {
+            "new": {
+                "pattern_v2": "ALTER TABLE `lh_generic_bot_trigger_event` ADD INDEX `pattern_v2` (`pattern`(191));",
+                "on_start_type": "ALTER TABLE `lh_generic_bot_trigger_event` ADD INDEX `on_start_type` (`on_start_type`);"
+            },
+            "old": [
+                "pattern"
+            ]
+        },
+        "lh_canned_msg": {
+            "new": {
+                "attr_int_1": "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_1` (`attr_int_1`);",
+                "attr_int_2": "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_2` (`attr_int_2`);",
+                "attr_int_3": "ALTER TABLE `lh_canned_msg` ADD INDEX `attr_int_3` (`attr_int_3`);",
+                "disabled": "ALTER TABLE `lh_canned_msg` ADD INDEX `disabled` (`disabled`);",
+                "unique_id": "ALTER TABLE `lh_canned_msg` ADD INDEX `unique_id` (`unique_id`);",
+                "repetitiveness": "ALTER TABLE `lh_canned_msg` ADD INDEX `repetitiveness` (`repetitiveness`);",
+                "position_title_v2": "ALTER TABLE `lh_canned_msg` ADD INDEX `position_title_v2` (`position`, `title`(191));",
+                "delete_on_exp": "ALTER TABLE `lh_canned_msg` ADD INDEX `delete_on_exp` (`delete_on_exp`);"
+            },
+            "old": [
+                "position_title"
+            ]
+        },
+        "lh_departament_custom_work_hours": {
+            "new": {
+                "repetitiveness": "ALTER TABLE `lh_departament_custom_work_hours` ADD INDEX `repetitiveness` (`repetitiveness`);"
+            },
+            "old": []
+        },
+        "lhc_mailconv_response_template": {
+            "new": {
+                "unique_id": "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `unique_id` (`unique_id`);",
+                "disabled": "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `disabled` (`disabled`);",
+                "dep_id": "ALTER TABLE `lhc_mailconv_response_template` ADD INDEX `dep_id` (`dep_id`);"
+            },
+            "old": []
+        },
+        "lh_msg": {
+            "new": {
+                "user_id": "ALTER TABLE `lh_msg` ADD INDEX `user_id` (`user_id`);"
+            },
+            "old": []
+        },
+        "lh_abstract_form_collected": {
+            "new": {
+                "form_id_chat_id": "ALTER TABLE `lh_abstract_form_collected` ADD INDEX `form_id_chat_id` (`form_id`, `chat_id`);",
+                "chat_id": "ALTER TABLE `lh_abstract_form_collected` ADD INDEX `chat_id` (`chat_id`);"
+            },
+            "old": [
+                "form_id"
+            ]
+        },
+        "lh_abstract_survey_item": {
+            "new": {
+                "ftime": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `ftime` (`ftime`);",
+                "max_stars_1": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_1` (`max_stars_1`);",
+                "max_stars_2": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_2` (`max_stars_2`);",
+                "max_stars_3": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_3` (`max_stars_3`);",
+                "max_stars_4": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_4` (`max_stars_4`);",
+                "max_stars_5": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `max_stars_5` (`max_stars_5`);",
+                "question_options_1": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_1` (`question_options_1`);",
+                "question_options_2": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_2` (`question_options_2`);",
+                "question_options_3": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_3` (`question_options_3`);",
+                "question_options_4": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_4` (`question_options_4`);",
+                "question_options_5": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `question_options_5` (`question_options_5`);",
+                "online_user_id": "ALTER TABLE `lh_abstract_survey_item` ADD INDEX `online_user_id` (`online_user_id`);"
+            },
+            "old": []
+        },
+        "lh_abstract_survey": {
+            "new": {
+                "identifier": "ALTER TABLE `lh_abstract_survey` ADD INDEX `identifier` (`identifier`);"
+            },
+            "old": []
+        },
+        "lh_abstract_proactive_chat_invitation": {
+            "new": {
+                "tag": "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `tag` (`tag`);",
+                "dynamic_invitation": "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `dynamic_invitation` (`dynamic_invitation`);",
+                "show_on_mobile": "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `show_on_mobile` (`show_on_mobile`)",
+                "parent_id": "ALTER TABLE `lh_abstract_proactive_chat_invitation` ADD INDEX `parent_id` (`parent_id`)"
+            },
+            "old": []
+        },
+        "lh_abstract_proactive_chat_campaign_conv": {
+            "new": {
+                "ctime": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `ctime` (`ctime`);",
+                "invitation_id_variation_id": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `invitation_id_variation_id` (`invitation_id`, `variation_id`);",
+                "conv_event_vid_id": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `conv_event_vid_id` (`conv_event`, `vid_id`);",
+                "unique_id": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `unique_id` (`unique_id`);",
+                "conv_int_time": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `conv_int_time` (`conv_int_time`);",
+                "inv_vid": "ALTER TABLE `lh_abstract_proactive_chat_campaign_conv` ADD INDEX `inv_vid` (`invitation_id`,`invitation_status`,`vid_id`);"
+            },
+            "old": [
+                "invitation_id"
+            ]
+        },
+        "lh_group_chat": {
+            "new": {
+                "chat_id": "ALTER TABLE `lh_group_chat` ADD INDEX `chat_id` (`chat_id`);"
+            },
+            "old": []
+        },
+        "lh_group_chat_member": {
+            "new": {
+                "type": "ALTER TABLE `lh_group_chat_member` ADD INDEX `type` (`type`);"
+            },
+            "old": []
+        },
+        "lh_admin_theme": {
+            "new": {
+                "user_id": "ALTER TABLE `lh_admin_theme` ADD INDEX `user_id` (`user_id`);"
+            },
+            "old": []
+        },
+        "lh_transfer": {
+            "new": {
+                "chat_id_transfer": "ALTER TABLE `lh_transfer` ADD INDEX `chat_id_transfer` (`chat_id`,`transfer_scope`);"
+            },
+            "old": []
+        },
+        "lh_abstract_auto_responder": {
+            "new": {
+                "disabled": "ALTER TABLE `lh_abstract_auto_responder` ADD INDEX `disabled` (`disabled`);"
+            },
+            "old": []
+        },
+        "lhc_mailconv_conversation": {
+            "new": {
+                "from_address": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `from_address` (`from_address`);",
+                "from_address_clean": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `from_address_clean` (`from_address_clean`);",
+                "mailbox_id": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `mailbox_id` (`mailbox_id`);",
+                "dep_id": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `dep_id` (`dep_id`);",
+                "status_priority": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_priority` (`status`, `priority`);",
+                "status_priority_asc": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_priority_asc` (`status`, `priority_asc`);",
+                "has_attachment": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `has_attachment` (`has_attachment`);",
+                "udate": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `udate` (`udate`);",
+                "user_id_status": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `user_id_status` (`user_id`, `status`);",
+                "status_dep_id": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `status_dep_id` (`status`, `dep_id`);",
+                "undelivered": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `undelivered` (`undelivered`);",
+                "lang": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `lang` (`lang`);",
+                "phone": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `phone` (`phone`);",
+                "mailbox_id_status_udate": "ALTER TABLE `lhc_mailconv_conversation` ADD INDEX `mailbox_id_status_udate` (`mailbox_id`,`status`,`udate`);"
+            },
+            "old": [
+                "status",
+                "user_id"
+            ]
+        },
+        "lhc_mailconv_msg": {
+            "new": {
+                "has_attachment": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `has_attachment` (`has_attachment`);",
+                "udate": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `udate` (`udate`);",
+                "dep_id": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `dep_id` (`dep_id`);",
+                "mailbox_id": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `mailbox_id` (`mailbox_id`);",
+                "conversation_id": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `conversation_id` (`conversation_id`);",
+                "conversation_id_old": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `conversation_id_old` (`conversation_id_old`);",
+                "lang": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `lang` (`lang`);",
+                "message_hash": "ALTER TABLE `lhc_mailconv_msg` ADD INDEX `message_hash` (`message_hash`);"
+            },
+            "old": []
+        },
+        "lhc_mailconv_mailing_campaign_recipient": {
+            "new": {
+                "campaign_id_email": "ALTER TABLE `lhc_mailconv_mailing_campaign_recipient` ADD INDEX `campaign_id_email` (`campaign_id`, `email`);"
+            },
+            "old": []
+        },
+        "lh_abstract_msg_protection": {
+            "new": {
+                "enabled_type": "ALTER TABLE `lh_abstract_msg_protection` ADD INDEX `enabled_type` (`enabled`,`rule_type`);"
+            },
+            "old": [
+                "enabled"
+            ]
+        },
+        "lhc_mailconv_file": {
+            "new": {
+                "message_id": "ALTER TABLE `lhc_mailconv_file` ADD INDEX `message_id` (`message_id`);",
+                "conversation_id": "ALTER TABLE `lhc_mailconv_file` ADD INDEX `conversation_id` (`conversation_id`);"
+            },
+            "old": []
+        },
+        "lhc_mailconv_match_rule": {
+            "new": {
+                "active_priority": "ALTER TABLE `lhc_mailconv_match_rule` ADD INDEX `active_priority` (`active`, `priority`);"
+            },
+            "old": []
+        },
+        "lhc_mailconv_recipient": {
+            "new": {
+                "email": "ALTER TABLE `lhc_mailconv_recipient` ADD INDEX `email` (`email`);"
+            },
+            "old": []
+        },
+        "lh_abstract_widget_theme": {
+            "new": {
+                "alias": "ALTER TABLE `lh_abstract_widget_theme` ADD INDEX `alias` (`alias`);"
+            },
+            "old": []
+        },
+        "lh_abstract_saved_search": {
+            "new": {
+                "user_id_status": "ALTER TABLE `lh_abstract_saved_search` ADD INDEX `user_id_status` (`user_id`,`status`);"
+            },
+            "old": [
+                "user_id"
+            ]
+        },
+        "lh_audits": {
+            "new": {
+                "time": "ALTER TABLE `lh_audits` ADD INDEX `time` (`time`);",
+                "user_id": "ALTER TABLE `lh_audits` ADD INDEX `user_id` (`user_id`);"
+            },
+            "old": []
+        },
+        "lh_abstract_performance": {
+            "new": {
+                "created_at": "ALTER TABLE `lh_abstract_performance` ADD INDEX `created_at` (`created_at`);"
+            },
+            "old": []
+        }
     },
-    "lh_audits" : {
-      "new" : {
-        "time" : "ALTER TABLE `lh_audits` ADD INDEX `time` (`time`);",
-        "user_id" : "ALTER TABLE `lh_audits` ADD INDEX `user_id` (`user_id`);"
-      },
-      "old" : [
-
-      ]
+    "version_updates": {
+        "328": [
+            "INSERT IGNORE INTO `lh_userdep_disabled` SELECT * FROM `lh_userdep` WHERE `lh_userdep`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
+            "DELETE FROM `lh_userdep` WHERE `lh_userdep`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
+            "INSERT IGNORE INTO `lh_departament_group_user_disabled` SELECT * FROM `lh_departament_group_user` WHERE `lh_departament_group_user`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
+            "DELETE FROM `lh_departament_group_user` WHERE `lh_departament_group_user`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);"
+        ],
+        "333": [
+            "UPDATE `lh_abstract_chat_variable` SET `case_insensitive` = 1 WHERE `type` = 4;",
+            "UPDATE `lh_abstract_chat_variable` SET `type` = 0 WHERE `type` = 4;"
+        ]
     },
-    "lh_abstract_performance" : {
-      "new" : {
-        "created_at" : "ALTER TABLE `lh_abstract_performance` ADD INDEX `created_at` (`created_at`);"
-      },
-      "old" : [
-
-      ]
+    "tables_create": {
+        "lh_abstract_product_departament": "CREATE TABLE `lh_abstract_product_departament` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `product_id` int(11) NOT NULL,  `departament_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `departament_id` (`departament_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_admin_theme": "CREATE TABLE `lh_admin_theme` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `static_content` longtext NOT NULL, `static_js_content` longtext NOT NULL, `user_id` int(11) NOT NULL, `static_css_content` longtext NOT NULL, `header_content` text NOT NULL, `header_css` text NOT NULL, PRIMARY KEY (`id`),  KEY `user_id` (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_product": "CREATE TABLE `lh_abstract_product` (`id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `priority` int(11) NOT NULL, `departament_id` int(11) NOT NULL, `disabled` int(11) NOT NULL, KEY `departament_id` (`departament_id`), PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_survey": "CREATE TABLE `lh_abstract_survey` (`id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(250) NOT NULL,`max_stars_1_title` varchar(250) NOT NULL,`max_stars_1_pos` int(11) NOT NULL,`max_stars_2_title` varchar(250) NOT NULL,`max_stars_2_pos` int(11) NOT NULL,`max_stars_2` int(11) NOT NULL,`max_stars_3_title` varchar(250) NOT NULL,`max_stars_3_pos` int(11) NOT NULL,`max_stars_3` int(11) NOT NULL,`max_stars_4_title` varchar(250) NOT NULL,`max_stars_4_pos` int(11) NOT NULL,`max_stars_4` int(11) NOT NULL,`max_stars_5_title` varchar(250) NOT NULL,`max_stars_5_pos` int(11) NOT NULL,`max_stars_5` int(11) NOT NULL,`question_options_1` varchar(250) NOT NULL,`question_options_1_items` text NOT NULL,`question_options_1_pos` int(11) NOT NULL,`question_options_2` varchar(250) NOT NULL,`question_options_2_items` text NOT NULL,`question_options_2_pos` int(11) NOT NULL,`question_options_3` varchar(250) NOT NULL,`question_options_3_items` text NOT NULL,`question_options_3_pos` int(11) NOT NULL,`question_options_4` varchar(250) NOT NULL,`question_options_4_items` text NOT NULL,`question_options_4_pos` int(11) NOT NULL,`question_options_5` varchar(250) NOT NULL,`question_options_5_items` text NOT NULL,`question_options_5_pos` int(11) NOT NULL,`question_plain_1` text NOT NULL,`question_plain_1_pos` int(11) NOT NULL,`question_plain_2` text NOT NULL,`question_plain_2_pos` int(11) NOT NULL,`question_plain_3` text NOT NULL,`question_plain_3_pos` int(11) NOT NULL,`question_plain_4` text NOT NULL,`question_plain_4_pos` int(11) NOT NULL,`question_plain_5` text NOT NULL,`question_plain_5_pos` int(11) NOT NULL,`max_stars_1_enabled` int(11) NOT NULL, `max_stars_2_enabled` int(11) NOT NULL,  `max_stars_3_enabled` int(11) NOT NULL,  `max_stars_4_enabled` int(11) NOT NULL,  `max_stars_5_enabled` int(11) NOT NULL,  `question_options_1_enabled` int(11) NOT NULL,  `question_options_2_enabled` int(11) NOT NULL,  `question_options_3_enabled` int(11) NOT NULL,  `question_options_4_enabled` int(11) NOT NULL,  `question_options_5_enabled` int(11) NOT NULL,  `question_plain_1_enabled` int(11) NOT NULL,  `question_plain_2_enabled` int(11) NOT NULL,  `question_plain_3_enabled` int(11) NOT NULL,  `question_plain_4_enabled` int(11) NOT NULL,  `question_plain_5_enabled` int(11) NOT NULL,  `max_stars_1` int(11) NOT NULL,  `max_stars_1_req` int(11) NOT NULL,  `max_stars_2_req` int(11) NOT NULL,  `max_stars_3_req` int(11) NOT NULL,  `max_stars_4_req` int(11) NOT NULL,  `max_stars_5_req` int(11) NOT NULL,  `question_options_1_req` int(11) NOT NULL,  `question_options_2_req` int(11) NOT NULL,  `question_options_3_req` int(11) NOT NULL,  `question_options_4_req` int(11) NOT NULL,  `question_options_5_req` int(11) NOT NULL,  `question_plain_1_req` int(11) NOT NULL,  `question_plain_2_req` int(11) NOT NULL,  `question_plain_3_req` int(11) NOT NULL,`question_plain_4_req` int(11) NOT NULL,`question_plain_5_req` int(11) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_survey_item": "CREATE TABLE `lh_abstract_survey_item` (  `id` bigint(20) NOT NULL AUTO_INCREMENT,  `survey_id` int(11) NOT NULL,  `chat_id` int(11) NOT NULL,  `user_id` int(11) NOT NULL,  `ftime` int(11) NOT NULL,  `dep_id` int(11) NOT NULL,  `max_stars_1` int(11) NOT NULL,  `max_stars_2` int(11) NOT NULL,  `max_stars_3` int(11) NOT NULL,  `max_stars_4` int(11) NOT NULL,  `max_stars_5` int(11) NOT NULL,  `question_options_1` int(11) NOT NULL,  `question_options_2` int(11) NOT NULL,  `question_options_3` int(11) NOT NULL,  `question_options_4` int(11) NOT NULL,  `question_options_5` int(11) NOT NULL,  `question_plain_1` text NOT NULL,  `question_plain_2` text NOT NULL,  `question_plain_3` text NOT NULL,  `question_plain_4` text NOT NULL,  `question_plain_5` text NOT NULL,  PRIMARY KEY (`id`),  KEY `survey_id` (`survey_id`),  KEY `chat_id` (`chat_id`),  KEY `user_id` (`user_id`),  KEY `dep_id` (`dep_id`),  KEY `ftime` (`ftime`),  KEY `max_stars_1` (`max_stars_1`),  KEY `max_stars_2` (`max_stars_2`),  KEY `max_stars_3` (`max_stars_3`),  KEY `max_stars_4` (`max_stars_4`),  KEY `max_stars_5` (`max_stars_5`),  KEY `question_options_1` (`question_options_1`),  KEY `question_options_2` (`question_options_2`),  KEY `question_options_3` (`question_options_3`),  KEY `question_options_4` (`question_options_4`),  KEY `question_options_5` (`question_options_5`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_speech_language": "CREATE TABLE IF NOT EXISTS `lh_speech_language` ( `id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(100) NOT NULL,PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_speech_language_dialect": "CREATE TABLE IF NOT EXISTS `lh_speech_language_dialect` (`id` int(11) NOT NULL AUTO_INCREMENT,`language_id` int(11) NOT NULL, `lang_name` varchar(100) NOT NULL,`lang_code` varchar(100) NOT NULL, PRIMARY KEY (`id`),KEY `language_id` (`language_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_speech_chat_language": "CREATE TABLE IF NOT EXISTS `lh_speech_chat_language` (`id` int(11) NOT NULL AUTO_INCREMENT, `chat_id` int(11) NOT NULL, `language_id` int(11) NOT NULL, `dialect` varchar(50) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_auto_responder": "CREATE TABLE `lh_abstract_auto_responder` (  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(3) NOT NULL,\n  `wait_message` text NOT NULL,`disabled` tinyint(1) NOT NULL DEFAULT '0',\n  `wait_timeout` int(11) NOT NULL,\n  `position` int(11) NOT NULL,\n  `timeout_message` text NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `siteaccess_position` (`siteaccess`,`position`), KEY `disabled` (`disabled`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_auto_responder_chat": "CREATE TABLE `lh_abstract_auto_responder_chat` ( `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `auto_responder_id` int(11) NOT NULL,\n  `wait_timeout_send` int(11) NOT NULL,`pending_send_status` int(11) NOT NULL, `active_send_status` int(11) NOT NULL, \n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_browse_offer_invitation": "CREATE TABLE `lh_abstract_browse_offer_invitation` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(10) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `content` longtext NOT NULL,\n  `callback_content` longtext NOT NULL,\n  `lhc_iframe_content` tinyint(4) NOT NULL,\n  `custom_iframe_url` varchar(250) NOT NULL,\n  `name` varchar(250) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `executed_times` int(11) NOT NULL,\n  `url` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `has_url` int(11) NOT NULL,\n  `is_wildcard` int(11) NOT NULL,\n  `referrer` varchar(250) NOT NULL,\n  `priority` varchar(250) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `width` int(11) NOT NULL,\n  `height` int(11) NOT NULL,\n  `unit` varchar(10) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`),\n  KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_email_template": "CREATE TABLE `lh_abstract_email_template` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) NOT NULL,\n  `from_name` varchar(150) NOT NULL,\n  `from_name_ac` tinyint(4) NOT NULL,\n  `from_email` varchar(150) NOT NULL,\n  `from_email_ac` tinyint(4) NOT NULL,\n  `content` text NOT NULL,\n  `subject` varchar(250) NOT NULL,\n  `bcc_recipients` varchar(200) NOT NULL,\n  `subject_ac` tinyint(4) NOT NULL,\n  `reply_to` varchar(150) NOT NULL,\n  `reply_to_ac` tinyint(4) NOT NULL,\n  `recipient` varchar(150) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_form": "CREATE TABLE `lh_abstract_form` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(100) NOT NULL,\n  `configuration` longtext NOT NULL, `content` longtext NOT NULL,\n  `recipient` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `name_attr` varchar(250) NOT NULL,\n  `intro_attr` varchar(400) NOT NULL,\n  `xls_columns` text NOT NULL,\n  `pagelayout` varchar(200) NOT NULL,\n  `post_content` text NOT NULL,\n  `form_type` tinyint(1) NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_form_collected": "CREATE TABLE IF NOT EXISTS `lh_abstract_form_collected` (`id` int(11) NOT NULL AUTO_INCREMENT,`form_id` int(11) NOT NULL,`ctime` int(11) NOT NULL,`ip` varchar(250) NOT NULL,`identifier` varchar(250) NOT NULL,`chat_id` bigint(20) NOT NULL,`content` longtext NOT NULL,`custom_fields` longtext NOT NULL,`user_id` bigint(20) NOT NULL DEFAULT 0,`attr_int_1` int(11) NOT NULL DEFAULT 0,`attr_int_2` int(11) NOT NULL DEFAULT 0, `attr_int_3` int(11) NOT NULL DEFAULT 0,PRIMARY KEY (`id`),KEY `form_id_chat_id` (`form_id`,`chat_id`),KEY `chat_id` (`chat_id`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_proactive_chat_invitation": "CREATE TABLE `lh_abstract_proactive_chat_invitation` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(10) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `pageviews` int(11) NOT NULL,\n  `message` text NOT NULL,\n  `executed_times` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `hide_after_ntimes` int(11) NOT NULL,\n  `name` varchar(50) NOT NULL,\n  `operator_ids` varchar(100) NOT NULL,\n  `wait_message` varchar(250) NOT NULL,\n  `timeout_message` varchar(250) NOT NULL,\n  `referrer` varchar(250) NOT NULL,\n  `wait_timeout` int(11) NOT NULL,\n  `show_random_operator` int(11) NOT NULL,\n  `operator_name` varchar(100) NOT NULL,\n  `position` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `requires_email` int(11) NOT NULL,\n  `requires_username` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `time_on_site_pageviews_siteaccess_position` (`time_on_site`,`pageviews`,`siteaccess`,`identifier`,`position`),\n  KEY `identifier` (`identifier`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_widget_theme": "CREATE TABLE `lh_abstract_widget_theme` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) NOT NULL,\n  `onl_bcolor` varchar(10) NOT NULL,\n  `text_color` varchar(10) NOT NULL,\n  `online_image` varchar(250) NOT NULL,\n  `online_image_path` varchar(250) NOT NULL,\n  `offline_image` varchar(250) NOT NULL,\n  `offline_image_path` varchar(250) NOT NULL,\n  `logo_image` varchar(250) NOT NULL,\n  `logo_image_path` varchar(250) NOT NULL,\n  `need_help_image` varchar(250) NOT NULL,\n  `header_background` varchar(10) NOT NULL,\n  `widget_border_color` varchar(10) NOT NULL,\n  `need_help_tcolor` varchar(10) NOT NULL,\n  `need_help_bcolor` varchar(10) NOT NULL,\n  `need_help_border` varchar(10) NOT NULL,\n  `need_help_close_bg` varchar(10) NOT NULL,\n  `need_help_hover_bg` varchar(10) NOT NULL,\n  `need_help_close_hover_bg` varchar(10) NOT NULL,\n  `need_help_image_path` varchar(250) NOT NULL,\n  `custom_status_css` text NOT NULL, `bot_configuration` text NOT NULL ,\n  `custom_container_css` text NOT NULL,\n  `custom_widget_css` text NOT NULL, `custom_popup_css` text NOT NULL, \n  `need_help_header` varchar(250) NOT NULL,\n  `need_help_text` varchar(250) NOT NULL, `alias` varchar(50) NOT NULL,\n  `online_text` varchar(250) NOT NULL,\n  `offline_text` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`), KEY `alias` (`alias`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_canned_msg": "CREATE TABLE `lh_canned_msg` (\n  `id` int(11) NOT NULL AUTO_INCREMENT, `msg` longtext NOT NULL,`html_snippet` longtext NOT NULL, `position` int(11) NOT NULL,\n  `department_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `delay` int(11) NOT NULL,\n  `auto_send` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `department_id` (`department_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat": "CREATE TABLE `lh_chat` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `nick` varchar(50) NOT NULL,\n  `status` int(11) NOT NULL DEFAULT '0',\n  `status_sub` int(11) NOT NULL DEFAULT '0',\n  `time` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `referrer` text NOT NULL,\n  `session_referrer` text NOT NULL,\n  `chat_variables` text NOT NULL,\n  `remarks` text NOT NULL,\n  `ip` varchar(100) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `user_status` int(11) NOT NULL DEFAULT '0',\n  `support_informed` int(11) NOT NULL DEFAULT '0',\n  `unread_messages_informed` int(11) NOT NULL DEFAULT '0',\n  `reinform_timeout` int(11) NOT NULL DEFAULT '0',\n  `email` varchar(100) NOT NULL,\n  `country_code` varchar(100) NOT NULL,\n  `country_name` varchar(100) NOT NULL,\n  `user_typing` int(11) NOT NULL,\n  `user_typing_txt` varchar(50) NOT NULL,\n  `operator_typing` int(11) NOT NULL,\n  `operator_typing_id` int(11) NOT NULL,\n  `phone` varchar(100) NOT NULL,\n  `has_unread_messages` int(11) NOT NULL,\n  `last_user_msg_time` int(11) NOT NULL,\n  `fbst` tinyint(1) NOT NULL,\n  `online_user_id` int(11) NOT NULL,\n  `last_msg_id` int(11) NOT NULL,\n  `additional_data` text NOT NULL,\n  `timeout_message` varchar(250) NOT NULL,\n  `lat` varchar(10) NOT NULL,\n  `lon` varchar(10) NOT NULL,\n  `city` varchar(100) NOT NULL,\n  `operation` varchar(200) NOT NULL,\n  `operation_admin` varchar(200) NOT NULL,\n  `mail_send` int(11) NOT NULL,\n  `screenshot_id` int(11) NOT NULL,\n  `wait_time` int(11) NOT NULL,\n  `wait_timeout` int(11) NOT NULL,\n  `wait_timeout_send` int(11) NOT NULL,\n  `chat_duration` int(11) NOT NULL,\n  `tslasign` int(11) NOT NULL,\n  `priority` int(11) NOT NULL,\n  `chat_initiator` int(11) NOT NULL,\n  `transfer_timeout_ts` int(11) NOT NULL,\n  `transfer_timeout_ac` int(11) NOT NULL,\n  `transfer_if_na` int(11) NOT NULL,\n  `na_cb_executed` int(11) NOT NULL,\n  `nc_cb_executed` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `status_user_id` (`status`,`user_id`),\n  KEY `user_id` (`user_id`),\n  KEY `online_user_id` (`online_user_id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `has_unread_messages_dep_id_id` (`has_unread_messages`,`dep_id`,`id`),\n  KEY `status_dep_id_id` (`status`,`dep_id`,`id`),\n  KEY `status_dep_id_priority_id` (`status`,`dep_id`,`priority`,`id`),\n  KEY `status_priority_id` (`status`,`priority`,`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_accept": "CREATE TABLE `lh_chat_accept` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `hash` varchar(50) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `wused` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hash` (`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_archive_range": "CREATE TABLE `lh_chat_archive_range` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `range_from` bigint(20) unsigned NOT NULL,\n  `range_to` bigint(20) unsigned NOT NULL,\n  `older_than` int(11) NOT NULL,\n  `last_id` bigint(20) NOT NULL,\n  `first_id` bigint(20) NOT NULL,\n  `year_month` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_mail_archive_range": "CREATE TABLE `lh_mail_archive_range` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL, `range_from` bigint(20) unsigned NOT NULL,\n  `range_to` bigint(20) unsigned NOT NULL,\n  `older_than` int(11) NOT NULL,\n  `last_id` bigint(20) NOT NULL,\n  `first_id` bigint(20) NOT NULL,\n  `year_month` int(11) NOT NULL, `type` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_blocked_user": "CREATE TABLE `lh_chat_blocked_user` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `ip` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `datets` bigint(20) unsigned NOT NULL,\n  `chat_id` bigint(20) unsigned NOT NULL,\n  `dep_id` bigint(20) unsigned NOT NULL,\n  `nick` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `btype` tinyint(1) NOT NULL DEFAULT 0,\n  `expires` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `online_user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `ip` (`ip`),\n  KEY `nick` (`nick`),\n  KEY `online_user_id` (`online_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_config": "CREATE TABLE `lh_chat_config` (\n  `identifier` varchar(50) NOT NULL,\n  `value` text NOT NULL,\n  `type` tinyint(1) NOT NULL DEFAULT '0',\n  `explain` varchar(250) NOT NULL,\n  `hidden` int(11) NOT NULL DEFAULT '0',\n  PRIMARY KEY (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_file": "CREATE TABLE `lh_chat_file` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  `upload_name` varchar(255) NOT NULL,\n  `size` int(11) NOT NULL,\n  `type` varchar(255) NOT NULL,\n  `file_path` varchar(255) NOT NULL,\n  `extension` varchar(255) NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `date` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_online_user": "CREATE TABLE `lh_chat_online_user` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `vid` varchar(50) NOT NULL,\n  `ip` varchar(50) NOT NULL,\n  `current_page` text NOT NULL,\n  `page_title` varchar(250) NOT NULL,\n  `referrer` text NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `invitation_seen_count` int(11) NOT NULL,\n  `invitation_id` int(11) NOT NULL,\n  `last_visit` int(11) NOT NULL,\n  `first_visit` int(11) NOT NULL,\n  `total_visits` int(11) NOT NULL,\n  `pages_count` int(11) NOT NULL,\n  `tt_pages_count` int(11) NOT NULL,\n  `invitation_count` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `user_agent` varchar(250) NOT NULL,\n  `user_country_code` varchar(50) NOT NULL,\n  `user_country_name` varchar(50) NOT NULL,\n  `operator_message` varchar(250) NOT NULL,\n  `operator_user_proactive` varchar(100) NOT NULL,\n  `operator_user_id` int(11) NOT NULL,\n  `message_seen` int(11) NOT NULL,\n  `message_seen_ts` int(11) NOT NULL,\n  `lat` varchar(10) NOT NULL,\n  `lon` varchar(10) NOT NULL,\n  `city` varchar(100) NOT NULL,\n  `reopen_chat` int(11) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `tt_time_on_site` int(11) NOT NULL,\n  `requires_email` int(11) NOT NULL,\n  `requires_username` int(11) NOT NULL,\n  `screenshot_id` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `operation` varchar(200) NOT NULL,\n  `online_attr` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `vid` (`vid`),\n  KEY `dep_id` (`dep_id`),\n  KEY `last_visit_dep_id` (`last_visit`,`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_online_user_footprint": "CREATE TABLE `lh_chat_online_user_footprint` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `online_user_id` int(11) NOT NULL,\n  `page` varchar(2083) NOT NULL,\n  `vtime` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_vtime` (`chat_id`,`vtime`),\n  KEY `online_user_id` (`online_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_online_user_footprint_update": "CREATE TABLE `lh_chat_online_user_footprint_update` (`online_user_id` bigint(20) NOT NULL,  `command` varchar(20) NOT NULL,  `args` varchar(250) NOT NULL,  `ctime` int(11) NOT NULL, KEY `online_user_id` (`online_user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_chatbox": "CREATE TABLE `lh_chatbox` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `identifier` varchar(50) NOT NULL,\n  `name` varchar(100) NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `active` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_departament": "CREATE TABLE `lh_departament` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `email` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `priority` int(11) NOT NULL,\n  `department_transfer_id` int(11) NOT NULL,\n  `transfer_timeout` int(11) NOT NULL,\n  `identifier` varchar(2083) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `inform_options` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `online_hours_active` tinyint(1) NOT NULL,\n  `inform_delay` int(11) NOT NULL,\n  `inform_close` int(11) NOT NULL,\n  `xmpp_recipients` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `xmpp_group_recipients` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` int(11) NOT NULL,\n  `delay_lm` int(11) NOT NULL,\n  `hidden` int(11) NOT NULL,\n  `inform_unread` tinyint(1) NOT NULL,\n  `inform_unread_delay` int(11) NOT NULL,\n  `nc_cb_execute` tinyint(1) NOT NULL,\n  `na_cb_execute` tinyint(1) NOT NULL,\n  `active_balancing` tinyint(1) NOT NULL,\n  `max_active_chats` int(11) NOT NULL,\n  `max_timeout_seconds` int(11) NOT NULL,\n  `attr_int_1` int(11) NOT NULL DEFAULT 0,\n  `attr_int_2` int(11) NOT NULL DEFAULT 0,\n  `attr_int_3` int(11) NOT NULL DEFAULT 0,\n  `active_chats_counter` int(11) NOT NULL,\n  `pending_chats_counter` int(11) NOT NULL,\n  `visible_if_online` tinyint(1) NOT NULL,\n  `sort_priority` int(11) NOT NULL,\n  `mod_start_hour` int(4) NOT NULL DEFAULT -1,\n  `mod_end_hour` int(4) NOT NULL DEFAULT -1,\n  `tud_start_hour` int(4) NOT NULL DEFAULT -1,\n  `tud_end_hour` int(4) NOT NULL DEFAULT -1,\n  `wed_start_hour` int(4) NOT NULL DEFAULT -1,\n  `wed_end_hour` int(4) NOT NULL DEFAULT -1,\n  `thd_start_hour` int(4) NOT NULL DEFAULT -1,\n  `thd_end_hour` int(4) NOT NULL DEFAULT -1,\n  `frd_start_hour` int(4) NOT NULL DEFAULT -1,\n  `frd_end_hour` int(4) NOT NULL DEFAULT -1,\n  `sad_start_hour` int(4) NOT NULL DEFAULT -1,\n  `sad_end_hour` int(4) NOT NULL DEFAULT -1,\n  `sud_start_hour` int(4) NOT NULL DEFAULT -1,\n  `sud_end_hour` int(4) NOT NULL DEFAULT -1,\n  `inform_close_all` int(11) NOT NULL,\n  `inform_close_all_email` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `product_configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `pending_max` int(11) NOT NULL,\n  `pending_group_max` int(11) NOT NULL,\n  `exclude_inactive_chats` int(11) NOT NULL,\n  `max_ac_dep_chats` int(11) NOT NULL,\n  `delay_before_assign` int(11) NOT NULL,\n  `bot_configuration` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `assign_same_language` int(11) NOT NULL,\n  `archive` tinyint(1) NOT NULL DEFAULT 0,\n  `max_load` int(11) NOT NULL DEFAULT 0,\n  `bot_chats_counter` int(11) NOT NULL DEFAULT 0,\n  `max_load_h` int(11) NOT NULL DEFAULT 0,\n  `inactive_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `inop_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `acop_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `alias` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `max_active_mails` int(11) NOT NULL DEFAULT 0,\n  `active_mail_balancing` tinyint(1) NOT NULL,\n  `max_ac_dep_mails` int(11) NOT NULL,\n  `max_timeout_seconds_mail` int(11) NOT NULL,\n  `delay_before_assign_mail` int(11) NOT NULL,\n  `ignore_op_status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `disabled_hidden` (`disabled`,`hidden`),\n  KEY `attr_int_1` (`attr_int_1`),\n  KEY `attr_int_2` (`attr_int_2`),\n  KEY `attr_int_3` (`attr_int_3`),\n  KEY `sort_priority_name` (`sort_priority`,`name`),\n  KEY `active_mod` (`online_hours_active`,`mod_start_hour`,`mod_end_hour`),\n  KEY `active_tud` (`online_hours_active`,`tud_start_hour`,`tud_end_hour`),\n  KEY `active_wed` (`online_hours_active`,`wed_start_hour`,`wed_end_hour`),\n  KEY `active_thd` (`online_hours_active`,`thd_start_hour`,`thd_end_hour`),\n  KEY `active_frd` (`online_hours_active`,`frd_start_hour`,`frd_end_hour`),\n  KEY `active_sad` (`online_hours_active`,`sad_start_hour`,`sad_end_hour`),\n  KEY `active_sud` (`online_hours_active`,`sud_start_hour`,`sud_end_hour`),\n  KEY `active_chats_counter` (`active_chats_counter`),\n  KEY `pending_chats_counter` (`pending_chats_counter`),\n  KEY `archive` (`archive`),\n  KEY `bot_chats_counter` (`bot_chats_counter`),\n  KEY `identifier_2` (`identifier`(768)),\n  KEY `alias` (`alias`),\n  KEY `ignore_op_status` (`ignore_op_status`)\n) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_departament_custom_work_hours": "CREATE TABLE IF NOT EXISTS `lh_departament_custom_work_hours` (`id` int(11) NOT NULL AUTO_INCREMENT,`dep_id` int(11) NOT NULL,`date_from` int(11) NOT NULL,`date_to` int(11) NOT NULL,`start_hour` int(11) NOT NULL,`end_hour` int(11) NOT NULL,PRIMARY KEY (`id`),KEY `dep_id` (`dep_id`),KEY `date_from` (`date_from`),KEY `search_active` (`date_from`, `date_to`, `dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_faq": "CREATE TABLE `lh_faq` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question` varchar(250) NOT NULL,\n  `answer` text NOT NULL,\n  `url` varchar(250) NOT NULL,\n  `email` varchar(50) NOT NULL,\n  `identifier` varchar(10) NOT NULL,\n  `active` int(11) NOT NULL,\n  `has_url` tinyint(1) NOT NULL,\n  `is_wildcard` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`),\n  KEY `active_url` (`active`,`url`),\n  KEY `has_url` (`has_url`),\n  KEY `identifier` (`identifier`),\n  KEY `is_wildcard` (`is_wildcard`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_forgotpasswordhash": "CREATE TABLE `lh_forgotpasswordhash` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `created` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_group": "CREATE TABLE `lh_group` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_grouprole": "CREATE TABLE `lh_grouprole` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `group_id` int(11) NOT NULL,\n  `role_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`role_id`,`group_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_groupuser": "CREATE TABLE `lh_groupuser` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `group_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`group_id`),\n  KEY `user_id` (`user_id`),\n  KEY `group_id_2` (`group_id`,`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_msg": "CREATE TABLE `lh_msg` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `msg` longtext NOT NULL,\n  `time` int(11) NOT NULL,\n  `chat_id` int(11) NOT NULL DEFAULT '0',\n  `user_id` int(11) NOT NULL DEFAULT '0',\n  `name_support` varchar(100) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_question": "CREATE TABLE `lh_question` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question` varchar(250) NOT NULL,\n  `location` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `priority` int(11) NOT NULL,\n  `is_voting` int(11) NOT NULL,\n  `question_intro` text NOT NULL,\n  `revote` int(11) NOT NULL DEFAULT '0',\n  PRIMARY KEY (`id`),\n  KEY `priority` (`priority`),\n  KEY `active_priority` (`active`,`priority`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_question_answer": "CREATE TABLE `lh_question_answer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `ip` bigint(20) NOT NULL,\n  `question_id` int(11) NOT NULL,\n  `answer` text NOT NULL,\n  `ctime` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `ip` (`ip`),\n  KEY `question_id` (`question_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_question_option": "CREATE TABLE `lh_question_option` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question_id` int(11) NOT NULL,\n  `option_name` varchar(250) NOT NULL,\n  `priority` tinyint(4) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `question_id` (`question_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_question_option_answer": "CREATE TABLE `lh_question_option_answer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question_id` int(11) NOT NULL,\n  `option_id` int(11) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `ip` bigint(20) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `question_id` (`question_id`),\n  KEY `ip` (`ip`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_role": "CREATE TABLE `lh_role` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_rolefunction": "CREATE TABLE `lh_rolefunction` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `role_id` int(11) NOT NULL,\n  `module` varchar(100) NOT NULL,\n  `function` varchar(100) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `role_id` (`role_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_transfer": "CREATE TABLE `lh_transfer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `transfer_user_id` int(11) NOT NULL,\n  `from_dep_id` int(11) NOT NULL,\n  `transfer_to_user_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `transfer_user_id_dep_id` (`transfer_user_id`,`dep_id`),\n  KEY `transfer_to_user_id` (`transfer_to_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_userdep": "CREATE TABLE `lh_userdep` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL, `only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0', `dep_id` int(11) NOT NULL,\n  `last_activity` int(11) NOT NULL,\n  `hide_online` int(11) NOT NULL,\n  `last_accepted` int(11) NOT NULL,\n  `active_chats` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`),\n  KEY `last_activity_hide_online_dep_id` (`last_activity`,`hide_online`,`dep_id`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users": "CREATE TABLE `lh_users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(40) NOT NULL,\n  `password` varchar(40) NOT NULL,\n  `email` varchar(100) NOT NULL,\n  `time_zone` varchar(100) NOT NULL,\n  `name` varchar(100) NOT NULL,\n  `surname` varchar(100) NOT NULL,\n  `filepath` varchar(200) NOT NULL,\n  `filename` varchar(200) NOT NULL,\n  `job_title` varchar(100) NOT NULL,\n  `xmpp_username` varchar(200) NOT NULL,\n  `skype` varchar(50) NOT NULL,\n  `disabled` tinyint(4) NOT NULL,\n  `hide_online` tinyint(1) NOT NULL,\n  `all_departments` tinyint(1) NOT NULL,\n  `invisible_mode` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hide_online` (`hide_online`),\n  KEY `email` (`email`),\n  KEY `xmpp_username` (`xmpp_username`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users_remember": "CREATE TABLE `lh_users_remember` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `mtime` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users_setting": "CREATE TABLE `lh_users_setting` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `value` text NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`,`identifier`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users_setting_option": "CREATE TABLE `lh_users_setting_option` (\n  `identifier` varchar(50) NOT NULL,\n  `class` varchar(50) NOT NULL,\n  `attribute` varchar(40) NOT NULL,\n  PRIMARY KEY (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_cobrowse": "CREATE TABLE `lh_cobrowse` ( `id` int(11) NOT NULL AUTO_INCREMENT, `chat_id` int(11) NOT NULL, `mtime` int(11) NOT NULL, `url` varchar(250) NOT NULL, `initialize` longtext NOT NULL, `modifications` longtext NOT NULL, `finished` tinyint(1) NOT NULL, `w` int(11) NOT NULL, `wh` int(11) NOT NULL, `x` int(11) NOT NULL, `y` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_paid": "CREATE TABLE `lh_chat_paid` ( `id` int(11) NOT NULL AUTO_INCREMENT,  `hash` varchar(250) NOT NULL,  `chat_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `hash` (`hash`(191)),  KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_rest_api_key": "CREATE TABLE `lh_abstract_rest_api_key` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `api_key` varchar(50) NOT NULL,  `user_id` int(11) NOT NULL,  `active` int(11) NOT NULL DEFAULT '0',  PRIMARY KEY (`id`),  KEY `user_id` (`user_id`),  KEY `api_key_active` (`api_key`,`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_rest_api_key_remote": "CREATE TABLE `lh_abstract_rest_api_key_remote` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `api_key` varchar(50) NOT NULL, `username` varchar(50) NOT NULL, `name` varchar(50) NOT NULL,  `host` varchar(250) NOT NULL, `active` tinyint(1) NOT NULL DEFAULT '0', `position` int(11) NOT NULL DEFAULT '0',  PRIMARY KEY (`id`), KEY `active` (`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_departament_group_user": "CREATE TABLE `lh_departament_group_user` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n  `dep_group_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `read_only` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `exc_indv_autoasign` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `assign_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `chat_min_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `chat_max_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `dep_group_id` (`dep_group_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=382 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
+        "lh_departament_group_member": "CREATE TABLE `lh_departament_group_member` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `dep_id` int(11) NOT NULL,  `dep_group_id` int(11) NOT NULL,  PRIMARY KEY (`id`), UNIQUE KEY `dep_group_id_dep_id` (`dep_group_id`,`dep_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_departament_limit_group_member": "CREATE TABLE `lh_departament_limit_group_member` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `dep_id` int(11) NOT NULL,  `dep_limit_group_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `dep_limit_group_id` (`dep_limit_group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_departament_group": "CREATE TABLE `lh_departament_group` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL,  PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_departament_limit_group": "CREATE TABLE `lh_departament_limit_group` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL,`pending_max` int(11) NOT NULL,  PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users_session": "CREATE TABLE `lh_users_session` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `token` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `device_type` int(11) NOT NULL,\n  `device_token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `created_on` int(11) NOT NULL,\n  `updated_on` int(11) NOT NULL,\n  `expires_on` int(11) NOT NULL,\n  `notifications_status` int(11) NOT NULL DEFAULT 1,\n  `error` int(11) NOT NULL DEFAULT 0,\n  `last_error` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `token` (`token`),\n  KEY `device_token_device_type_v2` (`device_token`(191),`device_type`),\n  KEY `error` (`error`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_canned_msg_tag_link": "CREATE TABLE `lh_canned_msg_tag_link` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag_id` int(11) NOT NULL,  `canned_id` int(11) NOT NULL,  PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`), KEY `tag_id` (`tag_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_canned_msg_tag": "CREATE TABLE `lh_canned_msg_tag` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag` varchar(40) NOT NULL, PRIMARY KEY (`id`), KEY `tag` (`tag`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_group_work": "CREATE TABLE `lh_group_work` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `group_id` int(11) NOT NULL, `group_work_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_users_online_session": "CREATE TABLE `lh_users_online_session` (  `id` bigint(20) NOT NULL AUTO_INCREMENT,  `user_id` int(11) NOT NULL, `duration` int(11) NOT NULL, `time` int(11) NOT NULL, `lactivity` int(11) NOT NULL, `type` tinyint(1) NOT NULL DEFAULT '0', `offline_reason_id` int(11) unsigned NOT NULL DEFAULT 0, `updated_by_user_id` int(11) unsigned NOT NULL DEFAULT 0, `online_by_user_id` int(11) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`id`), KEY `user_id_lactivity` (`user_id`, `lactivity`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_variables": "CREATE TABLE `lh_abstract_proactive_chat_variables` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL, `identifier` varchar(50) NOT NULL, `store_timeout` int(11) NOT NULL, `filter_val` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `identifier` (`identifier`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_event": "CREATE TABLE `lh_abstract_proactive_chat_event` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `vid_id` int(11) NOT NULL,  `ev_id` int(11) NOT NULL,  `ts` int(11) NOT NULL,  `val` varchar(50) NOT NULL,  PRIMARY KEY (`id`),  KEY `vid_id_ev_id_val_ts` (`vid_id`,`ev_id`,`val`,`ts`),  KEY `vid_id_ev_id_ts` (`vid_id`,`ev_id`,`ts`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_invitation_event": "CREATE TABLE `lh_abstract_proactive_chat_invitation_event` ( `id` int(11) NOT NULL AUTO_INCREMENT, `invitation_id` int(11) NOT NULL, `event_id` int(11) NOT NULL, `min_number` int(11) NOT NULL, `during_seconds` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `invitation_id` (`invitation_id`), KEY `event_id` (`event_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_start_settings": "CREATE TABLE `lh_chat_start_settings` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_chat_event_track": "CREATE TABLE `lh_chat_event_track` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_subject": "CREATE TABLE `lh_abstract_subject` (`id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,`internal` tinyint(1) NOT NULL DEFAULT 0,`internal_type` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,`color` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,`pinned` tinyint(1) NOT NULL DEFAULT 0,`widgets` int(11) NOT NULL DEFAULT 0,`archive` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`id`),\n  KEY `internal` (`internal`),\n  KEY `internal_type` (`internal_type`),\n  KEY `widgets` (`widgets`),\n  KEY `archive` (`archive`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_chat_variable": "CREATE TABLE `lh_abstract_chat_variable` ( `id` int(11) NOT NULL AUTO_INCREMENT, `var_name` varchar(255) NOT NULL, `try_decrypt` tinyint(1) unsigned NOT NULL DEFAULT '0', `content_field` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL, `var_identifier` varchar(255) NOT NULL, `old_js_id` varchar(50) NOT NULL, `inv` tinyint(1) NOT NULL, `change_message` varchar(250) NOT NULL, `type` tinyint(1) NOT NULL, `persistent` tinyint(1) NOT NULL,`js_variable` varchar(255) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_chat_column": "CREATE TABLE `lh_abstract_chat_column` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `column_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `variable` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `position` int(11) NOT NULL,\n  `enabled` tinyint(1) NOT NULL,\n  `conditions` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `column_icon` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `column_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `chat_enabled` tinyint(1) NOT NULL,\n  `online_enabled` tinyint(1) NOT NULL,\n  `icon_mode` tinyint(1) NOT NULL DEFAULT 0,\n  `has_popup` tinyint(1) NOT NULL DEFAULT 0,\n  `popup_content` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sort_column` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sort_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `chat_list_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `mail_list_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `mail_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `enabled` (`enabled`),\n  KEY `online_enabled` (`online_enabled`),\n  KEY `chat_enabled` (`chat_enabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_chat_priority": "CREATE TABLE `lh_abstract_chat_priority` (`id` int(11) NOT NULL AUTO_INCREMENT,`value` text COLLATE utf8mb4_unicode_ci NOT NULL,`role_destination` varchar(50) NOT NULL,`present_role_is` varchar(50) NOT NULL, `dep_id` int(11) NOT NULL, `dest_dep_id` int(11) NOT NULL DEFAULT 0, `sort_priority` int(11) NOT NULL DEFAULT 0,`priority` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_subject_dep": "CREATE TABLE `lh_abstract_subject_dep` ( `id` int(11) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `subject_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `subject_id` (`subject_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_subject_chat": "CREATE TABLE `lh_abstract_subject_chat` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `subject_id` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_group_object": "CREATE TABLE `lh_group_object` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `object_id` bigint(20) NOT NULL, `group_id` bigint(20) NOT NULL, `type` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `object_id_type` (`object_id`,`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_departament_availability": "CREATE TABLE `lh_departament_availability` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `hour` int(11) NOT NULL, `hourminute` int(4) NOT NULL, `minute` int(11) NOT NULL, `time` int(11) NOT NULL, `ymdhi` bigint(20) NOT NULL, `ymd` int(11) NOT NULL, `status` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `ymdhi` (`ymdhi`), KEY `dep_id` (`dep_id`),  KEY `hourminute` (`hourminute`), KEY `time` (`time`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_bot": "CREATE TABLE `lh_generic_bot_bot` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `short_name` varchar(50) NOT NULL DEFAULT '', `avatar` varchar(150) NOT NULL, `nick` varchar(100) NOT NULL, `filepath` varchar(250) NOT NULL, `filename` varchar(250) NOT NULL, `configuration` longtext NOT NULL,`attr_str_1` varchar(100) NOT NULL,`attr_str_2` varchar(100) NOT NULL,`attr_str_3` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_exception": "CREATE TABLE `lh_generic_bot_exception` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `priority` int(11) NOT NULL, `active` tinyint(1) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_exception_message": "CREATE TABLE `lh_generic_bot_exception_message` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `code` varchar(20) NOT NULL, `exception_group_id` int(11) NOT NULL, `priority` int(11) NOT NULL, `active` tinyint(1) NOT NULL, `message` text NOT NULL, PRIMARY KEY (`id`),  KEY `code` (`code`), KEY `exception_group_id` (`exception_group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_tr_group": "CREATE TABLE `lh_generic_bot_tr_group` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL,`filename` varchar(250) NOT NULL, `bot_lang` varchar(10) NOT NULL, `use_translation_service` tinyint(1) unsigned NOT NULL DEFAULT '0', `filepath` varchar(250) NOT NULL,`configuration` longtext NOT NULL,`nick` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_tr_item": "CREATE TABLE `lh_generic_bot_tr_item` ( `id` int(11) NOT NULL AUTO_INCREMENT, `group_id` int(11) NOT NULL, `identifier` varchar(50) NOT NULL,`auto_translate` tinyint(1) unsigned NOT NULL DEFAULT '0', `translation` text NOT NULL, PRIMARY KEY (`id`),  KEY `identifier` (`identifier`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_group": "CREATE TABLE `lh_generic_bot_group` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL,`is_collapsed` int(11) NOT NULL DEFAULT '0', `pos` int(11) NOT NULL DEFAULT '0', `bot_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `bot_id` (`bot_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_trigger_template": "CREATE TABLE `lh_generic_bot_trigger_template` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `actions` longtext NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_trigger": "CREATE TABLE `lh_generic_bot_trigger` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `actions` longtext NOT NULL, `group_id` bigint(20) NOT NULL, `pos` int(11) NOT NULL DEFAULT '0', `bot_id` int(11) NOT NULL, `default` int(11) NOT NULL, `default_unknown` int(11) NOT NULL, `default_unknown_btn` int(11) NOT NULL DEFAULT '0', `in_progress` int(11) NOT NULL DEFAULT '0', `as_argument` int(11) NOT NULL DEFAULT '0', PRIMARY KEY (`id`), KEY `default_unknown` (`default_unknown`), KEY `default_unknown_btn` (`default_unknown_btn`), KEY `bot_id` (`bot_id`), KEY `in_progress` (`in_progress`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_trigger_event": "CREATE TABLE `lh_generic_bot_trigger_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `pattern` text NOT NULL, `pattern_exc` text NOT NULL, `configuration` longtext NOT NULL, `trigger_id` bigint(20) NOT NULL, `bot_id` int(11) NOT NULL, `on_start_type` tinyint(1) NOT NULL, `priority` int(11) NOT NULL, `type` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `pattern_v2` (`pattern`(191)), KEY `type` (`type`), KEY `on_start_type` (`on_start_type`), KEY `trigger_id` (`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_trigger_event_template": "CREATE TABLE `lh_generic_bot_trigger_event_template` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `configuration` longtext NOT NULL, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_payload": "CREATE TABLE `lh_generic_bot_payload` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `payload` varchar(100) NOT NULL, `bot_id` int(11) NOT NULL, `trigger_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `bot_id` (`bot_id`), KEY `trigger_id` (`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_chat_workflow": "CREATE TABLE `lh_generic_bot_chat_workflow` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `time` int(11) NOT NULL, `trigger_id` bigint(20) NOT NULL, `identifier` varchar(100) NOT NULL, `status` int(11) NOT NULL, `collected_data` text, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_chat_event": "CREATE TABLE `lh_generic_bot_chat_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `counter` int(11) NOT NULL, `content` longtext NOT NULL, `ctime` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_pending_event": "CREATE TABLE `lh_generic_bot_pending_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `trigger_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_notification_subscriber": "CREATE TABLE `lh_notification_subscriber` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `online_user_id` bigint(20) NOT NULL, `dep_id` int(11) NOT NULL,`theme_id` int(11) NOT NULL, `ctime` int(11) NOT NULL, `utime` int(11) NOT NULL, `status` int(11) NOT NULL, `params` text NOT NULL, `device_type` tinyint(1) NOT NULL,`subscriber_hash` varchar(50) NOT NULL, `uagent` varchar(250) NOT NULL, `ip` varchar(250) NOT NULL, `last_error` text NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), KEY `dep_id` (`dep_id`), KEY `online_user_id` (`online_user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_speech_user_language": "CREATE TABLE `lh_speech_user_language` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `user_id` bigint(20) NOT NULL, `language` varchar(20) NOT NULL, PRIMARY KEY (`id`), KEY `user_id_language` (`user_id`,`language`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_proactive_chat_campaign": "CREATE TABLE `lh_abstract_proactive_chat_campaign` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `text` text NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_proactive_chat_campaign_conv": "CREATE TABLE `lh_abstract_proactive_chat_campaign_conv` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `device_type` tinyint(11) NOT NULL,\n  `invitation_type` tinyint(1) NOT NULL,\n  `invitation_status` tinyint(1) NOT NULL,\n  `chat_id` bigint(20) NOT NULL,\n  `campaign_id` int(11) NOT NULL,\n  `invitation_id` int(11) NOT NULL,\n  `department_id` int(11) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `con_time` int(11) NOT NULL,\n  `vid_id` bigint(20) DEFAULT NULL,\n  `variation_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_int_expires` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_int_time` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_event` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `unique_id` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`), KEY `inv_vid` (`invitation_id`,`invitation_status`,`vid_id`),\n  KEY `campaign_id` (`campaign_id`),\n  KEY `invitation_status` (`invitation_status`),\n  KEY `ctime` (`ctime`),\n  KEY `invitation_id_variation_id` (`invitation_id`,`variation_id`),\n  KEY `unique_id` (`unique_id`),\n  KEY `conv_int_time` (`conv_int_time`),\n  KEY `conv_event_vid_id` (`conv_event`,`vid_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_audits": "CREATE TABLE `lh_audits` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `category` varchar(255) NOT NULL, `file` varchar(255), `user_id` bigint(20) DEFAULT '0', `object_id` bigint(20) DEFAULT '0', `line` bigint(20), `message` longtext NOT NULL, `severity` varchar(255) NOT NULL, `source` varchar(255) NOT NULL, `time` timestamp NOT NULL, KEY `time` (`time`), KEY `user_id` (`user_id`),  KEY `object_id` (`object_id`), KEY `source` (`source`(191)), KEY `category` (`category`(191))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_repeat_restrict": "CREATE TABLE `lh_generic_bot_repeat_restrict` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `chat_id` bigint(20) NOT NULL, `trigger_id` bigint(20), `counter` int(11) DEFAULT '0', KEY `chat_id_trigger_id` (`chat_id`,`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_rest_api": "CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(50) NOT NULL, `description` varchar(250), `configuration` longtext NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_group_chat": "CREATE TABLE `lh_group_chat` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  `status` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, `time` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `last_msg_op_id` bigint(20) NOT NULL,\n  `last_msg` varchar(200) NOT NULL,\n  `last_user_msg_time` int(11) NOT NULL,  `last_msg_id` bigint(20) NOT NULL,  `type` tinyint(1) NOT NULL DEFAULT 0,  `tm` int(11) NOT NULL,  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`), KEY `chat_id` (`chat_id`),\n  KEY `type` (`type`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_group_msg": "CREATE TABLE `lh_group_msg` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `time` int(11) NOT NULL,\n  `chat_id` int(11) NOT NULL DEFAULT 0,\n  `user_id` int(11) NOT NULL DEFAULT 0,\n  `name_support` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `meta_msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_conversation": "CREATE TABLE `lhc_mailconv_conversation` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `dep_id` int(11) unsigned NOT NULL,\n  `user_id` int(11) unsigned NOT NULL,\n  `status` int(11) unsigned NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `ctime` int(11) unsigned NOT NULL,\n  `priority` int(11) NOT NULL DEFAULT 0,\n  `priority_asc` int(11) NOT NULL DEFAULT 0,\n  `from_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,`from_address_clean` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',\n  `lang` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `phone` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_message_id` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `udate` bigint(20) unsigned NOT NULL,\n  `date` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `opened_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `total_messages` int(11) unsigned NOT NULL,\n  `match_rule_id` int(11) unsigned NOT NULL,\n  `cls_time` int(11) unsigned NOT NULL,\n  `pnd_time` int(11) unsigned NOT NULL,\n  `wait_time` int(11) unsigned NOT NULL,\n  `accept_time` int(11) unsigned NOT NULL,\n  `response_time` int(11) NOT NULL,\n  `interaction_time` int(11) NOT NULL,\n  `lr_time` int(11) unsigned NOT NULL,\n  `tslasign` int(11) unsigned NOT NULL,\n  `start_type` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `transfer_uid` int(11) unsigned NOT NULL,\n  `remarks` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conv_duration` int(11) NOT NULL DEFAULT 0,\n  `mail_variables` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `has_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `pending_sync` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `follow_up_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `undelivered` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `lang` (`lang`),\n  KEY `from_address` (`from_address`),\n  KEY `mailbox_id` (`mailbox_id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `mailbox_id_status_udate` (`mailbox_id`,`status`,`udate`),\n  KEY `status_priority` (`status`,`priority`),\n  KEY `status_priority_asc` (`status`,`priority_asc`),\n  KEY `has_attachment` (`has_attachment`),\n  KEY `udate` (`udate`),\n  KEY `user_id_status` (`user_id`,`status`),\n  KEY `status_dep_id` (`status`,`dep_id`),\n  KEY `undelivered` (`undelivered`),\n  KEY `phone` (`phone`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_file": "CREATE TABLE `lhc_mailconv_file` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `size` int(11) unsigned NOT NULL,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `description` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `extension` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `type` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attachment_id` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `file_path` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `file_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `content_id` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disposition` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conversation_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `conversation_id` (`conversation_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_mailbox": "CREATE TABLE `lhc_mailconv_mailbox` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,`delete_on_archive` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `delete_policy` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mail` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `username` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `password` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `active` tinyint(1) unsigned NOT NULL DEFAULT 1,\n  `port` int(11) unsigned NOT NULL,\n  `workflow_options` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `imap` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_sync_log` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sync_started` bigint(20) unsigned NOT NULL,\n  `last_sync_time` bigint(20) unsigned NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `mailbox_sync` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sync_status` int(11) unsigned NOT NULL,\n  `sync_interval` int(11) unsigned NOT NULL,\n  `signature` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `signature_under` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `import_since` int(11) unsigned NOT NULL DEFAULT 0,\n  `dep_id` int(11) unsigned NOT NULL DEFAULT 0,\n  `delete_mode` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `reopen_timeout` int(11) unsigned NOT NULL DEFAULT 4,\n  `failed` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `uuid_status` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `create_a_copy` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `import_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `assign_parent_user` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mail_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `name_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `username_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `password_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `no_pswd_smtp` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `auth_method` tinyint(1) unsigned NOT NULL DEFAULT '0',\n  `reopen_reset` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `last_process_time` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_match_rule": "CREATE TABLE `lhc_mailconv_match_rule` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n  `dep_id` int(11) unsigned NOT NULL,\n  `conditions` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `active` tinyint(1) unsigned NOT NULL DEFAULT 1,\n  `mailbox_id` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_name` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_mail` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject_contains` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `priority` int(11) NOT NULL,\n  `priority_rule` int(11) NOT NULL,\n  `options` text COLLATE utf8mb4_unicode_ci NOT NULL,`name` varchar(50) NOT NULL, PRIMARY KEY (`id`),  \n  KEY `active_priority` (`active`,`priority`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_msg_open": "CREATE TABLE `lhc_mailconv_msg_open` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `opened_at` bigint(20) unsigned NOT NULL,\n  `hash` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hash` (`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_msg": "CREATE TABLE `lhc_mailconv_msg` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `priority` int(11) NOT NULL DEFAULT 0, `is_external` tinyint(1) unsigned NOT NULL DEFAULT 0, `message_hash` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL, `status` int(11) unsigned NOT NULL,`opened_at` bigint(20) unsigned NOT NULL DEFAULT 0, `conversation_id_old` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conversation_id` bigint(20) unsigned NOT NULL,`lang` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL, \n  `message_id` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `in_reply_to` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `alt_body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `references` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `ctime` int(11) unsigned NOT NULL,\n  `udate` int(11) unsigned NOT NULL,\n  `date` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `flagged` int(11) unsigned NOT NULL,\n  `recent` int(11) unsigned NOT NULL,\n  `msgno` bigint(20) unsigned NOT NULL,\n  `uid` bigint(20) unsigned NOT NULL,\n  `size` int(11) unsigned NOT NULL,\n  `from_host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `to_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `reply_to_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `response_time` bigint(20) unsigned NOT NULL,\n  `cls_time` bigint(20) unsigned NOT NULL,\n  `wait_time` bigint(20) unsigned NOT NULL,\n  `accept_time` bigint(20) unsigned NOT NULL,\n  `interaction_time` bigint(20) NOT NULL, `conv_user_id` bigint(20) unsigned NOT NULL DEFAULT 0, `user_id` bigint(20) unsigned NOT NULL,\n  `lr_time` bigint(20) unsigned NOT NULL,\n  `response_type` int(11) unsigned NOT NULL,\n  `bcc_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `cc_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) unsigned NOT NULL,\n  `mb_folder` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conv_duration` int(11) NOT NULL DEFAULT 0,\n  `has_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `undelivered` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `rfc822_body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `delivery_status` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `response_type` (`response_type`),\n  KEY `user_id` (`user_id`),\n  KEY `conversation_id_old` (`conversation_id_old`), KEY `conversation_id` (`conversation_id`),\n  KEY `mailbox_id` (`mailbox_id`),\n  KEY `dep_id` (`dep_id`), KEY `message_hash` (`message_hash`), KEY `lang` (`lang`),\n  KEY `has_attachment` (`has_attachment`),\n  KEY `udate` (`udate`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_msg_internal": "CREATE TABLE `lhc_mailconv_msg_internal` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `time` bigint(20) unsigned NOT NULL,\n  `chat_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `user_id` bigint(20) NOT NULL DEFAULT 0,\n  `name_support` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `meta_msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_msg_subject": "CREATE TABLE `lhc_mailconv_msg_subject` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `subject_id` int(11) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `conversation_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
+        "lhc_mailconv_response_template": "CREATE TABLE `lhc_mailconv_response_template` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `template` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) NOT NULL DEFAULT 0,\n  `template_plain` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `unique_id` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `unique_id` (`unique_id`),\n  KEY `disabled` (`disabled`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_personal_mailbox_group": "CREATE TABLE `lhc_mailconv_personal_mailbox_group` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL, `mails` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `active` tinyint(1) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `active` (`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_group_chat_member": "CREATE TABLE `lh_group_chat_member` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` bigint(20) NOT NULL, `type` tinyint(1) NOT NULL DEFAULT '0',\n  `group_id` bigint(20) NOT NULL, `last_msg_id` bigint(20) NOT NULL DEFAULT '0', `last_activity` int(11) NOT NULL,\n  `jtime` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`group_id`), KEY `user_id` (`user_id`), KEY `type` (`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_command": "CREATE TABLE `lh_generic_bot_command` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `command` varchar(50) NOT NULL, `info_msg` varchar(100) NOT NULL, `sub_command` varchar(100) NOT NULL,`shortcut_1` varchar(10) NOT NULL,`shortcut_2` varchar(10) NOT NULL,\n  `bot_id` int(11) NOT NULL,\n  `trigger_id` int(11) NOT NULL, `position` int(11) unsigned NOT NULL DEFAULT '1000',\n  `dep_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `command` (`command`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_sent_copy": "CREATE TABLE `lhc_mailconv_sent_copy` (\n                                          `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                                          `mailbox_id` bigint(20) unsigned NOT NULL,\n                                          `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                          `body` longblob NOT NULL,\n                                          PRIMARY KEY (`id`),\n                                          KEY `status` (`status`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_webhook": "CREATE TABLE `lh_webhook` (  `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `delay` int(11) NOT NULL DEFAULT '0', `event` varchar(50) NOT NULL,`bot_id_alt` int(11) NOT NULL DEFAULT '0', `trigger_id_alt` int(11) NOT NULL DEFAULT '0',  `bot_id` int(11) NOT NULL,  `trigger_id` int(11) NOT NULL,  `disabled` tinyint(1) NOT NULL, `status` longtext NOT NULL, `configuration` longtext NOT NULL, `type` tinyint(1) NOT NULL DEFAULT 0,  PRIMARY KEY (`id`),  KEY `event_disabled` (`event`,`disabled`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_users_login": "CREATE TABLE `lh_users_login` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`user_id` bigint(20) NOT NULL,`type` int(11) NOT NULL,`ctime` bigint(20) NOT NULL,`status` int(11) NOT NULL,`ip` varchar(100) NOT NULL,`msg` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,PRIMARY KEY (`id`),KEY `user_id_type` (`user_id`,`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_chat_alert_icon": "CREATE TABLE `lh_abstract_chat_alert_icon` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `identifier` varchar(50) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_stats": "CREATE TABLE `lh_abstract_stats` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `type` int(11) NOT NULL,\n  `lupdate` bigint(20) NOT NULL,\n  `object_id` bigint(20) NOT NULL,\n  `stats` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `type_object_id` (`type`,`object_id`)\n) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_chat_voice_video": "CREATE TABLE IF NOT EXISTS `lh_chat_voice_video` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`chat_id` bigint(20) NOT NULL,`user_id` bigint(20) NOT NULL,`op_status` tinyint(4) NOT NULL,`vi_status` tinyint(4) NOT NULL,`voice` tinyint(4) NOT NULL, `video` tinyint(4) NOT NULL,`screen_share` tinyint(4) NOT NULL,`status` tinyint(4) NOT NULL,`ctime` int(11) NOT NULL, `token` varchar(200) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`) ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_incoming_webhook": "CREATE TABLE `lh_incoming_webhook` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `identifier` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) NOT NULL,\n  `configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `scope` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `icon` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `icon_color` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `log_incoming` tinyint(1) unsigned NOT NULL,\n  `log_failed_parse` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `identifier` (`identifier`,`disabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
+        "lh_chat_incoming": "CREATE TABLE `lh_chat_incoming` (  `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `utime` bigint(20) NOT NULL, `incoming_id` int(11) NOT NULL, `payload` longtext NOT NULL, `chat_external_id` varchar(100) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), UNIQUE KEY `incoming_ext_id_uniq` (`incoming_id`,`chat_external_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_canned_msg_dep": "CREATE TABLE `lh_canned_msg_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`canned_id` int(11) NOT NULL,`dep_id` int(11) NOT NULL,PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_content_chunk": "CREATE TABLE `lh_abstract_content_chunk` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `identifier` varchar(50) NOT NULL, `content` longtext NOT NULL, `in_active` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`id`), KEY `identifier` (`identifier`, `in_active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_content_chunk_dep": "CREATE TABLE `lh_abstract_content_chunk_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `chunk_id` bigint(20) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chunk_id` (`chunk_id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_offline_reason": "CREATE TABLE `lh_abstract_offline_reason` (`id` int(11) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `description` text NOT NULL, `icon` varchar(250) NOT NULL, `pos` int(11) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_auto_responder_dep": "CREATE TABLE `lh_abstract_auto_responder_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `autoresponder_id` int(11) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `autoresponder_id` (`autoresponder_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_canned_msg_subject": "CREATE TABLE `lh_canned_msg_subject` (\n    `id` int(11) NOT NULL AUTO_INCREMENT,\n    `canned_id` int(11) NOT NULL,\n    `subject_id` int(11) NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `canned_id` (`canned_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_response_template_dep": "CREATE TABLE `lhc_mailconv_response_template_dep` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `template_id` bigint(20) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `template_id` (`template_id`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_remarks": "CREATE TABLE `lhc_mailconv_remarks` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `email` varchar(250) NOT NULL, `remarks` longtext NOT NULL, PRIMARY KEY (`id`), KEY `email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_response_template_subject": "CREATE TABLE `lhc_mailconv_response_template_subject` (\n    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n    `template_id` bigint(20) unsigned NOT NULL,\n    `subject_id` bigint(20) unsigned NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `template_id` (`template_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_canned_msg_replace": "CREATE TABLE `lh_canned_msg_replace` (    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,    `identifier` varchar(50) NOT NULL,    `default` text NOT NULL, `conditions` longtext NOT NULL,    PRIMARY KEY (`id`),    KEY `identifier` (`identifier`)    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_canned_msg_use": "CREATE TABLE `lh_canned_msg_use` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `canned_id` int(11) unsigned NOT NULL, `chat_id` bigint(20) unsigned NOT NULL, `ctime` bigint(20) unsigned NOT NULL, `user_id` bigint(20) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), KEY `ctime` (`ctime`),   KEY `canned_id` (`canned_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_saved_search": "CREATE TABLE `lh_abstract_saved_search` (\n                    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`description` text COLLATE utf8mb4_unicode_ci NOT NULL, `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `params` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `user_id` bigint(20) unsigned NOT NULL, `passive` tinyint(1) unsigned NOT NULL DEFAULT 0, `position` int(11) unsigned NOT NULL, `scope` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `days` int(11) unsigned NOT NULL,\n                  `updated_at` bigint(20) unsigned NOT NULL,\n                  `requested_at` bigint(20) unsigned NOT NULL,\n                  `total_records` bigint(20) unsigned NOT NULL,\n                  PRIMARY KEY (`id`),\n                  KEY `user_id` (`user_id`),\n                  KEY `scope` (`scope`),\n                  KEY `updated_at` (`updated_at`),\n                  KEY `requested_at` (`requested_at`)\n                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_saved_report": "CREATE TABLE `lh_abstract_saved_report` (\n    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n    `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n    `description` text COLLATE utf8mb4_unicode_ci NOT NULL,\n    `params` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `send_log` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `recurring_options` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n    `user_id` bigint(20) unsigned NOT NULL,\n    `position` int(11) unsigned NOT NULL,\n    `days` int(11) unsigned NOT NULL,\n    `date_type` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,\n    `days_end` int(11) unsigned NOT NULL,\n    `updated_at` bigint(20) unsigned NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_chat_action": "CREATE TABLE `lh_chat_action` (\n                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                  `chat_id` bigint(20) NOT NULL,\n                  `action` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `created_at` bigint(20) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_mailing_list_recipient": "CREATE TABLE `lhc_mailconv_mailing_list_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `mailing_list_id` bigint(20) unsigned NOT NULL,\n  `mailing_recipient_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `mailing_list_id` (`mailing_list_id`),\n  KEY `mailing_recipient_id` (`mailing_recipient_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_recipient": "CREATE TABLE `lhc_mailconv_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) NOT NULL DEFAULT 0, `mailbox` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `email` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_1` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_2` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_3` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_4` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_5` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_6` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `email` (`email`),\n  KEY `disabled` (`disabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_mailing_list": "CREATE TABLE `lhc_mailconv_mailing_list` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lhc_mailconv_mailing_campaign_recipient": "CREATE TABLE `lhc_mailconv_mailing_campaign_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `campaign_id` bigint(20) unsigned NOT NULL,\n  `recipient_id` bigint(20) unsigned NOT NULL,\n  `type` tinyint(1) NOT NULL DEFAULT 0,\n  `email` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `status` tinyint(1) NOT NULL DEFAULT 0,\n  `opened_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `send_at` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conversation_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_1` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_2` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_3` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_4` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_5` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_6` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `log` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `campaign_id_status` (`campaign_id`,`status`),\n  KEY `campaign_id_email` (`campaign_id`, `email`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_mailing_campaign": "CREATE TABLE `lhc_mailconv_mailing_campaign` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `status` tinyint(1) NOT NULL DEFAULT 0,\n  `starts_at` bigint(20) unsigned NOT NULL,\n  `enabled` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body_alt` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `as_active` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `reply_email` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `reply_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,`owner_logic` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `owner_user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `status_enabled_starts_at` (`status`,`enabled`,`starts_at`),\n  KEY `enabled` (`enabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_invitation_dep": "CREATE TABLE `lh_abstract_proactive_chat_invitation_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`invitation_id` int(11) NOT NULL,`dep_id` int(11) NOT NULL,PRIMARY KEY (`id`), KEY `invitation_id` (`invitation_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_generic_bot_rest_api_cache": "CREATE TABLE `lh_generic_bot_rest_api_cache` (\n  `hash` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `rest_api_id` bigint(20) unsigned NOT NULL,\n  `response` text NOT NULL,\n  `ctime` bigint(20) NOT NULL,\n  UNIQUE KEY `rest_api_id_hash` (`rest_api_id`,`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_oauth_ms": "CREATE TABLE `lhc_mailconv_oauth_ms` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `oauth_uid` varchar(50) NOT NULL,\n  `name` varchar(200) NOT NULL,\n  `email` varchar(200) NOT NULL,\n  `surname` varchar(200) NOT NULL,\n  `display_name` varchar(200) NOT NULL,\n  `txtSessionKey` varchar(255) NOT NULL,\n  `txtCodeVerifier` varchar(255) NOT NULL,\n  `dtExpires` bigint(20) unsigned NOT NULL,\n  `txtRefreshToken` text NOT NULL,\n  `txtToken` text NOT NULL,\n  `txtIDToken` text NOT NULL,\n  `completed` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `oauth_uid` (`oauth_uid`),\n  KEY `user_id_completed` (`mailbox_id`,`completed`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_userdep_alias": "CREATE TABLE `lh_userdep_alias` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`dep_id` bigint(20) unsigned NOT NULL,`dep_group_id` bigint(20) unsigned NOT NULL, `job_title` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `user_id` bigint(20) unsigned NOT NULL,`nick` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,`filepath` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,`filename` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,`avatar` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`), KEY `dep_id_user_id` (`dep_id`,`user_id`), KEY `dep_group_id_user_id` (`dep_group_id`,`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_msg_protection": "CREATE TABLE `lh_abstract_msg_protection` (  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,  `pattern` text COLLATE utf8mb4_unicode_ci NOT NULL,  `enabled` int(11) NOT NULL DEFAULT 1,  `remove` int(11) NOT NULL DEFAULT 0, `languages` text COLLATE utf8mb4_unicode_ci NOT NULL, `v_warning` text COLLATE utf8mb4_unicode_ci NOT NULL,  `rule_type` tinyint(1) unsigned NOT NULL DEFAULT 0,  `has_dep` tinyint(1) unsigned NOT NULL DEFAULT 0,  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,  `dep_ids` text COLLATE utf8mb4_unicode_ci NOT NULL,  PRIMARY KEY (`id`),  KEY `enabled_type` (`enabled`,`rule_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_chat_participant": "CREATE TABLE `lh_chat_participant` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `chat_id` bigint(20) NOT NULL,\n  `user_id` bigint(20) NOT NULL,\n  `duration` int(11) unsigned NOT NULL,\n  `time` bigint(20) unsigned NOT NULL,\n  `dep_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`),\n  KEY `time` (`time`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_brand": "CREATE TABLE `lh_brand` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_brand_member": "CREATE TABLE `lh_brand_member` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `dep_id` bigint(20) unsigned NOT NULL, `brand_id` bigint(20) unsigned NOT NULL, `role` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n                                   PRIMARY KEY (`id`),\n                                   KEY `dep_id` (`dep_id`),\n                                   KEY `brand_id_role` (`brand_id`,`role`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_bot_condition": "CREATE TABLE `lh_bot_condition` (\n                                    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n                                    `configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    `identifier` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    PRIMARY KEY (`id`),\n                                    KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_delete_item": "CREATE TABLE `lhc_mailconv_delete_item` (\n                                            `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                                            `conversation_id` bigint(20) unsigned NOT NULL,\n                                            `filter_id` bigint(20) unsigned NOT NULL,\n                                            `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                            PRIMARY KEY (`id`),\n                                            KEY `filter_id_status` (`filter_id`,`status`),\n                                            KEY `status` (`status`)\n) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_delete_filter": "CREATE TABLE `lhc_mailconv_delete_filter` (\n                                              `id` int(11) unsigned NOT NULL AUTO_INCREMENT,`delete_policy` tinyint(1) unsigned NOT NULL DEFAULT 0, `processed_records` bigint(20) unsigned NOT NULL DEFAULT 0, `updated_at` bigint(20) unsigned NOT NULL,\n                                              `created_at` bigint(20) unsigned NOT NULL,\n                                              `user_id` bigint(20) unsigned NOT NULL,\n                                              `archive_id` int(11) unsigned NOT NULL DEFAULT 0,\n                                              `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                              `last_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `started_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `finished_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `filter` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                              `filter_input` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                              PRIMARY KEY (`id`),\n                                              KEY `status` (`status`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_mail_continuous_event": "CREATE TABLE `lh_mail_continuous_event` (\n  `webhook_id` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `created_at` bigint(20) unsigned NOT NULL,\n  UNIQUE KEY `webhook_id_message_id` (`webhook_id`,`message_id`),\n  KEY `created_at` (`created_at`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_notification_op_subscriber": "CREATE TABLE `lh_notification_op_subscriber` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `device_type` tinyint(1) NOT NULL,\n  `ctime` bigint(20) unsigned NOT NULL,\n  `utime` bigint(20) unsigned NOT NULL,\n  `status` tinyint(1) unsigned NOT NULL, `achat` tinyint(1) unsigned NOT NULL, `pchat` tinyint(1) unsigned NOT NULL,\n  `params` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_error` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subscriber_hash` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`), KEY `status` (`status`), KEY `user_id` (`user_id`), KEY `subscriber_hash` (`subscriber_hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_userdep_disabled": "CREATE TABLE `lh_userdep_disabled` (\n                              `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n                              `user_id` int(11) NOT NULL,\n                              `dep_id` int(11) NOT NULL,\n                              `last_activity` bigint(20) unsigned NOT NULL,\n                              `hide_online` int(11) NOT NULL,\n                              `last_accepted` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `active_chats` int(11) NOT NULL DEFAULT 0,\n                              `type` int(11) NOT NULL DEFAULT 0,\n                              `dep_group_id` int(11) NOT NULL DEFAULT 0,\n                              `hide_online_ts` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `pending_chats` int(11) NOT NULL DEFAULT 0,\n                              `inactive_chats` int(11) NOT NULL DEFAULT 0,\n                              `max_chats` int(11) NOT NULL DEFAULT 0,\n                              `exclude_autoasign` tinyint(1) NOT NULL DEFAULT 0,\n                              `ro` tinyint(1) NOT NULL DEFAULT 0,\n                              `always_on` tinyint(1) NOT NULL DEFAULT 0,\n                              `lastd_activity` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `exc_indv_autoasign` tinyint(1) NOT NULL DEFAULT 0,\n                              `exclude_autoasign_mails` tinyint(1) NOT NULL DEFAULT 0,\n                              `active_mails` int(11) NOT NULL DEFAULT 0,\n                              `pending_mails` int(11) NOT NULL DEFAULT 0,\n                              `max_mails` int(11) NOT NULL DEFAULT 0,\n                              `last_accepted_mail` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `assign_priority` int(11) NOT NULL DEFAULT 0,\n                              `chat_max_priority` int(11) NOT NULL DEFAULT 0,\n                              `chat_min_priority` int(11) NOT NULL DEFAULT 0,\n                              PRIMARY KEY (`id`),\n                              KEY `dep_id` (`dep_id`),\n                              KEY `user_id_type` (`user_id`,`type`),\n                              KEY `last_activity_hide_online_dep_id` (`last_activity`,`hide_online`,`dep_id`),\n                              KEY `online_op_widget_2` (`dep_id`,`last_activity`,`user_id`),\n                              KEY `online_op_widget_3` (`user_id`,`active_chats`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_departament_group_user_disabled": "CREATE TABLE `lh_departament_group_user_disabled` (\n                                             `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n                                             `dep_group_id` int(11) NOT NULL,\n                                             `user_id` int(11) NOT NULL,\n                                             `read_only` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                             `exc_indv_autoasign` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                             `assign_priority` int(11) NOT NULL DEFAULT 0,\n                                             `chat_min_priority` int(11) NOT NULL DEFAULT 0,\n                                             `chat_max_priority` int(11) NOT NULL DEFAULT 0,\n                                             PRIMARY KEY (`id`),\n                                             KEY `dep_group_id` (`dep_group_id`),\n                                             KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lhc_mailconv_pending_import": "CREATE TABLE `lhc_mailconv_pending_import` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,  `uid` bigint(20) unsigned NOT NULL,  `mailbox_id` int(11) unsigned NOT NULL,  `status` tinyint(1) unsigned NOT NULL DEFAULT 0,  `attempt` tinyint(1) unsigned NOT NULL DEFAULT 0,  `last_failure` text COLLATE utf8mb4_unicode_ci NOT NULL,  `created_at` int(11) unsigned NOT NULL,  `updated_at` int(11) unsigned NOT NULL,  PRIMARY KEY (`id`),  UNIQUE KEY `mailbox_id_uid` (`mailbox_id`,`uid`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "lh_abstract_proactive_chat_invitation_one_time": "CREATE TABLE `lh_abstract_proactive_chat_invitation_one_time` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,  `invitation_id` bigint(20) unsigned NOT NULL,  `vid_id` bigint(20) unsigned NOT NULL,  PRIMARY KEY (`id`),  KEY `invitation_id_vid_id` (`invitation_id`,`vid_id`),  KEY `vid_id` (`vid_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+        "lh_abstract_performance": "CREATE TABLE `lh_abstract_performance` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `type` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `created_at` bigint(20) unsigned NOT NULL,\n  `data` longtext NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `created_at` (`created_at`), \n  KEY `type_id` (`type`,`id` DESC)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
     }
-  },
-  "version_updates" : {
-    "328" : [
-      "INSERT IGNORE INTO `lh_userdep_disabled` SELECT * FROM `lh_userdep` WHERE `lh_userdep`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
-      "DELETE FROM `lh_userdep` WHERE `lh_userdep`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
-      "INSERT IGNORE INTO `lh_departament_group_user_disabled` SELECT * FROM `lh_departament_group_user` WHERE `lh_departament_group_user`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);",
-      "DELETE FROM `lh_departament_group_user` WHERE `lh_departament_group_user`.`user_id` IN (SELECT `id` FROM `lh_users` WHERE `disabled` = 1);"
-    ],
-    "333" : [
-      "UPDATE `lh_abstract_chat_variable` SET `case_insensitive` = 1 WHERE `type` = 4;",
-      "UPDATE `lh_abstract_chat_variable` SET `type` = 0 WHERE `type` = 4;"
-    ]
-  },
-  "tables_create": {
-    "lh_abstract_product_departament" : "CREATE TABLE `lh_abstract_product_departament` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `product_id` int(11) NOT NULL,  `departament_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `departament_id` (`departament_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_admin_theme" : "CREATE TABLE `lh_admin_theme` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `static_content` longtext NOT NULL, `static_js_content` longtext NOT NULL, `user_id` int(11) NOT NULL, `static_css_content` longtext NOT NULL, `header_content` text NOT NULL, `header_css` text NOT NULL, PRIMARY KEY (`id`),  KEY `user_id` (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_product" : "CREATE TABLE `lh_abstract_product` (`id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `priority` int(11) NOT NULL, `departament_id` int(11) NOT NULL, `disabled` int(11) NOT NULL, KEY `departament_id` (`departament_id`), PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_survey" : "CREATE TABLE `lh_abstract_survey` (`id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(250) NOT NULL,`max_stars_1_title` varchar(250) NOT NULL,`max_stars_1_pos` int(11) NOT NULL,`max_stars_2_title` varchar(250) NOT NULL,`max_stars_2_pos` int(11) NOT NULL,`max_stars_2` int(11) NOT NULL,`max_stars_3_title` varchar(250) NOT NULL,`max_stars_3_pos` int(11) NOT NULL,`max_stars_3` int(11) NOT NULL,`max_stars_4_title` varchar(250) NOT NULL,`max_stars_4_pos` int(11) NOT NULL,`max_stars_4` int(11) NOT NULL,`max_stars_5_title` varchar(250) NOT NULL,`max_stars_5_pos` int(11) NOT NULL,`max_stars_5` int(11) NOT NULL,`question_options_1` varchar(250) NOT NULL,`question_options_1_items` text NOT NULL,`question_options_1_pos` int(11) NOT NULL,`question_options_2` varchar(250) NOT NULL,`question_options_2_items` text NOT NULL,`question_options_2_pos` int(11) NOT NULL,`question_options_3` varchar(250) NOT NULL,`question_options_3_items` text NOT NULL,`question_options_3_pos` int(11) NOT NULL,`question_options_4` varchar(250) NOT NULL,`question_options_4_items` text NOT NULL,`question_options_4_pos` int(11) NOT NULL,`question_options_5` varchar(250) NOT NULL,`question_options_5_items` text NOT NULL,`question_options_5_pos` int(11) NOT NULL,`question_plain_1` text NOT NULL,`question_plain_1_pos` int(11) NOT NULL,`question_plain_2` text NOT NULL,`question_plain_2_pos` int(11) NOT NULL,`question_plain_3` text NOT NULL,`question_plain_3_pos` int(11) NOT NULL,`question_plain_4` text NOT NULL,`question_plain_4_pos` int(11) NOT NULL,`question_plain_5` text NOT NULL,`question_plain_5_pos` int(11) NOT NULL,`max_stars_1_enabled` int(11) NOT NULL, `max_stars_2_enabled` int(11) NOT NULL,  `max_stars_3_enabled` int(11) NOT NULL,  `max_stars_4_enabled` int(11) NOT NULL,  `max_stars_5_enabled` int(11) NOT NULL,  `question_options_1_enabled` int(11) NOT NULL,  `question_options_2_enabled` int(11) NOT NULL,  `question_options_3_enabled` int(11) NOT NULL,  `question_options_4_enabled` int(11) NOT NULL,  `question_options_5_enabled` int(11) NOT NULL,  `question_plain_1_enabled` int(11) NOT NULL,  `question_plain_2_enabled` int(11) NOT NULL,  `question_plain_3_enabled` int(11) NOT NULL,  `question_plain_4_enabled` int(11) NOT NULL,  `question_plain_5_enabled` int(11) NOT NULL,  `max_stars_1` int(11) NOT NULL,  `max_stars_1_req` int(11) NOT NULL,  `max_stars_2_req` int(11) NOT NULL,  `max_stars_3_req` int(11) NOT NULL,  `max_stars_4_req` int(11) NOT NULL,  `max_stars_5_req` int(11) NOT NULL,  `question_options_1_req` int(11) NOT NULL,  `question_options_2_req` int(11) NOT NULL,  `question_options_3_req` int(11) NOT NULL,  `question_options_4_req` int(11) NOT NULL,  `question_options_5_req` int(11) NOT NULL,  `question_plain_1_req` int(11) NOT NULL,  `question_plain_2_req` int(11) NOT NULL,  `question_plain_3_req` int(11) NOT NULL,`question_plain_4_req` int(11) NOT NULL,`question_plain_5_req` int(11) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_survey_item" : "CREATE TABLE `lh_abstract_survey_item` (  `id` bigint(20) NOT NULL AUTO_INCREMENT,  `survey_id` int(11) NOT NULL,  `chat_id` int(11) NOT NULL,  `user_id` int(11) NOT NULL,  `ftime` int(11) NOT NULL,  `dep_id` int(11) NOT NULL,  `max_stars_1` int(11) NOT NULL,  `max_stars_2` int(11) NOT NULL,  `max_stars_3` int(11) NOT NULL,  `max_stars_4` int(11) NOT NULL,  `max_stars_5` int(11) NOT NULL,  `question_options_1` int(11) NOT NULL,  `question_options_2` int(11) NOT NULL,  `question_options_3` int(11) NOT NULL,  `question_options_4` int(11) NOT NULL,  `question_options_5` int(11) NOT NULL,  `question_plain_1` text NOT NULL,  `question_plain_2` text NOT NULL,  `question_plain_3` text NOT NULL,  `question_plain_4` text NOT NULL,  `question_plain_5` text NOT NULL,  PRIMARY KEY (`id`),  KEY `survey_id` (`survey_id`),  KEY `chat_id` (`chat_id`),  KEY `user_id` (`user_id`),  KEY `dep_id` (`dep_id`),  KEY `ftime` (`ftime`),  KEY `max_stars_1` (`max_stars_1`),  KEY `max_stars_2` (`max_stars_2`),  KEY `max_stars_3` (`max_stars_3`),  KEY `max_stars_4` (`max_stars_4`),  KEY `max_stars_5` (`max_stars_5`),  KEY `question_options_1` (`question_options_1`),  KEY `question_options_2` (`question_options_2`),  KEY `question_options_3` (`question_options_3`),  KEY `question_options_4` (`question_options_4`),  KEY `question_options_5` (`question_options_5`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_speech_language" : "CREATE TABLE IF NOT EXISTS `lh_speech_language` ( `id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(100) NOT NULL,PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_speech_language_dialect" : "CREATE TABLE IF NOT EXISTS `lh_speech_language_dialect` (`id` int(11) NOT NULL AUTO_INCREMENT,`language_id` int(11) NOT NULL, `lang_name` varchar(100) NOT NULL,`lang_code` varchar(100) NOT NULL, PRIMARY KEY (`id`),KEY `language_id` (`language_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_speech_chat_language" : "CREATE TABLE IF NOT EXISTS `lh_speech_chat_language` (`id` int(11) NOT NULL AUTO_INCREMENT, `chat_id` int(11) NOT NULL, `language_id` int(11) NOT NULL, `dialect` varchar(50) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_auto_responder": "CREATE TABLE `lh_abstract_auto_responder` (  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(3) NOT NULL,\n  `wait_message` text NOT NULL,`disabled` tinyint(1) NOT NULL DEFAULT '0',\n  `wait_timeout` int(11) NOT NULL,\n  `position` int(11) NOT NULL,\n  `timeout_message` text NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `siteaccess_position` (`siteaccess`,`position`), KEY `disabled` (`disabled`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_auto_responder_chat": "CREATE TABLE `lh_abstract_auto_responder_chat` ( `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `auto_responder_id` int(11) NOT NULL,\n  `wait_timeout_send` int(11) NOT NULL,`pending_send_status` int(11) NOT NULL, `active_send_status` int(11) NOT NULL, \n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_browse_offer_invitation": "CREATE TABLE `lh_abstract_browse_offer_invitation` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(10) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `content` longtext NOT NULL,\n  `callback_content` longtext NOT NULL,\n  `lhc_iframe_content` tinyint(4) NOT NULL,\n  `custom_iframe_url` varchar(250) NOT NULL,\n  `name` varchar(250) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `executed_times` int(11) NOT NULL,\n  `url` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `has_url` int(11) NOT NULL,\n  `is_wildcard` int(11) NOT NULL,\n  `referrer` varchar(250) NOT NULL,\n  `priority` varchar(250) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `width` int(11) NOT NULL,\n  `height` int(11) NOT NULL,\n  `unit` varchar(10) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`),\n  KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_email_template": "CREATE TABLE `lh_abstract_email_template` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) NOT NULL,\n  `from_name` varchar(150) NOT NULL,\n  `from_name_ac` tinyint(4) NOT NULL,\n  `from_email` varchar(150) NOT NULL,\n  `from_email_ac` tinyint(4) NOT NULL,\n  `content` text NOT NULL,\n  `subject` varchar(250) NOT NULL,\n  `bcc_recipients` varchar(200) NOT NULL,\n  `subject_ac` tinyint(4) NOT NULL,\n  `reply_to` varchar(150) NOT NULL,\n  `reply_to_ac` tinyint(4) NOT NULL,\n  `recipient` varchar(150) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_form": "CREATE TABLE `lh_abstract_form` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(100) NOT NULL,\n  `configuration` longtext NOT NULL, `content` longtext NOT NULL,\n  `recipient` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `name_attr` varchar(250) NOT NULL,\n  `intro_attr` varchar(400) NOT NULL,\n  `xls_columns` text NOT NULL,\n  `pagelayout` varchar(200) NOT NULL,\n  `post_content` text NOT NULL,\n  `form_type` tinyint(1) NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_form_collected": "CREATE TABLE IF NOT EXISTS `lh_abstract_form_collected` (`id` int(11) NOT NULL AUTO_INCREMENT,`form_id` int(11) NOT NULL,`ctime` int(11) NOT NULL,`ip` varchar(250) NOT NULL,`identifier` varchar(250) NOT NULL,`chat_id` bigint(20) NOT NULL,`content` longtext NOT NULL,`custom_fields` longtext NOT NULL,`user_id` bigint(20) NOT NULL DEFAULT 0,`attr_int_1` int(11) NOT NULL DEFAULT 0,`attr_int_2` int(11) NOT NULL DEFAULT 0, `attr_int_3` int(11) NOT NULL DEFAULT 0,PRIMARY KEY (`id`),KEY `form_id_chat_id` (`form_id`,`chat_id`),KEY `chat_id` (`chat_id`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_proactive_chat_invitation": "CREATE TABLE `lh_abstract_proactive_chat_invitation` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `siteaccess` varchar(10) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `pageviews` int(11) NOT NULL,\n  `message` text NOT NULL,\n  `executed_times` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `hide_after_ntimes` int(11) NOT NULL,\n  `name` varchar(50) NOT NULL,\n  `operator_ids` varchar(100) NOT NULL,\n  `wait_message` varchar(250) NOT NULL,\n  `timeout_message` varchar(250) NOT NULL,\n  `referrer` varchar(250) NOT NULL,\n  `wait_timeout` int(11) NOT NULL,\n  `show_random_operator` int(11) NOT NULL,\n  `operator_name` varchar(100) NOT NULL,\n  `position` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `requires_email` int(11) NOT NULL,\n  `requires_username` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `time_on_site_pageviews_siteaccess_position` (`time_on_site`,`pageviews`,`siteaccess`,`identifier`,`position`),\n  KEY `identifier` (`identifier`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_widget_theme": "CREATE TABLE `lh_abstract_widget_theme` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) NOT NULL,\n  `onl_bcolor` varchar(10) NOT NULL,\n  `text_color` varchar(10) NOT NULL,\n  `online_image` varchar(250) NOT NULL,\n  `online_image_path` varchar(250) NOT NULL,\n  `offline_image` varchar(250) NOT NULL,\n  `offline_image_path` varchar(250) NOT NULL,\n  `logo_image` varchar(250) NOT NULL,\n  `logo_image_path` varchar(250) NOT NULL,\n  `need_help_image` varchar(250) NOT NULL,\n  `header_background` varchar(10) NOT NULL,\n  `widget_border_color` varchar(10) NOT NULL,\n  `need_help_tcolor` varchar(10) NOT NULL,\n  `need_help_bcolor` varchar(10) NOT NULL,\n  `need_help_border` varchar(10) NOT NULL,\n  `need_help_close_bg` varchar(10) NOT NULL,\n  `need_help_hover_bg` varchar(10) NOT NULL,\n  `need_help_close_hover_bg` varchar(10) NOT NULL,\n  `need_help_image_path` varchar(250) NOT NULL,\n  `custom_status_css` text NOT NULL, `bot_configuration` text NOT NULL ,\n  `custom_container_css` text NOT NULL,\n  `custom_widget_css` text NOT NULL, `custom_popup_css` text NOT NULL, \n  `need_help_header` varchar(250) NOT NULL,\n  `need_help_text` varchar(250) NOT NULL, `alias` varchar(50) NOT NULL,\n  `online_text` varchar(250) NOT NULL,\n  `offline_text` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`), KEY `alias` (`alias`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_canned_msg": "CREATE TABLE `lh_canned_msg` (\n  `id` int(11) NOT NULL AUTO_INCREMENT, `msg` longtext NOT NULL,`html_snippet` longtext NOT NULL, `position` int(11) NOT NULL,\n  `department_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `delay` int(11) NOT NULL,\n  `auto_send` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `department_id` (`department_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat": "CREATE TABLE `lh_chat` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `nick` varchar(50) NOT NULL,\n  `status` int(11) NOT NULL DEFAULT '0',\n  `status_sub` int(11) NOT NULL DEFAULT '0',\n  `time` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `referrer` text NOT NULL,\n  `session_referrer` text NOT NULL,\n  `chat_variables` text NOT NULL,\n  `remarks` text NOT NULL,\n  `ip` varchar(100) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `user_status` int(11) NOT NULL DEFAULT '0',\n  `support_informed` int(11) NOT NULL DEFAULT '0',\n  `unread_messages_informed` int(11) NOT NULL DEFAULT '0',\n  `reinform_timeout` int(11) NOT NULL DEFAULT '0',\n  `email` varchar(100) NOT NULL,\n  `country_code` varchar(100) NOT NULL,\n  `country_name` varchar(100) NOT NULL,\n  `user_typing` int(11) NOT NULL,\n  `user_typing_txt` varchar(50) NOT NULL,\n  `operator_typing` int(11) NOT NULL,\n  `operator_typing_id` int(11) NOT NULL,\n  `phone` varchar(100) NOT NULL,\n  `has_unread_messages` int(11) NOT NULL,\n  `last_user_msg_time` int(11) NOT NULL,\n  `fbst` tinyint(1) NOT NULL,\n  `online_user_id` int(11) NOT NULL,\n  `last_msg_id` int(11) NOT NULL,\n  `additional_data` text NOT NULL,\n  `timeout_message` varchar(250) NOT NULL,\n  `lat` varchar(10) NOT NULL,\n  `lon` varchar(10) NOT NULL,\n  `city` varchar(100) NOT NULL,\n  `operation` varchar(200) NOT NULL,\n  `operation_admin` varchar(200) NOT NULL,\n  `mail_send` int(11) NOT NULL,\n  `screenshot_id` int(11) NOT NULL,\n  `wait_time` int(11) NOT NULL,\n  `wait_timeout` int(11) NOT NULL,\n  `wait_timeout_send` int(11) NOT NULL,\n  `chat_duration` int(11) NOT NULL,\n  `tslasign` int(11) NOT NULL,\n  `priority` int(11) NOT NULL,\n  `chat_initiator` int(11) NOT NULL,\n  `transfer_timeout_ts` int(11) NOT NULL,\n  `transfer_timeout_ac` int(11) NOT NULL,\n  `transfer_if_na` int(11) NOT NULL,\n  `na_cb_executed` int(11) NOT NULL,\n  `nc_cb_executed` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `status_user_id` (`status`,`user_id`),\n  KEY `user_id` (`user_id`),\n  KEY `online_user_id` (`online_user_id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `has_unread_messages_dep_id_id` (`has_unread_messages`,`dep_id`,`id`),\n  KEY `status_dep_id_id` (`status`,`dep_id`,`id`),\n  KEY `status_dep_id_priority_id` (`status`,`dep_id`,`priority`,`id`),\n  KEY `status_priority_id` (`status`,`priority`,`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_accept": "CREATE TABLE `lh_chat_accept` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `hash` varchar(50) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `wused` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hash` (`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_archive_range": "CREATE TABLE `lh_chat_archive_range` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `range_from` bigint(20) unsigned NOT NULL,\n  `range_to` bigint(20) unsigned NOT NULL,\n  `older_than` int(11) NOT NULL,\n  `last_id` bigint(20) NOT NULL,\n  `first_id` bigint(20) NOT NULL,\n  `year_month` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_mail_archive_range": "CREATE TABLE `lh_mail_archive_range` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL, `range_from` bigint(20) unsigned NOT NULL,\n  `range_to` bigint(20) unsigned NOT NULL,\n  `older_than` int(11) NOT NULL,\n  `last_id` bigint(20) NOT NULL,\n  `first_id` bigint(20) NOT NULL,\n  `year_month` int(11) NOT NULL, `type` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_blocked_user": "CREATE TABLE `lh_chat_blocked_user` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `ip` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `datets` bigint(20) unsigned NOT NULL,\n  `chat_id` bigint(20) unsigned NOT NULL,\n  `dep_id` bigint(20) unsigned NOT NULL,\n  `nick` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `btype` tinyint(1) NOT NULL DEFAULT 0,\n  `expires` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `online_user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `ip` (`ip`),\n  KEY `nick` (`nick`),\n  KEY `online_user_id` (`online_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_config": "CREATE TABLE `lh_chat_config` (\n  `identifier` varchar(50) NOT NULL,\n  `value` text NOT NULL,\n  `type` tinyint(1) NOT NULL DEFAULT '0',\n  `explain` varchar(250) NOT NULL,\n  `hidden` int(11) NOT NULL DEFAULT '0',\n  PRIMARY KEY (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_file": "CREATE TABLE `lh_chat_file` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  `upload_name` varchar(255) NOT NULL,\n  `size` int(11) NOT NULL,\n  `type` varchar(255) NOT NULL,\n  `file_path` varchar(255) NOT NULL,\n  `extension` varchar(255) NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `date` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_online_user": "CREATE TABLE `lh_chat_online_user` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `vid` varchar(50) NOT NULL,\n  `ip` varchar(50) NOT NULL,\n  `current_page` text NOT NULL,\n  `page_title` varchar(250) NOT NULL,\n  `referrer` text NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `invitation_seen_count` int(11) NOT NULL,\n  `invitation_id` int(11) NOT NULL,\n  `last_visit` int(11) NOT NULL,\n  `first_visit` int(11) NOT NULL,\n  `total_visits` int(11) NOT NULL,\n  `pages_count` int(11) NOT NULL,\n  `tt_pages_count` int(11) NOT NULL,\n  `invitation_count` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `user_agent` varchar(250) NOT NULL,\n  `user_country_code` varchar(50) NOT NULL,\n  `user_country_name` varchar(50) NOT NULL,\n  `operator_message` varchar(250) NOT NULL,\n  `operator_user_proactive` varchar(100) NOT NULL,\n  `operator_user_id` int(11) NOT NULL,\n  `message_seen` int(11) NOT NULL,\n  `message_seen_ts` int(11) NOT NULL,\n  `lat` varchar(10) NOT NULL,\n  `lon` varchar(10) NOT NULL,\n  `city` varchar(100) NOT NULL,\n  `reopen_chat` int(11) NOT NULL,\n  `time_on_site` int(11) NOT NULL,\n  `tt_time_on_site` int(11) NOT NULL,\n  `requires_email` int(11) NOT NULL,\n  `requires_username` int(11) NOT NULL,\n  `screenshot_id` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `operation` varchar(200) NOT NULL,\n  `online_attr` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `vid` (`vid`),\n  KEY `dep_id` (`dep_id`),\n  KEY `last_visit_dep_id` (`last_visit`,`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_online_user_footprint": "CREATE TABLE `lh_chat_online_user_footprint` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `online_user_id` int(11) NOT NULL,\n  `page` varchar(2083) NOT NULL,\n  `vtime` varchar(250) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_vtime` (`chat_id`,`vtime`),\n  KEY `online_user_id` (`online_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_online_user_footprint_update": "CREATE TABLE `lh_chat_online_user_footprint_update` (`online_user_id` bigint(20) NOT NULL,  `command` varchar(20) NOT NULL,  `args` varchar(250) NOT NULL,  `ctime` int(11) NOT NULL, KEY `online_user_id` (`online_user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_chatbox": "CREATE TABLE `lh_chatbox` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `identifier` varchar(50) NOT NULL,\n  `name` varchar(100) NOT NULL,\n  `chat_id` int(11) NOT NULL,\n  `active` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_departament": "CREATE TABLE `lh_departament` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `email` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `priority` int(11) NOT NULL,\n  `department_transfer_id` int(11) NOT NULL,\n  `transfer_timeout` int(11) NOT NULL,\n  `identifier` varchar(2083) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `inform_options` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `online_hours_active` tinyint(1) NOT NULL,\n  `inform_delay` int(11) NOT NULL,\n  `inform_close` int(11) NOT NULL,\n  `xmpp_recipients` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `xmpp_group_recipients` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` int(11) NOT NULL,\n  `delay_lm` int(11) NOT NULL,\n  `hidden` int(11) NOT NULL,\n  `inform_unread` tinyint(1) NOT NULL,\n  `inform_unread_delay` int(11) NOT NULL,\n  `nc_cb_execute` tinyint(1) NOT NULL,\n  `na_cb_execute` tinyint(1) NOT NULL,\n  `active_balancing` tinyint(1) NOT NULL,\n  `max_active_chats` int(11) NOT NULL,\n  `max_timeout_seconds` int(11) NOT NULL,\n  `attr_int_1` int(11) NOT NULL DEFAULT 0,\n  `attr_int_2` int(11) NOT NULL DEFAULT 0,\n  `attr_int_3` int(11) NOT NULL DEFAULT 0,\n  `active_chats_counter` int(11) NOT NULL,\n  `pending_chats_counter` int(11) NOT NULL,\n  `visible_if_online` tinyint(1) NOT NULL,\n  `sort_priority` int(11) NOT NULL,\n  `mod_start_hour` int(4) NOT NULL DEFAULT -1,\n  `mod_end_hour` int(4) NOT NULL DEFAULT -1,\n  `tud_start_hour` int(4) NOT NULL DEFAULT -1,\n  `tud_end_hour` int(4) NOT NULL DEFAULT -1,\n  `wed_start_hour` int(4) NOT NULL DEFAULT -1,\n  `wed_end_hour` int(4) NOT NULL DEFAULT -1,\n  `thd_start_hour` int(4) NOT NULL DEFAULT -1,\n  `thd_end_hour` int(4) NOT NULL DEFAULT -1,\n  `frd_start_hour` int(4) NOT NULL DEFAULT -1,\n  `frd_end_hour` int(4) NOT NULL DEFAULT -1,\n  `sad_start_hour` int(4) NOT NULL DEFAULT -1,\n  `sad_end_hour` int(4) NOT NULL DEFAULT -1,\n  `sud_start_hour` int(4) NOT NULL DEFAULT -1,\n  `sud_end_hour` int(4) NOT NULL DEFAULT -1,\n  `inform_close_all` int(11) NOT NULL,\n  `inform_close_all_email` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `product_configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `pending_max` int(11) NOT NULL,\n  `pending_group_max` int(11) NOT NULL,\n  `exclude_inactive_chats` int(11) NOT NULL,\n  `max_ac_dep_chats` int(11) NOT NULL,\n  `delay_before_assign` int(11) NOT NULL,\n  `bot_configuration` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `assign_same_language` int(11) NOT NULL,\n  `archive` tinyint(1) NOT NULL DEFAULT 0,\n  `max_load` int(11) NOT NULL DEFAULT 0,\n  `bot_chats_counter` int(11) NOT NULL DEFAULT 0,\n  `max_load_h` int(11) NOT NULL DEFAULT 0,\n  `inactive_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `inop_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `acop_chats_cnt` int(11) NOT NULL DEFAULT 0,\n  `alias` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `max_active_mails` int(11) NOT NULL DEFAULT 0,\n  `active_mail_balancing` tinyint(1) NOT NULL,\n  `max_ac_dep_mails` int(11) NOT NULL,\n  `max_timeout_seconds_mail` int(11) NOT NULL,\n  `delay_before_assign_mail` int(11) NOT NULL,\n  `ignore_op_status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `disabled_hidden` (`disabled`,`hidden`),\n  KEY `attr_int_1` (`attr_int_1`),\n  KEY `attr_int_2` (`attr_int_2`),\n  KEY `attr_int_3` (`attr_int_3`),\n  KEY `sort_priority_name` (`sort_priority`,`name`),\n  KEY `active_mod` (`online_hours_active`,`mod_start_hour`,`mod_end_hour`),\n  KEY `active_tud` (`online_hours_active`,`tud_start_hour`,`tud_end_hour`),\n  KEY `active_wed` (`online_hours_active`,`wed_start_hour`,`wed_end_hour`),\n  KEY `active_thd` (`online_hours_active`,`thd_start_hour`,`thd_end_hour`),\n  KEY `active_frd` (`online_hours_active`,`frd_start_hour`,`frd_end_hour`),\n  KEY `active_sad` (`online_hours_active`,`sad_start_hour`,`sad_end_hour`),\n  KEY `active_sud` (`online_hours_active`,`sud_start_hour`,`sud_end_hour`),\n  KEY `active_chats_counter` (`active_chats_counter`),\n  KEY `pending_chats_counter` (`pending_chats_counter`),\n  KEY `archive` (`archive`),\n  KEY `bot_chats_counter` (`bot_chats_counter`),\n  KEY `identifier_2` (`identifier`(768)),\n  KEY `alias` (`alias`),\n  KEY `ignore_op_status` (`ignore_op_status`)\n) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_departament_custom_work_hours": "CREATE TABLE IF NOT EXISTS `lh_departament_custom_work_hours` (`id` int(11) NOT NULL AUTO_INCREMENT,`dep_id` int(11) NOT NULL,`date_from` int(11) NOT NULL,`date_to` int(11) NOT NULL,`start_hour` int(11) NOT NULL,`end_hour` int(11) NOT NULL,PRIMARY KEY (`id`),KEY `dep_id` (`dep_id`),KEY `date_from` (`date_from`),KEY `search_active` (`date_from`, `date_to`, `dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_faq": "CREATE TABLE `lh_faq` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question` varchar(250) NOT NULL,\n  `answer` text NOT NULL,\n  `url` varchar(250) NOT NULL,\n  `email` varchar(50) NOT NULL,\n  `identifier` varchar(10) NOT NULL,\n  `active` int(11) NOT NULL,\n  `has_url` tinyint(1) NOT NULL,\n  `is_wildcard` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`),\n  KEY `active_url` (`active`,`url`),\n  KEY `has_url` (`has_url`),\n  KEY `identifier` (`identifier`),\n  KEY `is_wildcard` (`is_wildcard`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_forgotpasswordhash": "CREATE TABLE `lh_forgotpasswordhash` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `hash` varchar(40) NOT NULL,\n  `created` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_group": "CREATE TABLE `lh_group` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_grouprole": "CREATE TABLE `lh_grouprole` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `group_id` int(11) NOT NULL,\n  `role_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`role_id`,`group_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_groupuser": "CREATE TABLE `lh_groupuser` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `group_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`group_id`),\n  KEY `user_id` (`user_id`),\n  KEY `group_id_2` (`group_id`,`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_msg": "CREATE TABLE `lh_msg` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `msg` longtext NOT NULL,\n  `time` int(11) NOT NULL,\n  `chat_id` int(11) NOT NULL DEFAULT '0',\n  `user_id` int(11) NOT NULL DEFAULT '0',\n  `name_support` varchar(100) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_question": "CREATE TABLE `lh_question` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question` varchar(250) NOT NULL,\n  `location` varchar(250) NOT NULL,\n  `active` int(11) NOT NULL,\n  `priority` int(11) NOT NULL,\n  `is_voting` int(11) NOT NULL,\n  `question_intro` text NOT NULL,\n  `revote` int(11) NOT NULL DEFAULT '0',\n  PRIMARY KEY (`id`),\n  KEY `priority` (`priority`),\n  KEY `active_priority` (`active`,`priority`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_question_answer": "CREATE TABLE `lh_question_answer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `ip` bigint(20) NOT NULL,\n  `question_id` int(11) NOT NULL,\n  `answer` text NOT NULL,\n  `ctime` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `ip` (`ip`),\n  KEY `question_id` (`question_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_question_option": "CREATE TABLE `lh_question_option` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question_id` int(11) NOT NULL,\n  `option_name` varchar(250) NOT NULL,\n  `priority` tinyint(4) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `question_id` (`question_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_question_option_answer": "CREATE TABLE `lh_question_option_answer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `question_id` int(11) NOT NULL,\n  `option_id` int(11) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `ip` bigint(20) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `question_id` (`question_id`),\n  KEY `ip` (`ip`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_role": "CREATE TABLE `lh_role` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_rolefunction": "CREATE TABLE `lh_rolefunction` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `role_id` int(11) NOT NULL,\n  `module` varchar(100) NOT NULL,\n  `function` varchar(100) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `role_id` (`role_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_transfer": "CREATE TABLE `lh_transfer` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `chat_id` int(11) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `transfer_user_id` int(11) NOT NULL,\n  `from_dep_id` int(11) NOT NULL,\n  `transfer_to_user_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `transfer_user_id_dep_id` (`transfer_user_id`,`dep_id`),\n  KEY `transfer_to_user_id` (`transfer_to_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_userdep": "CREATE TABLE `lh_userdep` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL, `only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0', `dep_id` int(11) NOT NULL,\n  `last_activity` int(11) NOT NULL,\n  `hide_online` int(11) NOT NULL,\n  `last_accepted` int(11) NOT NULL,\n  `active_chats` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`),\n  KEY `last_activity_hide_online_dep_id` (`last_activity`,`hide_online`,`dep_id`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users": "CREATE TABLE `lh_users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(40) NOT NULL,\n  `password` varchar(40) NOT NULL,\n  `email` varchar(100) NOT NULL,\n  `time_zone` varchar(100) NOT NULL,\n  `name` varchar(100) NOT NULL,\n  `surname` varchar(100) NOT NULL,\n  `filepath` varchar(200) NOT NULL,\n  `filename` varchar(200) NOT NULL,\n  `job_title` varchar(100) NOT NULL,\n  `xmpp_username` varchar(200) NOT NULL,\n  `skype` varchar(50) NOT NULL,\n  `disabled` tinyint(4) NOT NULL,\n  `hide_online` tinyint(1) NOT NULL,\n  `all_departments` tinyint(1) NOT NULL,\n  `invisible_mode` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hide_online` (`hide_online`),\n  KEY `email` (`email`),\n  KEY `xmpp_username` (`xmpp_username`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users_remember": "CREATE TABLE `lh_users_remember` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `mtime` int(11) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users_setting": "CREATE TABLE `lh_users_setting` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `identifier` varchar(50) NOT NULL,\n  `value` text NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`,`identifier`)\n) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users_setting_option": "CREATE TABLE `lh_users_setting_option` (\n  `identifier` varchar(50) NOT NULL,\n  `class` varchar(50) NOT NULL,\n  `attribute` varchar(40) NOT NULL,\n  PRIMARY KEY (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_cobrowse": "CREATE TABLE `lh_cobrowse` ( `id` int(11) NOT NULL AUTO_INCREMENT, `chat_id` int(11) NOT NULL, `mtime` int(11) NOT NULL, `url` varchar(250) NOT NULL, `initialize` longtext NOT NULL, `modifications` longtext NOT NULL, `finished` tinyint(1) NOT NULL, `w` int(11) NOT NULL, `wh` int(11) NOT NULL, `x` int(11) NOT NULL, `y` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_paid": "CREATE TABLE `lh_chat_paid` ( `id` int(11) NOT NULL AUTO_INCREMENT,  `hash` varchar(250) NOT NULL,  `chat_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `hash` (`hash`(191)),  KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_rest_api_key": "CREATE TABLE `lh_abstract_rest_api_key` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `api_key` varchar(50) NOT NULL,  `user_id` int(11) NOT NULL,  `active` int(11) NOT NULL DEFAULT '0',  PRIMARY KEY (`id`),  KEY `user_id` (`user_id`),  KEY `api_key_active` (`api_key`,`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_rest_api_key_remote": "CREATE TABLE `lh_abstract_rest_api_key_remote` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `api_key` varchar(50) NOT NULL, `username` varchar(50) NOT NULL, `name` varchar(50) NOT NULL,  `host` varchar(250) NOT NULL, `active` tinyint(1) NOT NULL DEFAULT '0', `position` int(11) NOT NULL DEFAULT '0',  PRIMARY KEY (`id`), KEY `active` (`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_departament_group_user": "CREATE TABLE `lh_departament_group_user` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n  `dep_group_id` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `read_only` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `exc_indv_autoasign` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `assign_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `chat_min_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `chat_max_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `dep_group_id` (`dep_group_id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=382 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
-    "lh_departament_group_member": "CREATE TABLE `lh_departament_group_member` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `dep_id` int(11) NOT NULL,  `dep_group_id` int(11) NOT NULL,  PRIMARY KEY (`id`), UNIQUE KEY `dep_group_id_dep_id` (`dep_group_id`,`dep_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_departament_limit_group_member": "CREATE TABLE `lh_departament_limit_group_member` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `dep_id` int(11) NOT NULL,  `dep_limit_group_id` int(11) NOT NULL,  PRIMARY KEY (`id`),  KEY `dep_limit_group_id` (`dep_limit_group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_departament_group": "CREATE TABLE `lh_departament_group` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL,  PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_departament_limit_group": "CREATE TABLE `lh_departament_limit_group` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL,`pending_max` int(11) NOT NULL,  PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users_session": "CREATE TABLE `lh_users_session` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `token` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `device_type` int(11) NOT NULL,\n  `device_token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `created_on` int(11) NOT NULL,\n  `updated_on` int(11) NOT NULL,\n  `expires_on` int(11) NOT NULL,\n  `notifications_status` int(11) NOT NULL DEFAULT 1,\n  `error` int(11) NOT NULL DEFAULT 0,\n  `last_error` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `token` (`token`),\n  KEY `device_token_device_type_v2` (`device_token`(191),`device_type`),\n  KEY `error` (`error`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_canned_msg_tag_link": "CREATE TABLE `lh_canned_msg_tag_link` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag_id` int(11) NOT NULL,  `canned_id` int(11) NOT NULL,  PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`), KEY `tag_id` (`tag_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_canned_msg_tag": "CREATE TABLE `lh_canned_msg_tag` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `tag` varchar(40) NOT NULL, PRIMARY KEY (`id`), KEY `tag` (`tag`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_group_work": "CREATE TABLE `lh_group_work` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `group_id` int(11) NOT NULL, `group_work_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_users_online_session": "CREATE TABLE `lh_users_online_session` (  `id` bigint(20) NOT NULL AUTO_INCREMENT,  `user_id` int(11) NOT NULL, `duration` int(11) NOT NULL, `time` int(11) NOT NULL, `lactivity` int(11) NOT NULL, `type` tinyint(1) NOT NULL DEFAULT '0', `offline_reason_id` int(11) unsigned NOT NULL DEFAULT 0, `updated_by_user_id` int(11) unsigned NOT NULL DEFAULT 0, `online_by_user_id` int(11) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`id`), KEY `user_id_lactivity` (`user_id`, `lactivity`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_variables": "CREATE TABLE `lh_abstract_proactive_chat_variables` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(50) NOT NULL, `identifier` varchar(50) NOT NULL, `store_timeout` int(11) NOT NULL, `filter_val` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `identifier` (`identifier`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_event": "CREATE TABLE `lh_abstract_proactive_chat_event` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `vid_id` int(11) NOT NULL,  `ev_id` int(11) NOT NULL,  `ts` int(11) NOT NULL,  `val` varchar(50) NOT NULL,  PRIMARY KEY (`id`),  KEY `vid_id_ev_id_val_ts` (`vid_id`,`ev_id`,`val`,`ts`),  KEY `vid_id_ev_id_ts` (`vid_id`,`ev_id`,`ts`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_invitation_event": "CREATE TABLE `lh_abstract_proactive_chat_invitation_event` ( `id` int(11) NOT NULL AUTO_INCREMENT, `invitation_id` int(11) NOT NULL, `event_id` int(11) NOT NULL, `min_number` int(11) NOT NULL, `during_seconds` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `invitation_id` (`invitation_id`), KEY `event_id` (`event_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_start_settings": "CREATE TABLE `lh_chat_start_settings` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_chat_event_track": "CREATE TABLE `lh_chat_event_track` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `data` longtext NOT NULL, `department_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `department_id` (`department_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_subject": "CREATE TABLE `lh_abstract_subject` (`id` int(11) NOT NULL AUTO_INCREMENT,`name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,`internal` tinyint(1) NOT NULL DEFAULT 0,`internal_type` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,`color` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,`pinned` tinyint(1) NOT NULL DEFAULT 0,`widgets` int(11) NOT NULL DEFAULT 0,`archive` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`id`),\n  KEY `internal` (`internal`),\n  KEY `internal_type` (`internal_type`),\n  KEY `widgets` (`widgets`),\n  KEY `archive` (`archive`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_chat_variable": "CREATE TABLE `lh_abstract_chat_variable` ( `id` int(11) NOT NULL AUTO_INCREMENT, `var_name` varchar(255) NOT NULL, `try_decrypt` tinyint(1) unsigned NOT NULL DEFAULT '0', `content_field` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL, `var_identifier` varchar(255) NOT NULL, `old_js_id` varchar(50) NOT NULL, `inv` tinyint(1) NOT NULL, `change_message` varchar(250) NOT NULL, `type` tinyint(1) NOT NULL, `persistent` tinyint(1) NOT NULL,`js_variable` varchar(255) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_chat_column": "CREATE TABLE `lh_abstract_chat_column` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `column_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `variable` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `position` int(11) NOT NULL,\n  `enabled` tinyint(1) NOT NULL,\n  `conditions` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `column_icon` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `column_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `chat_enabled` tinyint(1) NOT NULL,\n  `online_enabled` tinyint(1) NOT NULL,\n  `icon_mode` tinyint(1) NOT NULL DEFAULT 0,\n  `has_popup` tinyint(1) NOT NULL DEFAULT 0,\n  `popup_content` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sort_column` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sort_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `chat_list_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `mail_list_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  `mail_enabled` tinyint(1) NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `enabled` (`enabled`),\n  KEY `online_enabled` (`online_enabled`),\n  KEY `chat_enabled` (`chat_enabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_chat_priority": "CREATE TABLE `lh_abstract_chat_priority` (`id` int(11) NOT NULL AUTO_INCREMENT,`value` text COLLATE utf8mb4_unicode_ci NOT NULL,`role_destination` varchar(50) NOT NULL,`present_role_is` varchar(50) NOT NULL, `dep_id` int(11) NOT NULL, `dest_dep_id` int(11) NOT NULL DEFAULT 0, `sort_priority` int(11) NOT NULL DEFAULT 0,`priority` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_subject_dep": "CREATE TABLE `lh_abstract_subject_dep` ( `id` int(11) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `subject_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `subject_id` (`subject_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_subject_chat": "CREATE TABLE `lh_abstract_subject_chat` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `subject_id` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_group_object": "CREATE TABLE `lh_group_object` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `object_id` bigint(20) NOT NULL, `group_id` bigint(20) NOT NULL, `type` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `object_id_type` (`object_id`,`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_departament_availability": "CREATE TABLE `lh_departament_availability` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `dep_id` int(11) NOT NULL, `hour` int(11) NOT NULL, `hourminute` int(4) NOT NULL, `minute` int(11) NOT NULL, `time` int(11) NOT NULL, `ymdhi` bigint(20) NOT NULL, `ymd` int(11) NOT NULL, `status` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `ymdhi` (`ymdhi`), KEY `dep_id` (`dep_id`),  KEY `hourminute` (`hourminute`), KEY `time` (`time`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_bot": "CREATE TABLE `lh_generic_bot_bot` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `short_name` varchar(50) NOT NULL DEFAULT '', `avatar` varchar(150) NOT NULL, `nick` varchar(100) NOT NULL, `filepath` varchar(250) NOT NULL, `filename` varchar(250) NOT NULL, `configuration` longtext NOT NULL,`attr_str_1` varchar(100) NOT NULL,`attr_str_2` varchar(100) NOT NULL,`attr_str_3` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_exception": "CREATE TABLE `lh_generic_bot_exception` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `priority` int(11) NOT NULL, `active` tinyint(1) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_exception_message": "CREATE TABLE `lh_generic_bot_exception_message` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `code` varchar(20) NOT NULL, `exception_group_id` int(11) NOT NULL, `priority` int(11) NOT NULL, `active` tinyint(1) NOT NULL, `message` text NOT NULL, PRIMARY KEY (`id`),  KEY `code` (`code`), KEY `exception_group_id` (`exception_group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_tr_group": "CREATE TABLE `lh_generic_bot_tr_group` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL,`filename` varchar(250) NOT NULL, `bot_lang` varchar(10) NOT NULL, `use_translation_service` tinyint(1) unsigned NOT NULL DEFAULT '0', `filepath` varchar(250) NOT NULL,`configuration` longtext NOT NULL,`nick` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_tr_item": "CREATE TABLE `lh_generic_bot_tr_item` ( `id` int(11) NOT NULL AUTO_INCREMENT, `group_id` int(11) NOT NULL, `identifier` varchar(50) NOT NULL,`auto_translate` tinyint(1) unsigned NOT NULL DEFAULT '0', `translation` text NOT NULL, PRIMARY KEY (`id`),  KEY `identifier` (`identifier`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_group": "CREATE TABLE `lh_generic_bot_group` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL,`is_collapsed` int(11) NOT NULL DEFAULT '0', `pos` int(11) NOT NULL DEFAULT '0', `bot_id` bigint(20) NOT NULL, PRIMARY KEY (`id`), KEY `bot_id` (`bot_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_trigger_template": "CREATE TABLE `lh_generic_bot_trigger_template` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `actions` longtext NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_trigger": "CREATE TABLE `lh_generic_bot_trigger` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `actions` longtext NOT NULL, `group_id` bigint(20) NOT NULL, `pos` int(11) NOT NULL DEFAULT '0', `bot_id` int(11) NOT NULL, `default` int(11) NOT NULL, `default_unknown` int(11) NOT NULL, `default_unknown_btn` int(11) NOT NULL DEFAULT '0', `in_progress` int(11) NOT NULL DEFAULT '0', `as_argument` int(11) NOT NULL DEFAULT '0', PRIMARY KEY (`id`), KEY `default_unknown` (`default_unknown`), KEY `default_unknown_btn` (`default_unknown_btn`), KEY `bot_id` (`bot_id`), KEY `in_progress` (`in_progress`), KEY `group_id` (`group_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_trigger_event": "CREATE TABLE `lh_generic_bot_trigger_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `pattern` text NOT NULL, `pattern_exc` text NOT NULL, `configuration` longtext NOT NULL, `trigger_id` bigint(20) NOT NULL, `bot_id` int(11) NOT NULL, `on_start_type` tinyint(1) NOT NULL, `priority` int(11) NOT NULL, `type` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `pattern_v2` (`pattern`(191)), KEY `type` (`type`), KEY `on_start_type` (`on_start_type`), KEY `trigger_id` (`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_trigger_event_template": "CREATE TABLE `lh_generic_bot_trigger_event_template` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `configuration` longtext NOT NULL, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_payload": "CREATE TABLE `lh_generic_bot_payload` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, `payload` varchar(100) NOT NULL, `bot_id` int(11) NOT NULL, `trigger_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `bot_id` (`bot_id`), KEY `trigger_id` (`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_chat_workflow": "CREATE TABLE `lh_generic_bot_chat_workflow` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `time` int(11) NOT NULL, `trigger_id` bigint(20) NOT NULL, `identifier` varchar(100) NOT NULL, `status` int(11) NOT NULL, `collected_data` text, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_chat_event": "CREATE TABLE `lh_generic_bot_chat_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `counter` int(11) NOT NULL, `content` longtext NOT NULL, `ctime` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_pending_event": "CREATE TABLE `lh_generic_bot_pending_event` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `trigger_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_notification_subscriber": "CREATE TABLE `lh_notification_subscriber` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `online_user_id` bigint(20) NOT NULL, `dep_id` int(11) NOT NULL,`theme_id` int(11) NOT NULL, `ctime` int(11) NOT NULL, `utime` int(11) NOT NULL, `status` int(11) NOT NULL, `params` text NOT NULL, `device_type` tinyint(1) NOT NULL,`subscriber_hash` varchar(50) NOT NULL, `uagent` varchar(250) NOT NULL, `ip` varchar(250) NOT NULL, `last_error` text NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), KEY `dep_id` (`dep_id`), KEY `online_user_id` (`online_user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_speech_user_language": "CREATE TABLE `lh_speech_user_language` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `user_id` bigint(20) NOT NULL, `language` varchar(20) NOT NULL, PRIMARY KEY (`id`), KEY `user_id_language` (`user_id`,`language`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_proactive_chat_campaign": "CREATE TABLE `lh_abstract_proactive_chat_campaign` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `text` text NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_proactive_chat_campaign_conv": "CREATE TABLE `lh_abstract_proactive_chat_campaign_conv` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `device_type` tinyint(11) NOT NULL,\n  `invitation_type` tinyint(1) NOT NULL,\n  `invitation_status` tinyint(1) NOT NULL,\n  `chat_id` bigint(20) NOT NULL,\n  `campaign_id` int(11) NOT NULL,\n  `invitation_id` int(11) NOT NULL,\n  `department_id` int(11) NOT NULL,\n  `ctime` int(11) NOT NULL,\n  `con_time` int(11) NOT NULL,\n  `vid_id` bigint(20) DEFAULT NULL,\n  `variation_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_int_expires` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_int_time` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conv_event` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `unique_id` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`), KEY `inv_vid` (`invitation_id`,`invitation_status`,`vid_id`),\n  KEY `campaign_id` (`campaign_id`),\n  KEY `invitation_status` (`invitation_status`),\n  KEY `ctime` (`ctime`),\n  KEY `invitation_id_variation_id` (`invitation_id`,`variation_id`),\n  KEY `unique_id` (`unique_id`),\n  KEY `conv_int_time` (`conv_int_time`),\n  KEY `conv_event_vid_id` (`conv_event`,`vid_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_audits": "CREATE TABLE `lh_audits` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `category` varchar(255) NOT NULL, `file` varchar(255), `user_id` bigint(20) DEFAULT '0', `object_id` bigint(20) DEFAULT '0', `line` bigint(20), `message` longtext NOT NULL, `severity` varchar(255) NOT NULL, `source` varchar(255) NOT NULL, `time` timestamp NOT NULL, KEY `time` (`time`), KEY `user_id` (`user_id`),  KEY `object_id` (`object_id`), KEY `source` (`source`(191)), KEY `category` (`category`(191))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_repeat_restrict": "CREATE TABLE `lh_generic_bot_repeat_restrict` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `chat_id` bigint(20) NOT NULL, `trigger_id` bigint(20), `counter` int(11) DEFAULT '0', KEY `chat_id_trigger_id` (`chat_id`,`trigger_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_rest_api": "CREATE TABLE `lh_generic_bot_rest_api` (`id` bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(50) NOT NULL, `description` varchar(250), `configuration` longtext NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_group_chat": "CREATE TABLE `lh_group_chat` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) NOT NULL,\n  `status` int(11) NOT NULL, `chat_id` bigint(20) NOT NULL, `time` int(11) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `last_msg_op_id` bigint(20) NOT NULL,\n  `last_msg` varchar(200) NOT NULL,\n  `last_user_msg_time` int(11) NOT NULL,  `last_msg_id` bigint(20) NOT NULL,  `type` tinyint(1) NOT NULL DEFAULT 0,  `tm` int(11) NOT NULL,  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`), KEY `chat_id` (`chat_id`),\n  KEY `type` (`type`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_group_msg": "CREATE TABLE `lh_group_msg` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `time` int(11) NOT NULL,\n  `chat_id` int(11) NOT NULL DEFAULT 0,\n  `user_id` int(11) NOT NULL DEFAULT 0,\n  `name_support` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `meta_msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_conversation": "CREATE TABLE `lhc_mailconv_conversation` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `dep_id` int(11) unsigned NOT NULL,\n  `user_id` int(11) unsigned NOT NULL,\n  `status` int(11) unsigned NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `ctime` int(11) unsigned NOT NULL,\n  `priority` int(11) NOT NULL DEFAULT 0,\n  `priority_asc` int(11) NOT NULL DEFAULT 0,\n  `from_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,`from_address_clean` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',\n  `lang` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `phone` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_message_id` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `udate` bigint(20) unsigned NOT NULL,\n  `date` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `opened_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `total_messages` int(11) unsigned NOT NULL,\n  `match_rule_id` int(11) unsigned NOT NULL,\n  `cls_time` int(11) unsigned NOT NULL,\n  `pnd_time` int(11) unsigned NOT NULL,\n  `wait_time` int(11) unsigned NOT NULL,\n  `accept_time` int(11) unsigned NOT NULL,\n  `response_time` int(11) NOT NULL,\n  `interaction_time` int(11) NOT NULL,\n  `lr_time` int(11) unsigned NOT NULL,\n  `tslasign` int(11) unsigned NOT NULL,\n  `start_type` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `transfer_uid` int(11) unsigned NOT NULL,\n  `remarks` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conv_duration` int(11) NOT NULL DEFAULT 0,\n  `mail_variables` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `has_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `pending_sync` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `follow_up_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `undelivered` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `lang` (`lang`),\n  KEY `from_address` (`from_address`),\n  KEY `mailbox_id` (`mailbox_id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `mailbox_id_status_udate` (`mailbox_id`,`status`,`udate`),\n  KEY `status_priority` (`status`,`priority`),\n  KEY `status_priority_asc` (`status`,`priority_asc`),\n  KEY `has_attachment` (`has_attachment`),\n  KEY `udate` (`udate`),\n  KEY `user_id_status` (`user_id`,`status`),\n  KEY `status_dep_id` (`status`,`dep_id`),\n  KEY `undelivered` (`undelivered`),\n  KEY `phone` (`phone`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_file": "CREATE TABLE `lhc_mailconv_file` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `size` int(11) unsigned NOT NULL,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `description` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `extension` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `type` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attachment_id` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `file_path` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `file_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `content_id` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disposition` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conversation_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `conversation_id` (`conversation_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_mailbox": "CREATE TABLE `lhc_mailconv_mailbox` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,`delete_on_archive` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `delete_policy` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mail` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `username` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `password` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `active` tinyint(1) unsigned NOT NULL DEFAULT 1,\n  `port` int(11) unsigned NOT NULL,\n  `workflow_options` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `imap` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_sync_log` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sync_started` bigint(20) unsigned NOT NULL,\n  `last_sync_time` bigint(20) unsigned NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `mailbox_sync` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sync_status` int(11) unsigned NOT NULL,\n  `sync_interval` int(11) unsigned NOT NULL,\n  `signature` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `signature_under` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `import_since` int(11) unsigned NOT NULL DEFAULT 0,\n  `dep_id` int(11) unsigned NOT NULL DEFAULT 0,\n  `delete_mode` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `reopen_timeout` int(11) unsigned NOT NULL DEFAULT 4,\n  `failed` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `uuid_status` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `create_a_copy` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `import_priority` int(11) unsigned NOT NULL DEFAULT 0,\n  `assign_parent_user` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mail_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `name_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `username_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `password_smtp` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `no_pswd_smtp` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `auth_method` tinyint(1) unsigned NOT NULL DEFAULT '0',\n  `reopen_reset` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `last_process_time` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `active` (`active`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_match_rule": "CREATE TABLE `lhc_mailconv_match_rule` (\n  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n  `dep_id` int(11) unsigned NOT NULL,\n  `conditions` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `active` tinyint(1) unsigned NOT NULL DEFAULT 1,\n  `mailbox_id` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_name` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_mail` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject_contains` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `priority` int(11) NOT NULL,\n  `priority_rule` int(11) NOT NULL,\n  `options` text COLLATE utf8mb4_unicode_ci NOT NULL,`name` varchar(50) NOT NULL, PRIMARY KEY (`id`),  \n  KEY `active_priority` (`active`,`priority`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_msg_open": "CREATE TABLE `lhc_mailconv_msg_open` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `opened_at` bigint(20) unsigned NOT NULL,\n  `hash` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `hash` (`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_msg": "CREATE TABLE `lhc_mailconv_msg` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `priority` int(11) NOT NULL DEFAULT 0, `is_external` tinyint(1) unsigned NOT NULL DEFAULT 0, `message_hash` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL, `status` int(11) unsigned NOT NULL,`opened_at` bigint(20) unsigned NOT NULL DEFAULT 0, `conversation_id_old` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conversation_id` bigint(20) unsigned NOT NULL,`lang` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL, \n  `message_id` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `in_reply_to` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `alt_body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `references` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `ctime` int(11) unsigned NOT NULL,\n  `udate` int(11) unsigned NOT NULL,\n  `date` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `flagged` int(11) unsigned NOT NULL,\n  `recent` int(11) unsigned NOT NULL,\n  `msgno` bigint(20) unsigned NOT NULL,\n  `uid` bigint(20) unsigned NOT NULL,\n  `size` int(11) unsigned NOT NULL,\n  `from_host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `from_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_host` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `sender_address` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `to_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `reply_to_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `response_time` bigint(20) unsigned NOT NULL,\n  `cls_time` bigint(20) unsigned NOT NULL,\n  `wait_time` bigint(20) unsigned NOT NULL,\n  `accept_time` bigint(20) unsigned NOT NULL,\n  `interaction_time` bigint(20) NOT NULL, `conv_user_id` bigint(20) unsigned NOT NULL DEFAULT 0, `user_id` bigint(20) unsigned NOT NULL,\n  `lr_time` bigint(20) unsigned NOT NULL,\n  `response_type` int(11) unsigned NOT NULL,\n  `bcc_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `cc_data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) unsigned NOT NULL,\n  `mb_folder` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `conv_duration` int(11) NOT NULL DEFAULT 0,\n  `has_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `undelivered` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `rfc822_body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `delivery_status` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `response_type` (`response_type`),\n  KEY `user_id` (`user_id`),\n  KEY `conversation_id_old` (`conversation_id_old`), KEY `conversation_id` (`conversation_id`),\n  KEY `mailbox_id` (`mailbox_id`),\n  KEY `dep_id` (`dep_id`), KEY `message_hash` (`message_hash`), KEY `lang` (`lang`),\n  KEY `has_attachment` (`has_attachment`),\n  KEY `udate` (`udate`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_msg_internal": "CREATE TABLE `lhc_mailconv_msg_internal` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `time` bigint(20) unsigned NOT NULL,\n  `chat_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `user_id` bigint(20) NOT NULL DEFAULT 0,\n  `name_support` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `meta_msg` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id_id` (`chat_id`,`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_msg_subject": "CREATE TABLE `lhc_mailconv_msg_subject` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `subject_id` int(11) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `conversation_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
-    "lhc_mailconv_response_template": "CREATE TABLE `lhc_mailconv_response_template` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `template` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) NOT NULL DEFAULT 0,\n  `template_plain` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `unique_id` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `unique_id` (`unique_id`),\n  KEY `disabled` (`disabled`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_personal_mailbox_group": "CREATE TABLE `lhc_mailconv_personal_mailbox_group` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL, `mails` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `active` tinyint(1) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `active` (`active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_group_chat_member": "CREATE TABLE `lh_group_chat_member` (\n `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` bigint(20) NOT NULL, `type` tinyint(1) NOT NULL DEFAULT '0',\n  `group_id` bigint(20) NOT NULL, `last_msg_id` bigint(20) NOT NULL DEFAULT '0', `last_activity` int(11) NOT NULL,\n  `jtime` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `group_id` (`group_id`), KEY `user_id` (`user_id`), KEY `type` (`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_command": "CREATE TABLE `lh_generic_bot_command` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `command` varchar(50) NOT NULL, `info_msg` varchar(100) NOT NULL, `sub_command` varchar(100) NOT NULL,`shortcut_1` varchar(10) NOT NULL,`shortcut_2` varchar(10) NOT NULL,\n  `bot_id` int(11) NOT NULL,\n  `trigger_id` int(11) NOT NULL, `position` int(11) unsigned NOT NULL DEFAULT '1000',\n  `dep_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `dep_id` (`dep_id`),\n  KEY `command` (`command`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_sent_copy": "CREATE TABLE `lhc_mailconv_sent_copy` (\n                                          `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                                          `mailbox_id` bigint(20) unsigned NOT NULL,\n                                          `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                          `body` longblob NOT NULL,\n                                          PRIMARY KEY (`id`),\n                                          KEY `status` (`status`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_webhook": "CREATE TABLE `lh_webhook` (  `id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `delay` int(11) NOT NULL DEFAULT '0', `event` varchar(50) NOT NULL,`bot_id_alt` int(11) NOT NULL DEFAULT '0', `trigger_id_alt` int(11) NOT NULL DEFAULT '0',  `bot_id` int(11) NOT NULL,  `trigger_id` int(11) NOT NULL,  `disabled` tinyint(1) NOT NULL, `status` longtext NOT NULL, `configuration` longtext NOT NULL, `type` tinyint(1) NOT NULL DEFAULT 0,  PRIMARY KEY (`id`),  KEY `event_disabled` (`event`,`disabled`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_users_login": "CREATE TABLE `lh_users_login` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`user_id` bigint(20) NOT NULL,`type` int(11) NOT NULL,`ctime` bigint(20) NOT NULL,`status` int(11) NOT NULL,`ip` varchar(100) NOT NULL,`msg` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,PRIMARY KEY (`id`),KEY `user_id_type` (`user_id`,`type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_chat_alert_icon": "CREATE TABLE `lh_abstract_chat_alert_icon` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(50) NOT NULL, `identifier` varchar(50) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_stats": "CREATE TABLE `lh_abstract_stats` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `type` int(11) NOT NULL,\n  `lupdate` bigint(20) NOT NULL,\n  `object_id` bigint(20) NOT NULL,\n  `stats` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `type_object_id` (`type`,`object_id`)\n) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_chat_voice_video" : "CREATE TABLE IF NOT EXISTS `lh_chat_voice_video` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`chat_id` bigint(20) NOT NULL,`user_id` bigint(20) NOT NULL,`op_status` tinyint(4) NOT NULL,`vi_status` tinyint(4) NOT NULL,`voice` tinyint(4) NOT NULL, `video` tinyint(4) NOT NULL,`screen_share` tinyint(4) NOT NULL,`status` tinyint(4) NOT NULL,`ctime` int(11) NOT NULL, `token` varchar(200) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`) ) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_incoming_webhook" : "CREATE TABLE `lh_incoming_webhook` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `identifier` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) NOT NULL,\n  `configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  `scope` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `icon` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `icon_color` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `log_incoming` tinyint(1) unsigned NOT NULL,\n  `log_failed_parse` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `identifier` (`identifier`,`disabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci\n",
-    "lh_chat_incoming" : "CREATE TABLE `lh_chat_incoming` (  `id` bigint(20) NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) NOT NULL, `utime` bigint(20) NOT NULL, `incoming_id` int(11) NOT NULL, `payload` longtext NOT NULL, `chat_external_id` varchar(100) NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), UNIQUE KEY `incoming_ext_id_uniq` (`incoming_id`,`chat_external_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_canned_msg_dep" : "CREATE TABLE `lh_canned_msg_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`canned_id` int(11) NOT NULL,`dep_id` int(11) NOT NULL,PRIMARY KEY (`id`), KEY `canned_id` (`canned_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_content_chunk" : "CREATE TABLE `lh_abstract_content_chunk` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `identifier` varchar(50) NOT NULL, `content` longtext NOT NULL, `in_active` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`id`), KEY `identifier` (`identifier`, `in_active`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_content_chunk_dep" : "CREATE TABLE `lh_abstract_content_chunk_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `chunk_id` bigint(20) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `chunk_id` (`chunk_id`), KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_offline_reason" : "CREATE TABLE `lh_abstract_offline_reason` (`id` int(11) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(250) NOT NULL, `description` text NOT NULL, `icon` varchar(250) NOT NULL, `pos` int(11) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_auto_responder_dep" : "CREATE TABLE `lh_abstract_auto_responder_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT, `autoresponder_id` int(11) NOT NULL, `dep_id` int(11) NOT NULL, PRIMARY KEY (`id`), KEY `autoresponder_id` (`autoresponder_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_canned_msg_subject" : "CREATE TABLE `lh_canned_msg_subject` (\n    `id` int(11) NOT NULL AUTO_INCREMENT,\n    `canned_id` int(11) NOT NULL,\n    `subject_id` int(11) NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `canned_id` (`canned_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_response_template_dep" : "CREATE TABLE `lhc_mailconv_response_template_dep` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `template_id` bigint(20) NOT NULL,\n  `dep_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `template_id` (`template_id`),\n  KEY `dep_id` (`dep_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_remarks" : "CREATE TABLE `lhc_mailconv_remarks` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `email` varchar(250) NOT NULL, `remarks` longtext NOT NULL, PRIMARY KEY (`id`), KEY `email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_response_template_subject" : "CREATE TABLE `lhc_mailconv_response_template_subject` (\n    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n    `template_id` bigint(20) unsigned NOT NULL,\n    `subject_id` bigint(20) unsigned NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `template_id` (`template_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_canned_msg_replace" : "CREATE TABLE `lh_canned_msg_replace` (    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,    `identifier` varchar(50) NOT NULL,    `default` text NOT NULL, `conditions` longtext NOT NULL,    PRIMARY KEY (`id`),    KEY `identifier` (`identifier`)    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_canned_msg_use" : "CREATE TABLE `lh_canned_msg_use` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `canned_id` int(11) unsigned NOT NULL, `chat_id` bigint(20) unsigned NOT NULL, `ctime` bigint(20) unsigned NOT NULL, `user_id` bigint(20) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`), KEY `ctime` (`ctime`),   KEY `canned_id` (`canned_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_saved_search" : "CREATE TABLE `lh_abstract_saved_search` (\n                    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`description` text COLLATE utf8mb4_unicode_ci NOT NULL, `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `params` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `user_id` bigint(20) unsigned NOT NULL, `passive` tinyint(1) unsigned NOT NULL DEFAULT 0, `position` int(11) unsigned NOT NULL, `scope` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `days` int(11) unsigned NOT NULL,\n                  `updated_at` bigint(20) unsigned NOT NULL,\n                  `requested_at` bigint(20) unsigned NOT NULL,\n                  `total_records` bigint(20) unsigned NOT NULL,\n                  PRIMARY KEY (`id`),\n                  KEY `user_id` (`user_id`),\n                  KEY `scope` (`scope`),\n                  KEY `updated_at` (`updated_at`),\n                  KEY `requested_at` (`requested_at`)\n                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_saved_report" : "CREATE TABLE `lh_abstract_saved_report` (\n    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n    `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n    `description` text COLLATE utf8mb4_unicode_ci NOT NULL,\n    `params` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `send_log` longtext COLLATE utf8mb4_unicode_ci NOT NULL, `recurring_options` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n    `user_id` bigint(20) unsigned NOT NULL,\n    `position` int(11) unsigned NOT NULL,\n    `days` int(11) unsigned NOT NULL,\n    `date_type` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,\n    `days_end` int(11) unsigned NOT NULL,\n    `updated_at` bigint(20) unsigned NOT NULL,\n    PRIMARY KEY (`id`),\n    KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_chat_action" : "CREATE TABLE `lh_chat_action` (\n                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                  `chat_id` bigint(20) NOT NULL,\n                  `action` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                  `created_at` bigint(20) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `chat_id` (`chat_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_mailing_list_recipient" : "CREATE TABLE `lhc_mailconv_mailing_list_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `mailing_list_id` bigint(20) unsigned NOT NULL,\n  `mailing_recipient_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `mailing_list_id` (`mailing_list_id`),\n  KEY `mailing_recipient_id` (`mailing_recipient_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_recipient" : "CREATE TABLE `lhc_mailconv_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `disabled` tinyint(1) NOT NULL DEFAULT 0, `mailbox` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `email` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_1` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_2` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_3` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_4` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_5` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `attr_str_6` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `email` (`email`),\n  KEY `disabled` (`disabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_mailing_list" : "CREATE TABLE `lhc_mailconv_mailing_list` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lhc_mailconv_mailing_campaign_recipient" : "CREATE TABLE `lhc_mailconv_mailing_campaign_recipient` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `campaign_id` bigint(20) unsigned NOT NULL,\n  `recipient_id` bigint(20) unsigned NOT NULL,\n  `type` tinyint(1) NOT NULL DEFAULT 0,\n  `email` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `mailbox` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `status` tinyint(1) NOT NULL DEFAULT 0,\n  `opened_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `send_at` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `conversation_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_1` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_2` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_3` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_4` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_5` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `attr_str_6` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `log` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `message_id` (`message_id`),\n  KEY `campaign_id_status` (`campaign_id`,`status`),\n  KEY `campaign_id_email` (`campaign_id`, `email`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_mailing_campaign" : "CREATE TABLE `lhc_mailconv_mailing_campaign` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `status` tinyint(1) NOT NULL DEFAULT 0,\n  `starts_at` bigint(20) unsigned NOT NULL,\n  `enabled` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `body` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `body_alt` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subject` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `as_active` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `reply_email` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,\n  `reply_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL,`owner_logic` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `owner_user_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n  PRIMARY KEY (`id`),\n  KEY `status_enabled_starts_at` (`status`,`enabled`,`starts_at`),\n  KEY `enabled` (`enabled`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_invitation_dep" : "CREATE TABLE `lh_abstract_proactive_chat_invitation_dep` (`id` bigint(20) NOT NULL AUTO_INCREMENT,`invitation_id` int(11) NOT NULL,`dep_id` int(11) NOT NULL,PRIMARY KEY (`id`), KEY `invitation_id` (`invitation_id`),KEY `dep_id` (`dep_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_generic_bot_rest_api_cache" : "CREATE TABLE `lh_generic_bot_rest_api_cache` (\n  `hash` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n  `rest_api_id` bigint(20) unsigned NOT NULL,\n  `response` text NOT NULL,\n  `ctime` bigint(20) NOT NULL,\n  UNIQUE KEY `rest_api_id_hash` (`rest_api_id`,`hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_oauth_ms" : "CREATE TABLE `lhc_mailconv_oauth_ms` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `mailbox_id` bigint(20) unsigned NOT NULL,\n  `oauth_uid` varchar(50) NOT NULL,\n  `name` varchar(200) NOT NULL,\n  `email` varchar(200) NOT NULL,\n  `surname` varchar(200) NOT NULL,\n  `display_name` varchar(200) NOT NULL,\n  `txtSessionKey` varchar(255) NOT NULL,\n  `txtCodeVerifier` varchar(255) NOT NULL,\n  `dtExpires` bigint(20) unsigned NOT NULL,\n  `txtRefreshToken` text NOT NULL,\n  `txtToken` text NOT NULL,\n  `txtIDToken` text NOT NULL,\n  `completed` tinyint(1) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `oauth_uid` (`oauth_uid`),\n  KEY `user_id_completed` (`mailbox_id`,`completed`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_userdep_alias" : "CREATE TABLE `lh_userdep_alias` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`dep_id` bigint(20) unsigned NOT NULL,`dep_group_id` bigint(20) unsigned NOT NULL, `job_title` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL, `user_id` bigint(20) unsigned NOT NULL,`nick` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,`filepath` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,`filename` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,`avatar` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`), KEY `dep_id_user_id` (`dep_id`,`user_id`), KEY `dep_group_id_user_id` (`dep_group_id`,`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_msg_protection" : "CREATE TABLE `lh_abstract_msg_protection` (  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,  `pattern` text COLLATE utf8mb4_unicode_ci NOT NULL,  `enabled` int(11) NOT NULL DEFAULT 1,  `remove` int(11) NOT NULL DEFAULT 0, `languages` text COLLATE utf8mb4_unicode_ci NOT NULL, `v_warning` text COLLATE utf8mb4_unicode_ci NOT NULL,  `rule_type` tinyint(1) unsigned NOT NULL DEFAULT 0,  `has_dep` tinyint(1) unsigned NOT NULL DEFAULT 0,  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,  `dep_ids` text COLLATE utf8mb4_unicode_ci NOT NULL,  PRIMARY KEY (`id`),  KEY `enabled_type` (`enabled`,`rule_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_chat_participant" : "CREATE TABLE `lh_chat_participant` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `chat_id` bigint(20) NOT NULL,\n  `user_id` bigint(20) NOT NULL,\n  `duration` int(11) unsigned NOT NULL,\n  `time` bigint(20) unsigned NOT NULL,\n  `dep_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `chat_id` (`chat_id`),\n  KEY `time` (`time`),\n  KEY `user_id` (`user_id`)\n) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_brand" : "CREATE TABLE `lh_brand` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_brand_member" : "CREATE TABLE `lh_brand_member` (`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `dep_id` bigint(20) unsigned NOT NULL, `brand_id` bigint(20) unsigned NOT NULL, `role` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,\n                                   PRIMARY KEY (`id`),\n                                   KEY `dep_id` (`dep_id`),\n                                   KEY `brand_id_role` (`brand_id`,`role`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_bot_condition" : "CREATE TABLE `lh_bot_condition` (\n                                    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n                                    `configuration` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    `identifier` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n                                    PRIMARY KEY (`id`),\n                                    KEY `identifier` (`identifier`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_delete_item" : "CREATE TABLE `lhc_mailconv_delete_item` (\n                                            `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n                                            `conversation_id` bigint(20) unsigned NOT NULL,\n                                            `filter_id` bigint(20) unsigned NOT NULL,\n                                            `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                            PRIMARY KEY (`id`),\n                                            KEY `filter_id_status` (`filter_id`,`status`),\n                                            KEY `status` (`status`)\n) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_delete_filter" : "CREATE TABLE `lhc_mailconv_delete_filter` (\n                                              `id` int(11) unsigned NOT NULL AUTO_INCREMENT,`delete_policy` tinyint(1) unsigned NOT NULL DEFAULT 0, `processed_records` bigint(20) unsigned NOT NULL DEFAULT 0, `updated_at` bigint(20) unsigned NOT NULL,\n                                              `created_at` bigint(20) unsigned NOT NULL,\n                                              `user_id` bigint(20) unsigned NOT NULL,\n                                              `archive_id` int(11) unsigned NOT NULL DEFAULT 0,\n                                              `status` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                              `last_id` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `started_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `finished_at` bigint(20) unsigned NOT NULL DEFAULT 0,\n                                              `filter` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                              `filter_input` longtext COLLATE utf8mb4_unicode_ci NOT NULL,\n                                              PRIMARY KEY (`id`),\n                                              KEY `status` (`status`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_mail_continuous_event" : "CREATE TABLE `lh_mail_continuous_event` (\n  `webhook_id` bigint(20) unsigned NOT NULL,\n  `message_id` bigint(20) unsigned NOT NULL,\n  `created_at` bigint(20) unsigned NOT NULL,\n  UNIQUE KEY `webhook_id_message_id` (`webhook_id`,`message_id`),\n  KEY `created_at` (`created_at`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_notification_op_subscriber" : "CREATE TABLE `lh_notification_op_subscriber` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `user_id` bigint(20) unsigned NOT NULL,\n  `device_type` tinyint(1) NOT NULL,\n  `ctime` bigint(20) unsigned NOT NULL,\n  `utime` bigint(20) unsigned NOT NULL,\n  `status` tinyint(1) unsigned NOT NULL, `achat` tinyint(1) unsigned NOT NULL, `pchat` tinyint(1) unsigned NOT NULL,\n  `params` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `last_error` text COLLATE utf8mb4_unicode_ci NOT NULL,\n  `subscriber_hash` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,\n  PRIMARY KEY (`id`), KEY `status` (`status`), KEY `user_id` (`user_id`), KEY `subscriber_hash` (`subscriber_hash`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_userdep_disabled" : "CREATE TABLE `lh_userdep_disabled` (\n                              `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n                              `user_id` int(11) NOT NULL,\n                              `dep_id` int(11) NOT NULL,\n                              `last_activity` bigint(20) unsigned NOT NULL,\n                              `hide_online` int(11) NOT NULL,\n                              `last_accepted` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `active_chats` int(11) NOT NULL DEFAULT 0,\n                              `type` int(11) NOT NULL DEFAULT 0,\n                              `dep_group_id` int(11) NOT NULL DEFAULT 0,\n                              `hide_online_ts` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `pending_chats` int(11) NOT NULL DEFAULT 0,\n                              `inactive_chats` int(11) NOT NULL DEFAULT 0,\n                              `max_chats` int(11) NOT NULL DEFAULT 0,\n                              `exclude_autoasign` tinyint(1) NOT NULL DEFAULT 0,\n                              `ro` tinyint(1) NOT NULL DEFAULT 0,\n                              `always_on` tinyint(1) NOT NULL DEFAULT 0,\n                              `lastd_activity` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `exc_indv_autoasign` tinyint(1) NOT NULL DEFAULT 0,\n                              `exclude_autoasign_mails` tinyint(1) NOT NULL DEFAULT 0,\n                              `active_mails` int(11) NOT NULL DEFAULT 0,\n                              `pending_mails` int(11) NOT NULL DEFAULT 0,\n                              `max_mails` int(11) NOT NULL DEFAULT 0,\n                              `last_accepted_mail` bigint(20) unsigned NOT NULL DEFAULT 0,\n                              `assign_priority` int(11) NOT NULL DEFAULT 0,\n                              `chat_max_priority` int(11) NOT NULL DEFAULT 0,\n                              `chat_min_priority` int(11) NOT NULL DEFAULT 0,\n                              PRIMARY KEY (`id`),\n                              KEY `dep_id` (`dep_id`),\n                              KEY `user_id_type` (`user_id`,`type`),\n                              KEY `last_activity_hide_online_dep_id` (`last_activity`,`hide_online`,`dep_id`),\n                              KEY `online_op_widget_2` (`dep_id`,`last_activity`,`user_id`),\n                              KEY `online_op_widget_3` (`user_id`,`active_chats`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_departament_group_user_disabled" : "CREATE TABLE `lh_departament_group_user_disabled` (\n                                             `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`only_priority` tinyint(1) unsigned NOT NULL DEFAULT '0',\n                                             `dep_group_id` int(11) NOT NULL,\n                                             `user_id` int(11) NOT NULL,\n                                             `read_only` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                             `exc_indv_autoasign` tinyint(1) unsigned NOT NULL DEFAULT 0,\n                                             `assign_priority` int(11) NOT NULL DEFAULT 0,\n                                             `chat_min_priority` int(11) NOT NULL DEFAULT 0,\n                                             `chat_max_priority` int(11) NOT NULL DEFAULT 0,\n                                             PRIMARY KEY (`id`),\n                                             KEY `dep_group_id` (`dep_group_id`),\n                                             KEY `user_id` (`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lhc_mailconv_pending_import" : "CREATE TABLE `lhc_mailconv_pending_import` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,  `uid` bigint(20) unsigned NOT NULL,  `mailbox_id` int(11) unsigned NOT NULL,  `status` tinyint(1) unsigned NOT NULL DEFAULT 0,  `attempt` tinyint(1) unsigned NOT NULL DEFAULT 0,  `last_failure` text COLLATE utf8mb4_unicode_ci NOT NULL,  `created_at` int(11) unsigned NOT NULL,  `updated_at` int(11) unsigned NOT NULL,  PRIMARY KEY (`id`),  UNIQUE KEY `mailbox_id_uid` (`mailbox_id`,`uid`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
-    "lh_abstract_proactive_chat_invitation_one_time" : "CREATE TABLE `lh_abstract_proactive_chat_invitation_one_time` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,  `invitation_id` bigint(20) unsigned NOT NULL,  `vid_id` bigint(20) unsigned NOT NULL,  PRIMARY KEY (`id`),  KEY `invitation_id_vid_id` (`invitation_id`,`vid_id`),  KEY `vid_id` (`vid_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-    "lh_abstract_performance" : "CREATE TABLE `lh_abstract_performance` (\n  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `type` tinyint(1) unsigned NOT NULL DEFAULT 0,\n  `created_at` bigint(20) unsigned NOT NULL,\n  `data` longtext NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `created_at` (`created_at`), \n  KEY `type_id` (`type`,`id` DESC)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
-  }
 }

--- a/lhc_web/doc/update_db/update_357.sql
+++ b/lhc_web/doc/update_db/update_357.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lh_abstract_widget_theme` CHANGE `custom_status_css` `custom_status_css` mediumtext NOT NULL, CHANGE `custom_container_css` `custom_container_css` mediumtext NOT NULL, CHANGE `custom_widget_css` `custom_widget_css` mediumtext NOT NULL, CHANGE `custom_popup_css` `custom_popup_css` mediumtext NOT NULL;


### PR DESCRIPTION
### Summary
Modern custom widget themes (with extensive styles, embedded SVG/base64 assets, and responsive CSS rules) can easily exceed the MySQL 64 KB `TEXT` limit (e.g. themes with 70+ KB of CSS). When this occurs, MySQL truncates the CSS content, leading to broken widget styles.

### Changes
1. Added `doc/update_db/update_357.sql` migrating `lh_abstract_widget_theme` CSS fields (`custom_status_css`, `custom_container_css`, `custom_widget_css`, `custom_popup_css`) from `TEXT` to `MEDIUMTEXT` (supporting up to 16 MB).
2. Updated `doc/update_db/structure.json` schema definitions to keep database update checks in sync.