### PR TITLE
Allow self-signed and unverified SSL certificates in Mailconv SMTP transport

### DIFF
--- a/lhc_web/lib/core/lhmailconv/lhmailconvvalidator.php
+++ b/lhc_web/lib/core/lhmailconv/lhmailconvvalidator.php
@@ -602,6 +602,15 @@ class erLhcoreClassMailconvValidator {
         $phpmailer->Host = $mailbox->host;
         $phpmailer->Port = $mailbox->port;
 
+        // To work with various SMTP servers
+        $phpmailer->SMTPOptions = array(
+            'ssl' => array(
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+                'allow_self_signed' => true
+            )
+        );
+
         $phpmailer->From = $mailbox->mail_smtp != '' ?  $mailbox->mail_smtp : $mailbox->mail;
         $phpmailer->FromName = $mailbox->name_smtp != '' ? $mailbox->name_smtp : $mailbox->name;
 


### PR DESCRIPTION
### Summary of Changes

This PR sets `SMTPOptions` with relaxed SSL verification in `erLhcoreClassMailconvValidator::setSendParameters()`.

#### Context & Problem
* When sending emails or replies in **Mailconv** (`sendEmail`, `sendReply`, or the "Test SMTP" button in the mailbox edit modal), `PHPMailer` defaults to strict SSL certificate verification (`verify_peer = true, verify_peer_name = true`).
* If an administrator uses a self-hosted mail server (e.g., Stalwart, Mailcow, Postfix, or internal mail relays) with self-signed SSL certificates, private CA certificates, or hostname variations, `PHPMailer` fails during the TLS handshake:
  ```text
  stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
  error:0A000086:SSL routines::certificate verify failed
  stream_socket_client(): Failed to enable crypto
  SMTP connect() failed.
  ```
* While IMAP incoming mail configuration allows flags such as `/novalidate-cert` (e.g. `{mail.example.com:993/imap/ssl/novalidate-cert}`), there was no setting or option in Mailconv to configure `SMTPOptions` for outbound SMTP sending.
* Live Helper Chat already has this exact configuration in core for standard chat mail in `lhc_web/lib/core/lhchat/lhchatmail.php` (lines 37–51: `// To work with various SMTP servers`).

#### Fix
* Added `SMTPOptions` to `erLhcoreClassMailconvValidator::setSendParameters()` to allow self-signed and unverified SSL certificates, bringing consistency between standard chat mail delivery and Mailconv outbound delivery.
